### PR TITLE
CP/DP split: update/delete user secrets

### DIFF
--- a/internal/framework/controller/predicate/annotation.go
+++ b/internal/framework/controller/predicate/annotation.go
@@ -19,24 +19,24 @@ type AnnotationPredicate struct {
 }
 
 // Create filters CreateEvents based on the Annotation.
-func (cp AnnotationPredicate) Create(e event.CreateEvent) bool {
+func (ap AnnotationPredicate) Create(e event.CreateEvent) bool {
 	if e.Object == nil {
 		return false
 	}
 
-	_, ok := e.Object.GetAnnotations()[cp.Annotation]
+	_, ok := e.Object.GetAnnotations()[ap.Annotation]
 	return ok
 }
 
 // Update filters UpdateEvents based on the Annotation.
-func (cp AnnotationPredicate) Update(e event.UpdateEvent) bool {
+func (ap AnnotationPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		// this case should not happen
 		return false
 	}
 
-	oldAnnotationVal := e.ObjectOld.GetAnnotations()[cp.Annotation]
-	newAnnotationVal := e.ObjectNew.GetAnnotations()[cp.Annotation]
+	oldAnnotationVal := e.ObjectOld.GetAnnotations()[ap.Annotation]
+	newAnnotationVal := e.ObjectNew.GetAnnotations()[ap.Annotation]
 
 	return oldAnnotationVal != newAnnotationVal
 }
@@ -52,7 +52,7 @@ type RestartDeploymentAnnotationPredicate struct {
 }
 
 // Update filters UpdateEvents based on if the annotation is present or changed.
-func (cp RestartDeploymentAnnotationPredicate) Update(e event.UpdateEvent) bool {
+func (RestartDeploymentAnnotationPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		// this case should not happen
 		return false

--- a/internal/framework/controller/predicate/secret.go
+++ b/internal/framework/controller/predicate/secret.go
@@ -1,0 +1,77 @@
+package predicate
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// SecretNamePredicate implements a predicate function that returns true if the Secret matches the expected
+// namespace and one of the expected names.
+type SecretNamePredicate struct {
+	predicate.Funcs
+	Namespace   string
+	SecretNames []string
+}
+
+// Create filters CreateEvents based on the Secret name.
+func (sp SecretNamePredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	if secret, ok := e.Object.(*corev1.Secret); ok {
+		return secretMatches(secret, sp.Namespace, sp.SecretNames)
+	}
+
+	return false
+}
+
+// Update filters UpdateEvents based on the Secret name.
+func (sp SecretNamePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil {
+		return false
+	}
+
+	if secret, ok := e.ObjectNew.(*corev1.Secret); ok {
+		return secretMatches(secret, sp.Namespace, sp.SecretNames)
+	}
+
+	return false
+}
+
+// Delete filters DeleteEvents based on the Secret name.
+func (sp SecretNamePredicate) Delete(e event.DeleteEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	if secret, ok := e.Object.(*corev1.Secret); ok {
+		return secretMatches(secret, sp.Namespace, sp.SecretNames)
+	}
+
+	return false
+}
+
+// Generic filters GenericEvents based on the Secret name.
+func (sp SecretNamePredicate) Generic(e event.GenericEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	if secret, ok := e.Object.(*corev1.Secret); ok {
+		return secretMatches(secret, sp.Namespace, sp.SecretNames)
+	}
+
+	return false
+}
+
+func secretMatches(secret *corev1.Secret, namespace string, names []string) bool {
+	if secret.GetNamespace() != namespace {
+		return false
+	}
+
+	return slices.Contains(names, secret.GetName())
+}

--- a/internal/framework/controller/predicate/secret_test.go
+++ b/internal/framework/controller/predicate/secret_test.go
@@ -134,16 +134,16 @@ func TestSecretNamePredicate(t *testing.T) {
 			expUpdate: false,
 		},
 		{
-			name: "Generic event with non-matching secret",
+			name: "Generic event with matching secret",
 			genericEvent: &event.GenericEvent{
 				Object: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "secret3",
+						Name:      "secret1",
 						Namespace: "test-namespace",
 					},
 				},
 			},
-			expUpdate: false,
+			expUpdate: true,
 		},
 		{
 			name: "Generic event with non-matching secret",

--- a/internal/framework/controller/predicate/secret_test.go
+++ b/internal/framework/controller/predicate/secret_test.go
@@ -1,0 +1,194 @@
+package predicate
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestSecretNamePredicate(t *testing.T) {
+	t.Parallel()
+
+	pred := SecretNamePredicate{
+		Namespace:   "test-namespace",
+		SecretNames: []string{"secret1", "secret2"},
+	}
+
+	tests := []struct {
+		createEvent  *event.CreateEvent
+		updateEvent  *event.UpdateEvent
+		deleteEvent  *event.DeleteEvent
+		genericEvent *event.GenericEvent
+		name         string
+		expUpdate    bool
+	}{
+		{
+			name: "Create event with matching secret",
+			createEvent: &event.CreateEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: true,
+		},
+		{
+			name: "Create event with non-matching secret",
+			createEvent: &event.CreateEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret3",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Create event with non-matching namespace",
+			createEvent: &event.CreateEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Update event with matching secret",
+			updateEvent: &event.UpdateEvent{
+				ObjectNew: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret2",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: true,
+		},
+		{
+			name: "Update event with non-matching secret",
+			updateEvent: &event.UpdateEvent{
+				ObjectNew: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret3",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Update event with non-matching namespace",
+			updateEvent: &event.UpdateEvent{
+				ObjectNew: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Delete event with matching secret",
+			deleteEvent: &event.DeleteEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: true,
+		},
+		{
+			name: "Delete event with non-matching secret",
+			deleteEvent: &event.DeleteEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret3",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Delete event with non-matching namespace",
+			deleteEvent: &event.DeleteEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Generic event with non-matching secret",
+			genericEvent: &event.GenericEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret3",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Generic event with non-matching secret",
+			genericEvent: &event.GenericEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret3",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+		{
+			name: "Generic event with non-matching namespace",
+			genericEvent: &event.GenericEvent{
+				Object: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+			expUpdate: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			var result bool
+			switch {
+			case test.createEvent != nil:
+				result = pred.Create(*test.createEvent)
+			case test.updateEvent != nil:
+				result = pred.Update(*test.updateEvent)
+			case test.deleteEvent != nil:
+				result = pred.Delete(*test.deleteEvent)
+			default:
+				result = pred.Generic(*test.genericEvent)
+			}
+
+			g.Expect(test.expUpdate).To(Equal(result))
+		})
+	}
+}

--- a/internal/framework/controller/resource.go
+++ b/internal/framework/controller/resource.go
@@ -1,9 +1,22 @@
 package controller
 
-import "fmt"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // CreateNginxResourceName creates the base resource name for all nginx resources
 // created by the control plane.
 func CreateNginxResourceName(prefix, suffix string) string {
 	return fmt.Sprintf("%s-%s", prefix, suffix)
+}
+
+// ObjectMetaToNamespacedName converts ObjectMeta to NamespacedName.
+func ObjectMetaToNamespacedName(meta metav1.ObjectMeta) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: meta.Namespace,
+		Name:      meta.Name,
+	}
 }

--- a/internal/mode/static/provisioner/handler_test.go
+++ b/internal/mode/static/provisioner/handler_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -22,11 +23,9 @@ func TestHandleEventBatch_Upsert(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	store := newStore(nil, "", "", "")
+	store := newStore([]string{dockerTestSecretName}, jwtTestSecretName, "", "")
 	provisioner, fakeClient, _ := defaultNginxProvisioner()
 	provisioner.cfg.StatusQueue = status.NewQueue()
-	provisioner.cfg.Plus = false
-	provisioner.cfg.NginxDockerSecretNames = nil
 
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": "nginx"},
@@ -57,15 +56,57 @@ func TestHandleEventBatch_Upsert(t *testing.T) {
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-service",
+			Name:      "gw-nginx",
 			Namespace: "default",
 			Labels:    map[string]string{"app": "nginx", controller.GatewayLabel: "test-gateway"},
 		},
 	}
 
+	jwtSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-nginx-" + jwtTestSecretName,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "nginx", controller.GatewayLabel: "test-gateway"},
+		},
+		Data: map[string][]byte{
+			"data": []byte("oldData"),
+		},
+	}
+
+	userJwtSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jwtTestSecretName,
+			Namespace: ngfNamespace,
+		},
+		Data: map[string][]byte{
+			"data": []byte("oldData"),
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userJwtSecret)).To(Succeed())
+
+	dockerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-nginx-" + dockerTestSecretName,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"data": []byte("oldDockerData"),
+		},
+	}
+
+	userDockerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dockerTestSecretName,
+			Namespace: ngfNamespace,
+		},
+		Data: map[string][]byte{
+			"data": []byte("oldDockerData"),
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userDockerSecret)).To(Succeed())
+
 	// Test handling Gateway
 	upsertEvent := &events.UpsertEvent{Resource: gateway}
