### PR TITLE
Update simplified http response assertion

### DIFF
--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -293,18 +293,16 @@ func checkForFailingTraffic(teaURL, coffeeURL string) error {
 	return nil
 }
 
-func expectRequestToSucceed(appURL, address string, responseBodyMessage string) error {
+func expectRequestToSucceed(appURL, address, responseBodyMessage string) error {
 	status, body, err := framework.Get(appURL, address, timeoutConfig.RequestTimeout, nil, nil)
-
-	if status != http.StatusOK {
-		return errors.New("http status was not 200")
+	if err != nil {
+		return err
 	}
 
-	if !strings.Contains(body, responseBodyMessage) {
-		return errors.New("expected response body to contain correct body message")
-	}
+	Expect(status).To(HaveHTTPStatus(http.StatusOK), "http status was not 200 but got %d", status)
+	Expect(body).To(HaveHTTPBody(ContainSubstring(responseBodyMessage)), "expected response body to contain correct body message but got: %s", responseBodyMessage)
 
-	return err
+	return nil
 }
 
 func expectRequestToFail(appURL, address string) error {


### PR DESCRIPTION
### Proposed changes

Adding simplified http response assertion

Problem: Not using built in Gomega assertions

Solution: Using built in Gomega assertions

Here we explicitly returns nil, making it clear that if framework.Get does not fail, the function should not return an error.
Expect will fail the test if conditions are not met, so returning err does not add value.

Closes #1992 


- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
