### PR TITLE
Added missing SnippetsFilter in the HTTPRoutes in example

### DIFF
--- a/examples/snippets-filter/httproutes.yaml
+++ b/examples/snippets-filter/httproutes.yaml
@@ -13,6 +13,12 @@ spec:
         - path:
             type: PathPrefix
             value: /coffee
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.nginx.org
+            kind: SnippetsFilter
+            name: rate-limiting-sf
       backendRefs:
         - name: coffee
           port: 80
@@ -32,6 +38,12 @@ spec:
         - path:
             type: PathPrefix
             value: /tea
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.nginx.org
+            kind: SnippetsFilter
+            name: no-delay-rate-limiting-sf
       backendRefs:
         - name: tea
           port: 80


### PR DESCRIPTION
### Proposed changes

HTTPRoutes in example is missing references to SnippetFilters. Updated with references as documented in https://docs.nginx.com/nginx-gateway-fabric/how-to/traffic-management/snippets/

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork