### PR TITLE
Add support for RequestMirror filter

### DIFF
--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	InternalRoutePathPrefix = "/_ngf-internal"
-	HTTPSScheme             = "https"
+	InternalRoutePathPrefix       = "/_ngf-internal"
+	InternalMirrorRoutePathPrefix = InternalRoutePathPrefix + "-mirror"
+	HTTPSScheme                   = "https"
 )
 
 // Server holds all configuration for an HTTP server.
@@ -41,6 +42,7 @@ type Location struct {
 	Return          *Return
 	ResponseHeaders ResponseHeaders
 	Rewrites        []string
+	MirrorPaths     []string
 	Includes        []shared.Include
 	GRPC            bool
 }

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -101,6 +101,10 @@ server {
         rewrite {{ $r }};
         {{- end }}
 
+        {{- range $m := $l.MirrorPaths }}
+        mirror {{ $m }};
+        {{- end }}
+
         {{- if $l.Return }}
         return {{ $l.Return.Code }} "{{ $l.Return.Body }}";
         {{- end }}

--- a/internal/mode/static/nginx/config/validation/http_validator.go
+++ b/internal/mode/static/nginx/config/validation/http_validator.go
@@ -15,4 +15,6 @@ type HTTPValidator struct {
 	HTTPPathValidator
 }
 
+func (HTTPValidator) SkipValidation() bool { return false }
+
 var _ validation.HTTPFieldsValidator = HTTPValidator{}

--- a/internal/mode/static/state/change_processor_test.go
+++ b/internal/mode/static/state/change_processor_test.go
@@ -1029,19 +1029,22 @@ var _ = Describe("ChangeProcessor", func() {
 							// no ref grant exists yet for the routes
 							expGraph.Routes[httpRouteKey1].Conditions = []conditions.Condition{
 								staticConds.NewRouteBackendRefRefNotPermitted(
-									"Backend ref to Service service-ns/service not permitted by any ReferenceGrant",
+									"spec.rules[0].backendRefs[0].namespace: Forbidden: " +
+										"Backend ref to Service service-ns/service not permitted by any ReferenceGrant",
 								),
 							}
 
 							expGraph.Routes[grpcRouteKey1].Conditions = []conditions.Condition{
 								staticConds.NewRouteBackendRefRefNotPermitted(
-									"Backend ref to Service grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
+									"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+										"grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
 								),
 							}
 
 							expGraph.L4Routes[trKey1].Conditions = []conditions.Condition{
 								staticConds.NewRouteBackendRefRefNotPermitted(
-									"Backend ref to Service tls-service-ns/tls-service not permitted by any ReferenceGrant",
+									"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+										"tls-service-ns/tls-service not permitted by any ReferenceGrant",
 								),
 							}
 
@@ -1118,7 +1121,8 @@ var _ = Describe("ChangeProcessor", func() {
 					expGraph.Routes[httpRouteKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteInvalidListener(),
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service service-ns/service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"service-ns/service not permitted by any ReferenceGrant",
 						),
 					}
 					expGraph.Routes[httpRouteKey1].ParentRefs[0].Attachment = expAttachment80
@@ -1128,7 +1132,8 @@ var _ = Describe("ChangeProcessor", func() {
 					expGraph.Routes[grpcRouteKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteInvalidListener(),
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
 						),
 					}
 					expGraph.Routes[grpcRouteKey1].ParentRefs[0].Attachment = expAttachment80
@@ -1137,7 +1142,8 @@ var _ = Describe("ChangeProcessor", func() {
 					// no ref grant exists yet for tr1
 					expGraph.L4Routes[trKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service tls-service-ns/tls-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"tls-service-ns/tls-service not permitted by any ReferenceGrant",
 						),
 					}
 
@@ -1158,21 +1164,24 @@ var _ = Describe("ChangeProcessor", func() {
 					// no ref grant exists yet for hr1
 					expGraph.Routes[httpRouteKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service service-ns/service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"service-ns/service not permitted by any ReferenceGrant",
 						),
 					}
 
 					// no ref grant exists yet for gr1
 					expGraph.Routes[grpcRouteKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
 						),
 					}
 
 					// no ref grant exists yet for tr1
 					expGraph.L4Routes[trKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service tls-service-ns/tls-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"tls-service-ns/tls-service not permitted by any ReferenceGrant",
 						),
 					}
 
@@ -1203,7 +1212,8 @@ var _ = Describe("ChangeProcessor", func() {
 					// no ref grant exists yet for gr1
 					expGraph.Routes[grpcRouteKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"grpc-service-ns/grpc-service not permitted by any ReferenceGrant",
 						),
 					}
 					delete(expGraph.ReferencedServices, refGRPCSvc)
@@ -1212,7 +1222,8 @@ var _ = Describe("ChangeProcessor", func() {
 					// no ref grant exists yet for tr1
 					expGraph.L4Routes[trKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service tls-service-ns/tls-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"tls-service-ns/tls-service not permitted by any ReferenceGrant",
 						),
 					}
 					delete(expGraph.ReferencedServices, refTLSSvc)
@@ -1240,7 +1251,8 @@ var _ = Describe("ChangeProcessor", func() {
 					// no ref grant exists yet for tr1
 					expGraph.L4Routes[trKey1].Conditions = []conditions.Condition{
 						staticConds.NewRouteBackendRefRefNotPermitted(
-							"Backend ref to Service tls-service-ns/tls-service not permitted by any ReferenceGrant",
+							"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+								"tls-service-ns/tls-service not permitted by any ReferenceGrant",
 						),
 					}
 					delete(expGraph.ReferencedServices, types.NamespacedName{Namespace: "tls-service-ns", Name: "tls-service"})

--- a/internal/mode/static/state/dataplane/convert.go
+++ b/internal/mode/static/state/dataplane/convert.go
@@ -7,7 +7,9 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginx/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/graph"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/mirror"
 )
 
 func convertMatch(m v1.HTTPRouteMatch) Match {
@@ -58,6 +60,25 @@ func convertHTTPURLRewriteFilter(filter *v1.HTTPURLRewriteFilter) *HTTPURLRewrit
 		Hostname: (*string)(filter.Hostname),
 		Path:     convertPathModifier(filter.Path),
 	}
+}
+
+func convertHTTPRequestMirrorFilter(filter *v1.HTTPRequestMirrorFilter, ruleIdx int) *HTTPRequestMirrorFilter {
+	if filter.BackendRef.Name == "" {
+		return &HTTPRequestMirrorFilter{}
+	}
+
+	result := &HTTPRequestMirrorFilter{
+		Name: helpers.GetPointer(string(filter.BackendRef.Name)),
+	}
+
+	namespace := (*string)(filter.BackendRef.Namespace)
+	if namespace != nil && len(*namespace) > 0 {
+		result.Namespace = namespace
+	}
+
+	result.Target = mirror.BackendPath(ruleIdx, namespace, *result.Name)
+
+	return result
 }
 
 func convertHTTPHeaderFilter(filter *v1.HTTPHeaderFilter) *HTTPHeaderFilter {

--- a/internal/mode/static/state/dataplane/convert_test.go
+++ b/internal/mode/static/state/dataplane/convert_test.go
@@ -316,6 +316,57 @@ func TestConvertHTTPURLRewriteFilter(t *testing.T) {
 	}
 }
 
+func TestConvertHTTPMirrorFilter(t *testing.T) {
+	tests := []struct {
+		filter   *v1.HTTPRequestMirrorFilter
+		expected *HTTPRequestMirrorFilter
+		name     string
+	}{
+		{
+			filter:   &v1.HTTPRequestMirrorFilter{},
+			expected: &HTTPRequestMirrorFilter{},
+			name:     "empty",
+		},
+		{
+			filter: &v1.HTTPRequestMirrorFilter{
+				BackendRef: v1.BackendObjectReference{
+					Name:      "backend",
+					Namespace: nil,
+				},
+			},
+			expected: &HTTPRequestMirrorFilter{
+				Name:      helpers.GetPointer("backend"),
+				Namespace: nil,
+				Target:    helpers.GetPointer("/_ngf-internal-mirror-backend-0"),
+			},
+			name: "missing namespace",
+		},
+		{
+			filter: &v1.HTTPRequestMirrorFilter{
+				BackendRef: v1.BackendObjectReference{
+					Name:      "backend",
+					Namespace: helpers.GetPointer[v1.Namespace]("namespace"),
+				},
+			},
+			expected: &HTTPRequestMirrorFilter{
+				Name:      helpers.GetPointer("backend"),
+				Namespace: helpers.GetPointer("namespace"),
+				Target:    helpers.GetPointer("/_ngf-internal-mirror-namespace-backend-0"),
+			},
+			name: "full",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := convertHTTPRequestMirrorFilter(test.filter, 0)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
 func TestConvertHTTPHeaderFilter(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/mode/static/state/dataplane/convert_test.go
+++ b/internal/mode/static/state/dataplane/convert_test.go
@@ -351,7 +351,7 @@ func TestConvertHTTPMirrorFilter(t *testing.T) {
 			expected: &HTTPRequestMirrorFilter{
 				Name:      helpers.GetPointer("backend"),
 				Namespace: helpers.GetPointer("namespace"),
-				Target:    helpers.GetPointer("/_ngf-internal-mirror-namespace-backend-0"),
+				Target:    helpers.GetPointer("/_ngf-internal-mirror-namespace/backend-0"),
 			},
 			name: "full",
 		},

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -149,6 +149,8 @@ type HTTPFilters struct {
 	RequestRedirect *HTTPRequestRedirectFilter
 	// RequestURLRewrite holds the HTTPURLRewriteFilter.
 	RequestURLRewrite *HTTPURLRewriteFilter
+	// RequestMirrors holds the HTTPRequestMirrorFilters. There could be more than one specified.
+	RequestMirrors []*HTTPRequestMirrorFilter
 	// RequestHeaderModifiers holds the HTTPHeaderFilter.
 	RequestHeaderModifiers *HTTPHeaderFilter
 	// ResponseHeaderModifiers holds the HTTPHeaderFilter.
@@ -205,6 +207,16 @@ type HTTPURLRewriteFilter struct {
 	Hostname *string
 	// Path is the path of the rewrite.
 	Path *HTTPPathModifier
+}
+
+// HTTPRequestMirrorFilter mirrors HTTP requests.
+type HTTPRequestMirrorFilter struct {
+	// Name is the service name.
+	Name *string
+	// Namespace is the namespace of the service.
+	Namespace *string
+	// Target is the target of the mirror (path with hostname and service name).
+	Target *string
 }
 
 // PathModifierType is the type of the PathModifier in a redirect or rewrite rule.

--- a/internal/mode/static/state/graph/common_filter.go
+++ b/internal/mode/static/state/graph/common_filter.go
@@ -160,6 +160,7 @@ func processRouteRuleFilters(
 var supportedGRPCFilterTypes = []FilterType{
 	FilterResponseHeaderModifier,
 	FilterRequestHeaderModifier,
+	FilterRequestMirror,
 	FilterExtensionRef,
 }
 
@@ -169,6 +170,7 @@ var supportedHTTPFilterTypes = []FilterType{
 	FilterExtensionRef,
 	FilterRequestRedirect,
 	FilterURLRewrite,
+	FilterRequestMirror,
 }
 
 func validateFilterType(filter Filter, filterPath *field.Path) *field.Error {
@@ -200,6 +202,8 @@ func validateFilter(
 		return validateFilterRedirect(validator, filter.RequestRedirect, filterPath)
 	case FilterURLRewrite:
 		return validateFilterRewrite(validator, filter.URLRewrite, filterPath)
+	case FilterRequestMirror:
+		return validateFilterMirror(filter.RequestMirror, filterPath)
 	case FilterRequestHeaderModifier:
 		return validateFilterHeaderModifier(
 			validator,
@@ -217,6 +221,16 @@ func validateFilter(
 	default:
 		panic(fmt.Sprintf("unexpected filter type %v", filter.FilterType))
 	}
+}
+
+func validateFilterMirror(mirror *v1.HTTPRequestMirrorFilter, filterPath *field.Path) field.ErrorList {
+	mirrorPath := filterPath.Child("requestMirror")
+
+	if mirror == nil {
+		return field.ErrorList{field.Required(mirrorPath, "cannot be nil")}
+	}
+
+	return nil
 }
 
 func validateFilterHeaderModifier(

--- a/internal/mode/static/state/graph/common_filter_test.go
+++ b/internal/mode/static/state/graph/common_filter_test.go
@@ -103,7 +103,7 @@ func TestValidateFilter(t *testing.T) {
 				RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
 			},
 			expectErrCount: 0,
-			name:           "valid GRPC filter",
+			name:           "valid GRPC mirror filter",
 		},
 		{
 			filter: Filter{

--- a/internal/mode/static/state/graph/common_filter_test.go
+++ b/internal/mode/static/state/graph/common_filter_test.go
@@ -41,6 +41,24 @@ func TestValidateFilter(t *testing.T) {
 		},
 		{
 			filter: Filter{
+				RouteType:     RouteTypeHTTP,
+				FilterType:    FilterRequestMirror,
+				RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+			},
+			expectErrCount: 0,
+			name:           "valid HTTP mirror filter",
+		},
+		{
+			filter: Filter{
+				RouteType:     RouteTypeHTTP,
+				FilterType:    FilterRequestMirror,
+				RequestMirror: nil,
+			},
+			expectErrCount: 1,
+			name:           "invalid HTTP mirror filter",
+		},
+		{
+			filter: Filter{
 				RouteType:             RouteTypeHTTP,
 				FilterType:            FilterRequestHeaderModifier,
 				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
@@ -73,10 +91,19 @@ func TestValidateFilter(t *testing.T) {
 		{
 			filter: Filter{
 				RouteType:  RouteTypeHTTP,
-				FilterType: FilterRequestMirror,
+				FilterType: "invalid-filter",
 			},
 			expectErrCount: 1,
 			name:           "unsupported HTTP filter type",
+		},
+		{
+			filter: Filter{
+				RouteType:     RouteTypeGRPC,
+				FilterType:    FilterRequestMirror,
+				RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{},
+			},
+			expectErrCount: 0,
+			name:           "valid GRPC filter",
 		},
 		{
 			filter: Filter{

--- a/internal/mode/static/state/graph/extension_ref_filter.go
+++ b/internal/mode/static/state/graph/extension_ref_filter.go
@@ -28,7 +28,7 @@ func validateExtensionRefFilter(ref *v1.LocalObjectReference, path *field.Path) 
 	extRefPath := path.Child("extensionRef")
 
 	if ref == nil {
-		return field.ErrorList{field.Required(extRefPath, "extensionRef cannot be nil")}
+		return field.ErrorList{field.Required(extRefPath, "cannot be nil")}
 	}
 
 	if ref.Name == "" {

--- a/internal/mode/static/state/graph/extension_ref_filter_test.go
+++ b/internal/mode/static/state/graph/extension_ref_filter_test.go
@@ -26,7 +26,7 @@ func TestValidateExtensionRefFilter(t *testing.T) {
 			ref:         nil,
 			expErrCount: 1,
 			errSubString: []string{
-				`test.extensionRef: Required value: extensionRef cannot be nil`,
+				`test.extensionRef: Required value: cannot be nil`,
 			},
 		},
 		{

--- a/internal/mode/static/state/graph/grpcroute.go
+++ b/internal/mode/static/state/graph/grpcroute.go
@@ -1,13 +1,18 @@
 package graph
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
 	staticConds "github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/conditions"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/mirror"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/validation"
 )
 
@@ -69,6 +74,88 @@ func buildGRPCRoute(
 	return r
 }
 
+func buildGRPCMirrorRoutes(
+	routes map[RouteKey]*L7Route,
+	l7route *L7Route,
+	route *v1.GRPCRoute,
+	gatewayNsNames []types.NamespacedName,
+	snippetsFilters map[types.NamespacedName]*SnippetsFilter,
+	http2disabled bool,
+) {
+	for idx, rule := range l7route.Spec.Rules {
+		if rule.Filters.Valid {
+			for _, filter := range rule.Filters.Filters {
+				if filter.RequestMirror == nil {
+					continue
+				}
+
+				objectMeta := route.ObjectMeta.DeepCopy()
+				backendRef := filter.RequestMirror.BackendRef
+				name := mirror.RouteName(route.GetName(), string(backendRef.Name), (*string)(backendRef.Namespace), idx)
+				objectMeta.SetName(name)
+
+				tmpMirrorRoute := &v1.GRPCRoute{
+					ObjectMeta: *objectMeta,
+					Spec: v1.GRPCRouteSpec{
+						CommonRouteSpec: route.Spec.CommonRouteSpec,
+						Hostnames:       route.Spec.Hostnames,
+						Rules:           buildGRPCMirrorRouteRule(idx, route.Spec.Rules[idx].Filters, filter),
+					},
+				}
+
+				mirrorRoute := buildGRPCRoute(
+					validation.SkipValidator{},
+					tmpMirrorRoute,
+					gatewayNsNames,
+					http2disabled,
+					snippetsFilters,
+				)
+
+				if mirrorRoute != nil {
+					routes[CreateRouteKey(tmpMirrorRoute)] = mirrorRoute
+				}
+			}
+		}
+	}
+}
+
+func buildGRPCMirrorRouteRule(
+	ruleIdx int,
+	filters []v1.GRPCRouteFilter,
+	filter Filter,
+) []v1.GRPCRouteRule {
+	return []v1.GRPCRouteRule{
+		{
+			Matches: []v1.GRPCRouteMatch{
+				{
+					Method: &v1.GRPCMethodMatch{
+						Type:    helpers.GetPointer(v1.GRPCMethodMatchExact),
+						Service: mirror.PathWithBackendRef(ruleIdx, filter.RequestMirror.BackendRef),
+					},
+				},
+			},
+			Filters: removeGRPCMirrorFilters(filters),
+			BackendRefs: []v1.GRPCBackendRef{
+				{
+					BackendRef: v1.BackendRef{
+						BackendObjectReference: filter.RequestMirror.BackendRef,
+					},
+				},
+			},
+		},
+	}
+}
+
+func removeGRPCMirrorFilters(filters []v1.GRPCRouteFilter) []v1.GRPCRouteFilter {
+	var newFilters []v1.GRPCRouteFilter
+	for _, filter := range filters {
+		if filter.Type != v1.GRPCRouteFilterRequestMirror {
+			newFilters = append(newFilters, filter)
+		}
+	}
+	return newFilters
+}
+
 func processGRPCRouteRule(
 	specRule v1.GRPCRouteRule,
 	rulePath *field.Path,
@@ -116,6 +203,22 @@ func processGRPCRouteRule(
 		backendRefs = append(backendRefs, rbr)
 	}
 
+	if routeFilters.Valid {
+		for i, filter := range routeFilters.Filters {
+			if filter.RequestMirror == nil {
+				continue
+			}
+
+			rbr := RouteBackendRef{
+				BackendRef: v1.BackendRef{
+					BackendObjectReference: filter.RequestMirror.BackendRef,
+				},
+				MirrorBackendIdx: helpers.GetPointer(i),
+			}
+			backendRefs = append(backendRefs, rbr)
+		}
+	}
+
 	return RouteRule{
 		ValidMatches:     validMatches,
 		Matches:          ConvertGRPCMatches(specRule.Matches),
@@ -139,7 +242,12 @@ func processGRPCRouteRules(
 	for i, rule := range specRules {
 		rulePath := field.NewPath("spec").Child("rules").Index(i)
 
-		rr, errors := processGRPCRouteRule(rule, rulePath, validator, resolveExtRefFunc)
+		rr, errors := processGRPCRouteRule(
+			rule,
+			rulePath,
+			validator,
+			resolveExtRefFunc,
+		)
 
 		if rr.ValidMatches && rr.Filters.Valid {
 			atLeastOneValid = true
@@ -204,12 +312,19 @@ func ConvertGRPCMatches(grpcMatches []v1.GRPCRouteMatch) []v1.HTTPRouteMatch {
 		}
 		hm.Headers = hmHeaders
 
-		if gm.Method != nil && gm.Method.Service != nil && gm.Method.Method != nil {
-			// if method match is provided, service and method are required
-			// as the only method type supported is exact.
-			// Validation has already been done at this point, and the condition will
-			// have been added there if required.
-			pathValue = "/" + *gm.Method.Service + "/" + *gm.Method.Method
+		if gm.Method != nil && gm.Method.Service != nil {
+			// service path used in mirror routes are special case; method is not specified
+			if strings.HasPrefix(*gm.Method.Service, http.InternalMirrorRoutePathPrefix) {
+				pathValue = *gm.Method.Service
+			}
+
+			if gm.Method.Method != nil {
+				// if method match is provided, service and method are required
+				// as the only method type supported is exact.
+				// Validation has already been done at this point, and the condition will
+				// have been added there if required.
+				pathValue = "/" + *gm.Method.Service + "/" + *gm.Method.Method
+			}
 			pathType = v1.PathMatchType("Exact")
 		}
 		hm.Path = &v1.HTTPPathMatch{
@@ -243,6 +358,11 @@ func validateGRPCMatch(
 ) field.ErrorList {
 	var allErrs field.ErrorList
 
+	// for internally-created routes used for request mirroring, we don't need to validate
+	if validator.SkipValidation() {
+		return nil
+	}
+
 	methodPath := matchPath.Child("method")
 	allErrs = append(allErrs, validateGRPCMethodMatch(validator, match.Method, methodPath)...)
 
@@ -275,6 +395,14 @@ func validateGRPCMethodMatch(
 		if method.Service == nil || *method.Service == "" {
 			allErrs = append(allErrs, field.Required(methodServicePath, "service is required"))
 		} else {
+			if strings.HasPrefix(*method.Service, http.InternalRoutePathPrefix) {
+				msg := fmt.Sprintf(
+					"service cannot start with %s. This prefix is reserved for internal use",
+					http.InternalRoutePathPrefix,
+				)
+				return field.ErrorList{field.Invalid(methodPath.Child("service"), *method.Service, msg)}
+			}
+
 			pathValue := "/" + *method.Service
 			if err := validator.ValidatePathInMatch(pathValue); err != nil {
 				valErr := field.Invalid(methodServicePath, *method.Service, err.Error())

--- a/internal/mode/static/state/graph/grpcroute.go
+++ b/internal/mode/static/state/graph/grpcroute.go
@@ -91,7 +91,11 @@ func buildGRPCMirrorRoutes(
 
 				objectMeta := route.ObjectMeta.DeepCopy()
 				backendRef := filter.RequestMirror.BackendRef
-				name := mirror.RouteName(route.GetName(), string(backendRef.Name), (*string)(backendRef.Namespace), idx)
+				namespace := route.GetNamespace()
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+				name := mirror.RouteName(route.GetName(), string(backendRef.Name), namespace, idx)
 				objectMeta.SetName(name)
 
 				tmpMirrorRoute := &v1.GRPCRoute{

--- a/internal/mode/static/state/graph/grpcroute_test.go
+++ b/internal/mode/static/state/graph/grpcroute_test.go
@@ -1140,7 +1140,7 @@ func TestBuildGRPCRouteWithMirrorRoutes(t *testing.T) {
 		Source: &v1.GRPCRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
-				Name:      mirror.RouteName("gr", "mirror-backend", nil, 0),
+				Name:      mirror.RouteName("gr", "mirror-backend", "test", 0),
 			},
 			Spec: v1.GRPCRouteSpec{
 				CommonRouteSpec: gr.Spec.CommonRouteSpec,

--- a/internal/mode/static/state/graph/grpcroute_test.go
+++ b/internal/mode/static/state/graph/grpcroute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/kinds"
 	staticConds "github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/conditions"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/mirror"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/validation/validationfakes"
 )
 
@@ -338,7 +339,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 
 	grInvalidFilterRule.Filters = []v1.GRPCRouteFilter{
 		{
-			Type: "RequestMirror",
+			Type: "InvalidFilter",
 		},
 	}
 
@@ -902,8 +903,8 @@ func TestBuildGRPCRoute(t *testing.T) {
 				Conditions: []conditions.Condition{
 					staticConds.NewRouteUnsupportedValue(
 						`All rules are invalid: spec.rules[0].filters[0].type: Unsupported value: ` +
-							`"RequestMirror": supported values: "ResponseHeaderModifier", ` +
-							`"RequestHeaderModifier", "ExtensionRef"`,
+							`"InvalidFilter": supported values: "ResponseHeaderModifier", ` +
+							`"RequestHeaderModifier", "RequestMirror", "ExtensionRef"`,
 					),
 				},
 				Spec: L7RouteSpec{
@@ -1088,6 +1089,150 @@ func TestBuildGRPCRoute(t *testing.T) {
 			g.Expect(helpers.Diff(test.expected, route)).To(BeEmpty())
 		})
 	}
+}
+
+func TestBuildGRPCRouteWithMirrorRoutes(t *testing.T) {
+	t.Parallel()
+	gatewayNsName := types.NamespacedName{Namespace: "test", Name: "gateway"}
+
+	// Create a route with a request mirror filter and another random filter
+	mirrorFilter := v1.GRPCRouteFilter{
+		Type: v1.GRPCRouteFilterRequestMirror,
+		RequestMirror: &v1.HTTPRequestMirrorFilter{
+			BackendRef: v1.BackendObjectReference{
+				Name: "mirror-backend",
+			},
+		},
+	}
+
+	headerFilter := v1.GRPCRouteFilter{
+		Type: v1.GRPCRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &v1.HTTPHeaderFilter{
+			Add: []v1.HTTPHeader{
+				{Name: "X-Custom-Header", Value: "some-value"},
+			},
+		},
+	}
+
+	gr := createGRPCRoute(
+		"gr",
+		gatewayNsName.Name,
+		"example.com",
+		[]v1.GRPCRouteRule{
+			{
+				Matches: []v1.GRPCRouteMatch{
+					{
+						Method: &v1.GRPCMethodMatch{
+							Type:    helpers.GetPointer(v1.GRPCMethodMatchExact),
+							Service: helpers.GetPointer("svc1"),
+							Method:  helpers.GetPointer("method"),
+						},
+					},
+				},
+				Filters: []v1.GRPCRouteFilter{mirrorFilter, headerFilter},
+			},
+		},
+	)
+
+	// Expected mirror route
+	expectedMirrorRoute := &L7Route{
+		RouteType: RouteTypeGRPC,
+		Source: &v1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				Name:      mirror.RouteName("gr", "mirror-backend", nil, 0),
+			},
+			Spec: v1.GRPCRouteSpec{
+				CommonRouteSpec: gr.Spec.CommonRouteSpec,
+				Hostnames:       gr.Spec.Hostnames,
+				Rules: []v1.GRPCRouteRule{
+					{
+						Matches: []v1.GRPCRouteMatch{
+							{
+								Method: &v1.GRPCMethodMatch{
+									Type:    helpers.GetPointer(v1.GRPCMethodMatchExact),
+									Service: helpers.GetPointer("/_ngf-internal-mirror-mirror-backend-0"),
+								},
+							},
+						},
+						Filters: []v1.GRPCRouteFilter{headerFilter},
+						BackendRefs: []v1.GRPCBackendRef{
+							{
+								BackendRef: v1.BackendRef{
+									BackendObjectReference: v1.BackendObjectReference{
+										Name: "mirror-backend",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ParentRefs: []ParentRef{
+			{
+				Idx:         0,
+				Gateway:     gatewayNsName,
+				SectionName: gr.Spec.ParentRefs[0].SectionName,
+			},
+		},
+		Valid:      true,
+		Attachable: true,
+		Spec: L7RouteSpec{
+			Hostnames: gr.Spec.Hostnames,
+			Rules: []RouteRule{
+				{
+					ValidMatches: true,
+					Filters: RouteRuleFilters{
+						Valid: true,
+						Filters: []Filter{
+							{
+								RouteType:             RouteTypeGRPC,
+								FilterType:            FilterRequestHeaderModifier,
+								RequestHeaderModifier: headerFilter.RequestHeaderModifier,
+							},
+						},
+					},
+					Matches: []v1.HTTPRouteMatch{
+						{
+							Path: &v1.HTTPPathMatch{
+								Type:  helpers.GetPointer(v1.PathMatchExact),
+								Value: helpers.GetPointer("/_ngf-internal-mirror-mirror-backend-0"),
+							},
+							Headers: []v1.HTTPHeaderMatch{},
+						},
+					},
+					RouteBackendRefs: []RouteBackendRef{
+						{
+							BackendRef: v1.BackendRef{
+								BackendObjectReference: v1.BackendObjectReference{
+									Name: "mirror-backend",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validator := &validationfakes.FakeHTTPFieldsValidator{}
+	gatewayNsNames := []types.NamespacedName{gatewayNsName}
+	snippetsFilters := map[types.NamespacedName]*SnippetsFilter{}
+
+	g := NewWithT(t)
+
+	routes := map[RouteKey]*L7Route{}
+	l7route := buildGRPCRoute(validator, gr, gatewayNsNames, false, snippetsFilters)
+	g.Expect(l7route).NotTo(BeNil())
+
+	buildGRPCMirrorRoutes(routes, l7route, gr, gatewayNsNames, snippetsFilters, false)
+
+	obj, ok := expectedMirrorRoute.Source.(*v1.GRPCRoute)
+	g.Expect(ok).To(BeTrue())
+	mirrorRouteKey := CreateRouteKey(obj)
+	g.Expect(routes).To(HaveKey(mirrorRouteKey))
+	g.Expect(helpers.Diff(expectedMirrorRoute, routes[mirrorRouteKey])).To(BeEmpty())
 }
 
 func TestConvertGRPCMatches(t *testing.T) {

--- a/internal/mode/static/state/graph/httproute.go
+++ b/internal/mode/static/state/graph/httproute.go
@@ -87,7 +87,11 @@ func buildHTTPMirrorRoutes(
 
 				objectMeta := route.ObjectMeta.DeepCopy()
 				backendRef := filter.RequestMirror.BackendRef
-				name := mirror.RouteName(route.GetName(), string(backendRef.Name), (*string)(backendRef.Namespace), idx)
+				namespace := route.GetNamespace()
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+				name := mirror.RouteName(route.GetName(), string(backendRef.Name), namespace, idx)
 				objectMeta.SetName(name)
 
 				tmpMirrorRoute := &v1.HTTPRoute{

--- a/internal/mode/static/state/graph/httproute.go
+++ b/internal/mode/static/state/graph/httproute.go
@@ -9,9 +9,10 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/conditions"
-
+	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
 	staticConds "github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/conditions"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/mirror"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/validation"
 )
 
@@ -70,6 +71,86 @@ func buildHTTPRoute(
 	return r
 }
 
+func buildHTTPMirrorRoutes(
+	routes map[RouteKey]*L7Route,
+	l7route *L7Route,
+	route *v1.HTTPRoute,
+	gatewayNsNames []types.NamespacedName,
+	snippetsFilters map[types.NamespacedName]*SnippetsFilter,
+) {
+	for idx, rule := range l7route.Spec.Rules {
+		if rule.Filters.Valid {
+			for _, filter := range rule.Filters.Filters {
+				if filter.RequestMirror == nil {
+					continue
+				}
+
+				objectMeta := route.ObjectMeta.DeepCopy()
+				backendRef := filter.RequestMirror.BackendRef
+				name := mirror.RouteName(route.GetName(), string(backendRef.Name), (*string)(backendRef.Namespace), idx)
+				objectMeta.SetName(name)
+
+				tmpMirrorRoute := &v1.HTTPRoute{
+					ObjectMeta: *objectMeta,
+					Spec: v1.HTTPRouteSpec{
+						CommonRouteSpec: route.Spec.CommonRouteSpec,
+						Hostnames:       route.Spec.Hostnames,
+						Rules:           buildHTTPMirrorRouteRule(idx, route.Spec.Rules[idx].Filters, filter),
+					},
+				}
+
+				mirrorRoute := buildHTTPRoute(
+					validation.SkipValidator{},
+					tmpMirrorRoute,
+					gatewayNsNames,
+					snippetsFilters,
+				)
+
+				if mirrorRoute != nil {
+					routes[CreateRouteKey(tmpMirrorRoute)] = mirrorRoute
+				}
+			}
+		}
+	}
+}
+
+func buildHTTPMirrorRouteRule(
+	ruleIdx int,
+	filters []v1.HTTPRouteFilter,
+	filter Filter,
+) []v1.HTTPRouteRule {
+	return []v1.HTTPRouteRule{
+		{
+			Matches: []v1.HTTPRouteMatch{
+				{
+					Path: &v1.HTTPPathMatch{
+						Type:  helpers.GetPointer(v1.PathMatchExact),
+						Value: mirror.PathWithBackendRef(ruleIdx, filter.RequestMirror.BackendRef),
+					},
+				},
+			},
+			Filters: removeHTTPMirrorFilters(filters),
+			BackendRefs: []v1.HTTPBackendRef{
+				{
+					BackendRef: v1.BackendRef{
+						BackendObjectReference: filter.RequestMirror.BackendRef,
+					},
+				},
+			},
+		},
+	}
+}
+
+func removeHTTPMirrorFilters(filters []v1.HTTPRouteFilter) []v1.HTTPRouteFilter {
+	var newFilters []v1.HTTPRouteFilter
+	for _, filter := range filters {
+		if filter.Type != v1.HTTPRouteFilterRequestMirror {
+			newFilters = append(newFilters, filter)
+		}
+	}
+	return newFilters
+}
+
 func processHTTPRouteRule(
 	specRule v1.HTTPRouteRule,
 	rulePath *field.Path,
@@ -117,6 +198,22 @@ func processHTTPRouteRule(
 		backendRefs = append(backendRefs, rbr)
 	}
 
+	if routeFilters.Valid {
+		for i, filter := range routeFilters.Filters {
+			if filter.RequestMirror == nil {
+				continue
+			}
+
+			rbr := RouteBackendRef{
+				BackendRef: v1.BackendRef{
+					BackendObjectReference: filter.RequestMirror.BackendRef,
+				},
+				MirrorBackendIdx: helpers.GetPointer[int](i),
+			}
+			backendRefs = append(backendRefs, rbr)
+		}
+	}
+
 	return RouteRule{
 		ValidMatches:     validMatches,
 		Matches:          specRule.Matches,
@@ -140,7 +237,12 @@ func processHTTPRouteRules(
 	for i, rule := range specRules {
 		rulePath := field.NewPath("spec").Child("rules").Index(i)
 
-		rr, errors := processHTTPRouteRule(rule, rulePath, validator, resolveExtRefFunc)
+		rr, errors := processHTTPRouteRule(
+			rule,
+			rulePath,
+			validator,
+			resolveExtRefFunc,
+		)
 
 		if rr.ValidMatches && rr.Filters.Valid {
 			atLeastOneValid = true
@@ -182,6 +284,11 @@ func validateMatch(
 	matchPath *field.Path,
 ) field.ErrorList {
 	var allErrs field.ErrorList
+
+	// for internally-created routes used for request mirroring, we don't need to validate
+	if validator.SkipValidation() {
+		return nil
+	}
 
 	pathPath := matchPath.Child("path")
 	allErrs = append(allErrs, validatePathMatch(validator, match.Path, pathPath)...)

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/internal/framework/kinds"
 	staticConds "github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/conditions"
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/mirror"
 	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/state/validation/validationfakes"
 )
 
@@ -912,6 +913,129 @@ func TestBuildHTTPRoute(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPRouteWithMirrorRoutes(t *testing.T) {
+	t.Parallel()
+	gatewayNsName := types.NamespacedName{Namespace: "test", Name: "gateway"}
+
+	// Create a route with a request mirror filter and another random filter
+	mirrorFilter := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestMirror,
+		RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+			BackendRef: gatewayv1.BackendObjectReference{
+				Name: "mirror-backend",
+			},
+		},
+	}
+	urlRewriteFilter := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterURLRewrite,
+		URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+			Hostname: helpers.GetPointer[gatewayv1.PreciseHostname]("hostname"),
+		},
+	}
+	hr := createHTTPRoute("hr", gatewayNsName.Name, "example.com", "/mirror")
+	addFilterToPath(hr, "/mirror", mirrorFilter)
+	addFilterToPath(hr, "/mirror", urlRewriteFilter)
+
+	// Expected mirror route
+	expectedMirrorRoute := &L7Route{
+		RouteType: RouteTypeHTTP,
+		Source: &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				Name:      mirror.RouteName("hr", "mirror-backend", nil, 0),
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: hr.Spec.CommonRouteSpec,
+				Hostnames:       hr.Spec.Hostnames,
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  helpers.GetPointer(gatewayv1.PathMatchExact),
+									Value: helpers.GetPointer("/_ngf-internal-mirror-mirror-backend-0"),
+								},
+							},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{urlRewriteFilter},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "mirror-backend",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ParentRefs: []ParentRef{
+			{
+				Idx:         0,
+				Gateway:     gatewayNsName,
+				SectionName: hr.Spec.ParentRefs[0].SectionName,
+			},
+		},
+		Valid:      true,
+		Attachable: true,
+		Spec: L7RouteSpec{
+			Hostnames: hr.Spec.Hostnames,
+			Rules: []RouteRule{
+				{
+					ValidMatches: true,
+					Filters: RouteRuleFilters{
+						Valid: true,
+						Filters: []Filter{
+							{
+								RouteType:  RouteTypeHTTP,
+								FilterType: FilterURLRewrite,
+								URLRewrite: urlRewriteFilter.URLRewrite,
+							},
+						},
+					},
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  helpers.GetPointer(gatewayv1.PathMatchExact),
+								Value: helpers.GetPointer("/_ngf-internal-mirror-mirror-backend-0"),
+							},
+						},
+					},
+					RouteBackendRefs: []RouteBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "mirror-backend",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validator := &validationfakes.FakeHTTPFieldsValidator{}
+	gatewayNsNames := []types.NamespacedName{gatewayNsName}
+	snippetsFilters := map[types.NamespacedName]*SnippetsFilter{}
+
+	g := NewWithT(t)
+
+	routes := map[RouteKey]*L7Route{}
+	l7route := buildHTTPRoute(validator, hr, gatewayNsNames, snippetsFilters)
+	g.Expect(l7route).NotTo(BeNil())
+
+	buildHTTPMirrorRoutes(routes, l7route, hr, gatewayNsNames, snippetsFilters)
+
+	obj, ok := expectedMirrorRoute.Source.(*gatewayv1.HTTPRoute)
+	g.Expect(ok).To(BeTrue())
+	mirrorRouteKey := CreateRouteKey(obj)
+	g.Expect(routes).To(HaveKey(mirrorRouteKey))
+	g.Expect(helpers.Diff(expectedMirrorRoute, routes[mirrorRouteKey])).To(BeEmpty())
+}
+
 func TestValidateMatch(t *testing.T) {
 	t.Parallel()
 	createAllValidValidator := func() *validationfakes.FakeHTTPFieldsValidator {
@@ -919,6 +1043,9 @@ func TestValidateMatch(t *testing.T) {
 		v.ValidateMethodInMatchReturns(true, nil)
 		return v
 	}
+
+	skipValidator := validationfakes.FakeHTTPFieldsValidator{}
+	skipValidator.SkipValidationReturns(true)
 
 	tests := []struct {
 		match          gatewayv1.HTTPRouteMatch
@@ -1164,6 +1291,11 @@ func TestValidateMatch(t *testing.T) {
 			},
 			expectErrCount: 3,
 			name:           "multiple errors",
+		},
+		{
+			validator:      &skipValidator,
+			expectErrCount: 0,
+			name:           "skip validation",
 		},
 	}
 

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -942,7 +942,7 @@ func TestBuildHTTPRouteWithMirrorRoutes(t *testing.T) {
 		Source: &gatewayv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
-				Name:      mirror.RouteName("hr", "mirror-backend", nil, 0),
+				Name:      mirror.RouteName("hr", "mirror-backend", "test", 0),
 			},
 			Spec: gatewayv1.HTTPRouteSpec{
 				CommonRouteSpec: hr.Spec.CommonRouteSpec,

--- a/internal/mode/static/state/graph/tlsroute.go
+++ b/internal/mode/static/state/graph/tlsroute.go
@@ -67,7 +67,8 @@ func buildTLSRoute(
 	return r
 }
 
-func validateBackendRefTLSRoute(gtr *v1alpha2.TLSRoute,
+func validateBackendRefTLSRoute(
+	gtr *v1alpha2.TLSRoute,
 	services map[types.NamespacedName]*apiv1.Service,
 	npCfg *NginxProxy,
 	refGrantResolver func(resource toResource) bool,

--- a/internal/mode/static/state/graph/tlsroute_test.go
+++ b/internal/mode/static/state/graph/tlsroute_test.go
@@ -429,7 +429,8 @@ func TestBuildTLSRoute(t *testing.T) {
 					},
 				},
 				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefRefNotPermitted(
-					"Backend ref to Service diff/hi not permitted by any ReferenceGrant",
+					"spec.rules[0].backendRefs[0].namespace: Forbidden: Backend ref to Service " +
+						"diff/hi not permitted by any ReferenceGrant",
 				)},
 				Attachable: true,
 				Valid:      true,

--- a/internal/mode/static/state/mirror/mirror.go
+++ b/internal/mode/static/state/mirror/mirror.go
@@ -12,13 +12,9 @@ import (
 // RouteName builds the name for the internal mirror route, using the user route name,
 // service namespace/name, and index of the rule.
 // The prefix is used to prevent a user from creating a route with a conflicting name.
-func RouteName(routeName, service string, namespace *string, idx int) string {
+func RouteName(routeName, service, namespace string, idx int) string {
 	prefix := strings.TrimPrefix(http.InternalMirrorRoutePathPrefix, "/")
-	if namespace != nil {
-		return fmt.Sprintf("%s-%s-%s-%s-%d", prefix, routeName, service, *namespace, idx)
-	}
-
-	return fmt.Sprintf("%s-%s-%s-%d", prefix, routeName, service, idx)
+	return fmt.Sprintf("%s-%s-%s/%s-%d", prefix, routeName, namespace, service, idx)
 }
 
 // BackendPath builds the path for the internal mirror location, using the BackendRef.
@@ -35,7 +31,7 @@ func BackendPath(idx int, namespace *string, service string) *string {
 	var mirrorPath string
 
 	if namespace != nil {
-		mirrorPath = fmt.Sprintf("%s-%s-%s-%d", http.InternalMirrorRoutePathPrefix, *namespace, service, idx)
+		mirrorPath = fmt.Sprintf("%s-%s/%s-%d", http.InternalMirrorRoutePathPrefix, *namespace, service, idx)
 	} else {
 		mirrorPath = fmt.Sprintf("%s-%s-%d", http.InternalMirrorRoutePathPrefix, service, idx)
 	}

--- a/internal/mode/static/state/mirror/mirror.go
+++ b/internal/mode/static/state/mirror/mirror.go
@@ -1,0 +1,44 @@
+package mirror
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/nginx/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
+)
+
+// RouteName builds the name for the internal mirror route, using the user route name,
+// service namespace/name, and index of the rule.
+// The prefix is used to prevent a user from creating a route with a conflicting name.
+func RouteName(routeName, service string, namespace *string, idx int) string {
+	prefix := strings.TrimPrefix(http.InternalMirrorRoutePathPrefix, "/")
+	if namespace != nil {
+		return fmt.Sprintf("%s-%s-%s-%s-%d", prefix, routeName, service, *namespace, idx)
+	}
+
+	return fmt.Sprintf("%s-%s-%s-%d", prefix, routeName, service, idx)
+}
+
+// BackendPath builds the path for the internal mirror location, using the BackendRef.
+func PathWithBackendRef(idx int, backendRef v1.BackendObjectReference) *string {
+	svcName := string(backendRef.Name)
+	if backendRef.Namespace == nil {
+		return BackendPath(idx, nil, svcName)
+	}
+	return BackendPath(idx, (*string)(backendRef.Namespace), svcName)
+}
+
+// BackendPath builds the path for the internal mirror location.
+func BackendPath(idx int, namespace *string, service string) *string {
+	var mirrorPath string
+
+	if namespace != nil {
+		mirrorPath = fmt.Sprintf("%s-%s-%s-%d", http.InternalMirrorRoutePathPrefix, *namespace, service, idx)
+	} else {
+		mirrorPath = fmt.Sprintf("%s-%s-%d", http.InternalMirrorRoutePathPrefix, service, idx)
+	}
+
+	return &mirrorPath
+}

--- a/internal/mode/static/state/mirror/mirror_test.go
+++ b/internal/mode/static/state/mirror/mirror_test.go
@@ -1,0 +1,126 @@
+package mirror
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/nginx/nginx-gateway-fabric/internal/framework/helpers"
+)
+
+func TestRouteName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		namespace *string
+		name      string
+		routeName string
+		service   string
+		expected  string
+		idx       int
+	}{
+		{
+			name:      "with namespace",
+			routeName: "route1",
+			service:   "service1",
+			namespace: helpers.GetPointer("namespace1"),
+			idx:       1,
+			expected:  "_ngf-internal-mirror-route1-service1-namespace1-1",
+		},
+		{
+			name:      "without namespace",
+			routeName: "route2",
+			service:   "service2",
+			namespace: nil,
+			idx:       2,
+			expected:  "_ngf-internal-mirror-route2-service2-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := RouteName(tt.routeName, tt.service, tt.namespace, tt.idx)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestPathWithBackendRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		backendRef v1.BackendObjectReference
+		expected   *string
+		name       string
+		idx        int
+	}{
+		{
+			name: "with namespace",
+			idx:  1,
+			backendRef: v1.BackendObjectReference{
+				Name:      "service1",
+				Namespace: helpers.GetPointer[v1.Namespace]("namespace1"),
+			},
+			expected: helpers.GetPointer("/_ngf-internal-mirror-namespace1-service1-1"),
+		},
+		{
+			name: "without namespace",
+			idx:  2,
+			backendRef: v1.BackendObjectReference{
+				Name: "service2",
+			},
+			expected: helpers.GetPointer("/_ngf-internal-mirror-service2-2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := PathWithBackendRef(tt.idx, tt.backendRef)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestBackendPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		namespace *string
+		expected  *string
+		name      string
+		service   string
+		idx       int
+	}{
+		{
+			name:      "With namespace",
+			idx:       1,
+			namespace: helpers.GetPointer("namespace1"),
+			service:   "service1",
+			expected:  helpers.GetPointer("/_ngf-internal-mirror-namespace1-service1-1"),
+		},
+		{
+			name:      "Without namespace",
+			idx:       2,
+			namespace: nil,
+			service:   "service2",
+			expected:  helpers.GetPointer("/_ngf-internal-mirror-service2-2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := BackendPath(tt.idx, tt.namespace, tt.service)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}

--- a/internal/mode/static/state/mirror/mirror_test.go
+++ b/internal/mode/static/state/mirror/mirror_test.go
@@ -11,42 +11,10 @@ import (
 
 func TestRouteName(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
-	tests := []struct {
-		namespace *string
-		name      string
-		routeName string
-		service   string
-		expected  string
-		idx       int
-	}{
-		{
-			name:      "with namespace",
-			routeName: "route1",
-			service:   "service1",
-			namespace: helpers.GetPointer("namespace1"),
-			idx:       1,
-			expected:  "_ngf-internal-mirror-route1-service1-namespace1-1",
-		},
-		{
-			name:      "without namespace",
-			routeName: "route2",
-			service:   "service2",
-			namespace: nil,
-			idx:       2,
-			expected:  "_ngf-internal-mirror-route2-service2-2",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewWithT(t)
-
-			result := RouteName(tt.routeName, tt.service, tt.namespace, tt.idx)
-			g.Expect(result).To(Equal(tt.expected))
-		})
-	}
+	result := RouteName("route1", "service1", "namespace1", 1)
+	g.Expect(result).To(Equal("_ngf-internal-mirror-route1-namespace1/service1-1"))
 }
 
 func TestPathWithBackendRef(t *testing.T) {
@@ -65,7 +33,7 @@ func TestPathWithBackendRef(t *testing.T) {
 				Name:      "service1",
 				Namespace: helpers.GetPointer[v1.Namespace]("namespace1"),
 			},
-			expected: helpers.GetPointer("/_ngf-internal-mirror-namespace1-service1-1"),
+			expected: helpers.GetPointer("/_ngf-internal-mirror-namespace1/service1-1"),
 		},
 		{
 			name: "without namespace",
@@ -103,7 +71,7 @@ func TestBackendPath(t *testing.T) {
 			idx:       1,
 			namespace: helpers.GetPointer("namespace1"),
 			service:   "service1",
-			expected:  helpers.GetPointer("/_ngf-internal-mirror-namespace1-service1-1"),
+			expected:  helpers.GetPointer("/_ngf-internal-mirror-namespace1/service1-1"),
 		},
 		{
 			name:      "Without namespace",

--- a/internal/mode/static/state/validation/validationfakes/fake_httpfields_validator.go
+++ b/internal/mode/static/state/validation/validationfakes/fake_httpfields_validator.go
@@ -8,6 +8,16 @@ import (
 )
 
 type FakeHTTPFieldsValidator struct {
+	SkipValidationStub        func() bool
+	skipValidationMutex       sync.RWMutex
+	skipValidationArgsForCall []struct {
+	}
+	skipValidationReturns struct {
+		result1 bool
+	}
+	skipValidationReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	ValidateFilterHeaderNameStub        func(string) error
 	validateFilterHeaderNameMutex       sync.RWMutex
 	validateFilterHeaderNameArgsForCall []struct {
@@ -159,6 +169,59 @@ type FakeHTTPFieldsValidator struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeHTTPFieldsValidator) SkipValidation() bool {
+	fake.skipValidationMutex.Lock()
+	ret, specificReturn := fake.skipValidationReturnsOnCall[len(fake.skipValidationArgsForCall)]
+	fake.skipValidationArgsForCall = append(fake.skipValidationArgsForCall, struct {
+	}{})
+	stub := fake.SkipValidationStub
+	fakeReturns := fake.skipValidationReturns
+	fake.recordInvocation("SkipValidation", []interface{}{})
+	fake.skipValidationMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeHTTPFieldsValidator) SkipValidationCallCount() int {
+	fake.skipValidationMutex.RLock()
+	defer fake.skipValidationMutex.RUnlock()
+	return len(fake.skipValidationArgsForCall)
+}
+
+func (fake *FakeHTTPFieldsValidator) SkipValidationCalls(stub func() bool) {
+	fake.skipValidationMutex.Lock()
+	defer fake.skipValidationMutex.Unlock()
+	fake.SkipValidationStub = stub
+}
+
+func (fake *FakeHTTPFieldsValidator) SkipValidationReturns(result1 bool) {
+	fake.skipValidationMutex.Lock()
+	defer fake.skipValidationMutex.Unlock()
+	fake.SkipValidationStub = nil
+	fake.skipValidationReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeHTTPFieldsValidator) SkipValidationReturnsOnCall(i int, result1 bool) {
+	fake.skipValidationMutex.Lock()
+	defer fake.skipValidationMutex.Unlock()
+	fake.SkipValidationStub = nil
+	if fake.skipValidationReturnsOnCall == nil {
+		fake.skipValidationReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.skipValidationReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeHTTPFieldsValidator) ValidateFilterHeaderName(arg1 string) error {
@@ -966,6 +1029,8 @@ func (fake *FakeHTTPFieldsValidator) ValidateRedirectStatusCodeReturnsOnCall(i i
 func (fake *FakeHTTPFieldsValidator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.skipValidationMutex.RLock()
+	defer fake.skipValidationMutex.RUnlock()
 	fake.validateFilterHeaderNameMutex.RLock()
 	defer fake.validateFilterHeaderNameMutex.RUnlock()
 	fake.validateFilterHeaderValueMutex.RLock()

--- a/internal/mode/static/state/validation/validator.go
+++ b/internal/mode/static/state/validation/validator.go
@@ -22,6 +22,7 @@ type Validators struct {
 //
 //counterfeiter:generate . HTTPFieldsValidator
 type HTTPFieldsValidator interface {
+	SkipValidation() bool
 	ValidatePathInMatch(path string) error
 	ValidateHeaderNameInMatch(name string) error
 	ValidateHeaderValueInMatch(value string) error
@@ -58,3 +59,22 @@ type PolicyValidator interface {
 	// Conflicts returns true if the two Policies conflict.
 	Conflicts(a, b policies.Policy) bool
 }
+
+// SkipValidator is used to skip validation on internally-created routes for request mirroring.
+type SkipValidator struct{}
+
+func (SkipValidator) SkipValidation() bool { return true }
+
+func (SkipValidator) ValidatePathInMatch(string) error                { return nil }
+func (SkipValidator) ValidateHeaderNameInMatch(string) error          { return nil }
+func (SkipValidator) ValidateHeaderValueInMatch(string) error         { return nil }
+func (SkipValidator) ValidateQueryParamNameInMatch(string) error      { return nil }
+func (SkipValidator) ValidateQueryParamValueInMatch(string) error     { return nil }
+func (SkipValidator) ValidateMethodInMatch(string) (bool, []string)   { return true, nil }
+func (SkipValidator) ValidateRedirectScheme(string) (bool, []string)  { return true, nil }
+func (SkipValidator) ValidateRedirectPort(int32) error                { return nil }
+func (SkipValidator) ValidateRedirectStatusCode(int) (bool, []string) { return true, nil }
+func (SkipValidator) ValidateHostname(string) error                   { return nil }
+func (SkipValidator) ValidateFilterHeaderName(string) error           { return nil }
+func (SkipValidator) ValidateFilterHeaderValue(string) error          { return nil }
+func (SkipValidator) ValidatePath(string) error                       { return nil }


### PR DESCRIPTION
Problem: As a user, I want to be able to mirror requests to another backend(s) using the RequestMirror filter on an HTTPRoute or GRPCRoute.

Solution: Add support for the RequestMirror filter, allowing users to mirror requests with HTTPRoutes or GRPCRoutes.

Testing: Manually verified single mirror filter, multiple mirror filter, mirror filter with other filters.

Note: the RequestMirror conformance tests seem to have a bug in 1.2.1 Gateway API, which may be fixed in 1.3. We can hopefully enable them at that point.

Closes #533

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Add support for request mirroring using the RequestMirror filter.
```