-
 	batch := events.EventBatch{upsertEvent}
 	handler.HandleEventBatch(ctx, logger, batch)
 
@@ -89,6 +130,44 @@ func TestHandleEventBatch_Upsert(t *testing.T) {
 	handler.HandleEventBatch(ctx, logger, batch)
 
 	g.Expect(provisioner.cfg.StatusQueue.Dequeue(ctx)).ToNot(BeNil())
+
+	// Test handling provisioned Secret
+	upsertEvent = &events.UpsertEvent{Resource: jwtSecret}
+	batch = events.EventBatch{upsertEvent}
+	handler.HandleEventBatch(ctx, logger, batch)
+
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(jwtSecret), &corev1.Secret{})).To(Succeed())
+
+	// Test handling user Plus Secret
+	secret := &corev1.Secret{}
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(jwtSecret), secret)).To(Succeed())
+	g.Expect(secret.Data).To(HaveKey("data"))
+	g.Expect(secret.Data["data"]).To(Equal([]byte("oldData")))
+
+	userJwtSecret.Data["data"] = []byte("newData")
+	g.Expect(fakeClient.Update(ctx, userJwtSecret)).To(Succeed())
+	upsertEvent = &events.UpsertEvent{Resource: userJwtSecret}
+	batch = events.EventBatch{upsertEvent}
+	handler.HandleEventBatch(ctx, logger, batch)
+
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(jwtSecret), secret)).To(Succeed())
+	g.Expect(secret.Data).To(HaveKey("data"))
+	g.Expect(secret.Data["data"]).To(Equal([]byte("newData")))
+
+	// Test handling user Docker Secret
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(dockerSecret), secret)).To(Succeed())
+	g.Expect(secret.Data).To(HaveKey("data"))
+	g.Expect(secret.Data["data"]).To(Equal([]byte("oldDockerData")))
+
+	userDockerSecret.Data["data"] = []byte("newDockerData")
+	g.Expect(fakeClient.Update(ctx, userDockerSecret)).To(Succeed())
+	upsertEvent = &events.UpsertEvent{Resource: userDockerSecret}
+	batch = events.EventBatch{upsertEvent}
+	handler.HandleEventBatch(ctx, logger, batch)
+
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(dockerSecret), secret)).To(Succeed())
+	g.Expect(secret.Data).To(HaveKey("data"))
+	g.Expect(secret.Data["data"]).To(Equal([]byte("newDockerData")))
 
 	// remove Gateway from store and verify that Deployment UpsertEvent results in deletion of resource
 	store.deleteGateway(client.ObjectKeyFromObject(gateway))
