### PR TITLE
CP/DP Split: Fix empty plus file, blocking calls

### DIFF
--- a/internal/mode/static/nginx/agent/agent.go
+++ b/internal/mode/static/nginx/agent/agent.go
@@ -85,10 +85,11 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 	deployment *Deployment,
 	files []File,
 ) bool {
-	n.logger.Info("Sending nginx configuration to agent")
-
 	msg := deployment.SetFiles(files)
 	applied := deployment.GetBroadcaster().Send(msg)
+	if applied {
+		n.logger.Info("Sent nginx configuration to agent")
+	}
 
 	deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
 

--- a/internal/mode/static/nginx/agent/command.go
+++ b/internal/mode/static/nginx/agent/command.go
@@ -393,8 +393,9 @@ func buildRequest(fileOverviews []*pb.File, instanceID, version string) *pb.Mana
 }
 
 func isRollbackMessage(msg string) bool {
-	return strings.Contains(msg, "rollback successful") ||
-		strings.Contains(strings.ToLower(msg), "rollback failed")
+	msgToLower := strings.ToLower(msg)
+	return strings.Contains(msgToLower, "rollback successful") ||
+		strings.Contains(msgToLower, "rollback failed")
 }
 
 func buildPlusAPIRequest(action *pb.NGINXPlusAction, instanceID string) *pb.ManagementPlaneRequest {

--- a/internal/mode/static/nginx/agent/file.go
+++ b/internal/mode/static/nginx/agent/file.go
@@ -75,6 +75,8 @@ func (fs *fileService) GetFile(
 		return nil, status.Errorf(codes.NotFound, "file not found")
 	}
 
+	fs.logger.V(1).Info("Getting file for agent", "file", filename)
+
 	return &pb.GetFileResponse{
 		Contents: &pb.FileContents{
 			Contents: contents,

--- a/internal/mode/static/nginx/config/plus_api.go
+++ b/internal/mode/static/nginx/config/plus_api.go
@@ -19,6 +19,8 @@ func executePlusAPI(conf dataplane.Configuration) []executeResult {
 			dest: nginxPlusConfigFile,
 			data: helpers.MustExecuteTemplate(plusAPITemplate, conf.NginxPlus),
 		}
+	} else {
+		return nil
 	}
 
 	return []executeResult{result}

--- a/internal/mode/static/nginx/config/plus_api.go
+++ b/internal/mode/static/nginx/config/plus_api.go
@@ -10,9 +10,7 @@ import (
 var plusAPITemplate = gotemplate.Must(gotemplate.New("plusAPI").Parse(plusAPITemplateText))
 
 func executePlusAPI(conf dataplane.Configuration) []executeResult {
-	result := executeResult{
-		dest: nginxPlusConfigFile,
-	}
+	var result executeResult
 	// if AllowedAddresses is empty, it means that we are not running on nginx plus, and we don't want this generated
 	if conf.NginxPlus.AllowedAddresses != nil {
 		result = executeResult{

--- a/internal/mode/static/nginx/config/plus_api_test.go
+++ b/internal/mode/static/nginx/config/plus_api_test.go
@@ -43,21 +43,7 @@ func TestExecutePlusAPI_EmptyNginxPlus(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	expSubStrings := map[string]int{
-		"listen unix:/var/run/nginx/nginx-plus-api.sock;": 0,
-		"access_log off;":               0,
-		"api write=on;":                 0,
-		"listen 8765;":                  0,
-		"root /usr/share/nginx/html;":   0,
-		"allow 127.0.0.1;":              0,
-		"deny all;":                     0,
-		"location = /dashboard.html {}": 0,
-		"api write=off;":                0,
-	}
 
-	for expSubStr, expCount := range expSubStrings {
-		res := executePlusAPI(conf)
-		g.Expect(res).To(HaveLen(1))
-		g.Expect(expCount).To(Equal(strings.Count(string(res[0].data), expSubStr)))
-	}
+	res := executePlusAPI(conf)
+	g.Expect(res).To(BeNil())
 }


### PR DESCRIPTION
Problem: The NGINX Plus API conf file was empty when sending using OSS, which caused an error applying config. This also revealed an issue where we received multiple messages from agent, causing some channel blocking.

Solution: Don't send the empty NGINX conf file if not running N+. Ignore responses from agent about rollbacks, so we only ever process a single response as expected.

Testing: Verified that the blocking issue no longer occurs when a failure happens. Also verified that OSS works again.