@@ -117,11 +196,9 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	store := newStore(nil, "", "", "")
+	store := newStore([]string{dockerTestSecretName}, jwtTestSecretName, caTestSecretName, clientTestSecretName)
 	provisioner, fakeClient, _ := defaultNginxProvisioner()
 	provisioner.cfg.StatusQueue = status.NewQueue()
-	provisioner.cfg.Plus = false
-	provisioner.cfg.NginxDockerSecretNames = nil
 
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": "nginx"},
@@ -134,6 +211,7 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 	ctx := context.TODO()
 	logger := logr.Discard()
 
+	// initialize resources
 	gateway := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gw",
@@ -155,14 +233,88 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 		},
 	}
 
+	jwtSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-nginx-" + jwtTestSecretName,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "nginx", controller.GatewayLabel: "gw"},
+		},
+	}
+
+	userJwtSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jwtTestSecretName,
+			Namespace: ngfNamespace,
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userJwtSecret)).To(Succeed())
+
+	userCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caTestSecretName,
+			Namespace: ngfNamespace,
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userCASecret)).To(Succeed())
+
+	userClientSSLSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clientTestSecretName,
+			Namespace: ngfNamespace,
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userClientSSLSecret)).To(Succeed())
+
+	userDockerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dockerTestSecretName,
+			Namespace: ngfNamespace,
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, userDockerSecret)).To(Succeed())
+
+	upsertEvent := &events.UpsertEvent{Resource: gateway}
+	batch := events.EventBatch{upsertEvent}
+	handler.HandleEventBatch(ctx, logger, batch)
 	store.registerResourceInGatewayConfig(client.ObjectKeyFromObject(gateway), deployment)
 
 	// if deployment is deleted, it should be re-created since Gateway still exists
 	deleteEvent := &events.DeleteEvent{Type: deployment, NamespacedName: client.ObjectKeyFromObject(deployment)}
-	batch := events.EventBatch{deleteEvent}
+	batch = events.EventBatch{deleteEvent}
 	handler.HandleEventBatch(ctx, logger, batch)
 
 	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})).To(Succeed())
+
+	// if provisioned secret is deleted, it should be re-created
+	deleteEvent = &events.DeleteEvent{Type: jwtSecret, NamespacedName: client.ObjectKeyFromObject(jwtSecret)}
+	batch = events.EventBatch{deleteEvent}
+	handler.HandleEventBatch(ctx, logger, batch)
+
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(jwtSecret), &corev1.Secret{})).To(Succeed())
+
+	// if user-provided secrets are deleted, then delete the duplicates of them
+	verifySecret := func(name string, userSecret *corev1.Secret) {
+		key := types.NamespacedName{
+			Name:      "gw-nginx-" + name,
+			Namespace: "default",
+		}
+
+		secret := &corev1.Secret{}
+		g.Expect(fakeClient.Get(ctx, key, secret)).To(Succeed())
+		store.registerResourceInGatewayConfig(client.ObjectKeyFromObject(gateway), secret)
+
+		g.Expect(fakeClient.Delete(ctx, userSecret)).To(Succeed())
+		deleteEvent = &events.DeleteEvent{Type: userSecret, NamespacedName: client.ObjectKeyFromObject(userSecret)}
+		batch = events.EventBatch{deleteEvent}
+		handler.HandleEventBatch(ctx, logger, batch)
+
+		g.Expect(fakeClient.Get(ctx, key, &corev1.Secret{})).ToNot(Succeed())
+	}
+
+	verifySecret(jwtTestSecretName, userJwtSecret)
+	verifySecret(caTestSecretName, userCASecret)
+	verifySecret(clientTestSecretName, userClientSSLSecret)
+	verifySecret(dockerTestSecretName, userDockerSecret)
 
 	// delete Gateway
 	deleteEvent = &events.DeleteEvent{Type: gateway, NamespacedName: client.ObjectKeyFromObject(gateway)}

--- a/internal/mode/static/provisioner/provisioner_test.go
+++ b/internal/mode/static/provisioner/provisioner_test.go
@@ -144,7 +144,7 @@ func defaultNginxProvisioner(
 	deploymentStore := &agentfakes.FakeDeploymentStorer{}
 
 	return &NginxProvisioner{
-		store:     newStore([]string{"docker-secret"}, "jwt-secret", "ca-secret", "client-ssl-secret"),
+		store:     newStore([]string{dockerTestSecretName}, jwtTestSecretName, caTestSecretName, clientTestSecretName),
 		k8sClient: fakeClient,
 		cfg: Config{
 			DeploymentStore: deploymentStore,

--- a/internal/mode/static/provisioner/store.go
+++ b/internal/mode/static/provisioner/store.go
@@ -88,6 +88,13 @@ func (s *store) getGateway(nsName types.NamespacedName) *gatewayv1.Gateway {
 	return s.gateways[nsName]
 }
 
+func (s *store) getGateways() map[types.NamespacedName]*gatewayv1.Gateway {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.gateways
+}
+
 // registerResourceInGatewayConfig adds or updates the provided resource in the tracking map.
 // If the object being updated is the Gateway, check if anything that we care about changed. This ensures that
 // we don't attempt to update nginx resources when the main event handler triggers this call with an unrelated event

--- a/internal/mode/static/provisioner/store_test.go
+++ b/internal/mode/static/provisioner/store_test.go
@@ -64,6 +64,37 @@ func TestDeleteGateway(t *testing.T) {
 	g.Expect(store.getGateway(nsName)).To(BeNil())
 }
 
+func TestGetGateways(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	store := newStore(nil, "", "", "")
+	gateway1 := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway-1",
+			Namespace: "default",
+		},
+	}
+	gateway2 := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway-2",
+			Namespace: "default",
+		},
+	}
+	nsName1 := client.ObjectKeyFromObject(gateway1)
+	nsName2 := client.ObjectKeyFromObject(gateway2)
+
+	store.updateGateway(gateway1)
+	store.updateGateway(gateway2)
+
+	gateways := store.getGateways()
+
+	g.Expect(gateways).To(HaveKey(nsName1))
+	g.Expect(gateways).To(HaveKey(nsName2))
+	g.Expect(gateways[nsName1]).To(Equal(gateway1))
+	g.Expect(gateways[nsName2]).To(Equal(gateway2))
+}
+
 func TestRegisterResourceInGatewayConfig(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)


### PR DESCRIPTION
Problem: When a user updates or deletes their docker registry or NGINX Plus secrets, those changes need to be propagated to all duplicate secrets that we've provisioned for the Gateway resources.

Solution: If updated, update the provisioned secret. If deleted, delete the provisioned secret.

Testing: Verified that when a special Secret is updated, the provisioned Secret is also updated. When the special Secret is deleted, the provisioned Secret is deleted.

Closes #2845
