### PR TITLE
CP/DP Split: Add ability to set loadBalancerClass for load balancer Service

### DIFF
--- a/apis/v1alpha2/nginxproxy_types.go
+++ b/apis/v1alpha2/nginxproxy_types.go
@@ -517,6 +517,12 @@ type ServiceSpec struct {
 	// +optional
 	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 
+	// LoadBalancerClass is the class of the load balancer implementation this Service belongs to.
+	// Requires service type to be LoadBalancer.
+	//
+	// +optional
+	LoadBalancerClass *string `json:"loadBalancerClass,omitempty"`
+
 	// Annotations contain any Service-specific annotations.
 	//
 	// +optional

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -530,6 +530,11 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerClass != nil {
+		in, out := &in.LoadBalancerClass, &out.LoadBalancerClass
+		*out = new(string)
+		**out = **in
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -427,6 +427,10 @@ nginx:
     # -- The static IP address for the load balancer. Requires nginx.service.type set to LoadBalancer.
     # loadBalancerIP: ""
 
+    # -- LoadBalancerClass is the class of the load balancer implementation this Service belongs to.
+    # Requires nginx.service.type set to LoadBalancer.
+    # loadBalancerClass: ""
+
     # -- The IP ranges (CIDR) that are allowed to access the load balancer. Requires nginx.service.type set to LoadBalancer.
     # loadBalancerSourceRanges: []
 

--- a/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
+++ b/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
@@ -3482,6 +3482,11 @@ spec:
                         - Cluster
                         - Local
                         type: string
+                      loadBalancerClass:
+                        description: |-
+                          LoadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          Requires service type to be LoadBalancer.
+                        type: string
                       loadBalancerIP:
                         description: LoadBalancerIP is a static IP address for the
                           load balancer. Requires service type to be LoadBalancer.

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -4067,6 +4067,11 @@ spec:
                         - Cluster
                         - Local
                         type: string
+                      loadBalancerClass:
+                        description: |-
+                          LoadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          Requires service type to be LoadBalancer.
+                        type: string
                       loadBalancerIP:
                         description: LoadBalancerIP is a static IP address for the
                           load balancer. Requires service type to be LoadBalancer.

--- a/internal/mode/static/provisioner/objects.go
+++ b/internal/mode/static/provisioner/objects.go
@@ -460,6 +460,9 @@ func buildNginxService(
 	if serviceCfg.LoadBalancerIP != nil {
 		svc.Spec.LoadBalancerIP = *serviceCfg.LoadBalancerIP
 	}
+	if serviceCfg.LoadBalancerClass != nil {
+		svc.Spec.LoadBalancerClass = serviceCfg.LoadBalancerClass
+	}
 	if serviceCfg.LoadBalancerSourceRanges != nil {
 		svc.Spec.LoadBalancerSourceRanges = serviceCfg.LoadBalancerSourceRanges
 	}

--- a/internal/mode/static/provisioner/objects_test.go
+++ b/internal/mode/static/provisioner/objects_test.go
@@ -253,6 +253,7 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 				ServiceType:              helpers.GetPointer(ngfAPIv1alpha2.ServiceTypeNodePort),
 				ExternalTrafficPolicy:    helpers.GetPointer(ngfAPIv1alpha2.ExternalTrafficPolicyCluster),
 				LoadBalancerIP:           helpers.GetPointer("1.2.3.4"),
+				LoadBalancerClass:        helpers.GetPointer("myLoadBalancerClass"),
 				LoadBalancerSourceRanges: []string{"5.6.7.8"},
 			},
 			Deployment: &ngfAPIv1alpha2.DeploymentSpec{
@@ -299,6 +300,7 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 	g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyTypeCluster))
 	g.Expect(svc.Spec.LoadBalancerIP).To(Equal("1.2.3.4"))
+	g.Expect(*svc.Spec.LoadBalancerClass).To(Equal("myLoadBalancerClass"))
 	g.Expect(svc.Spec.LoadBalancerSourceRanges).To(Equal([]string{"5.6.7.8"}))
 
 	depObj := objects[5]


### PR DESCRIPTION
### Proposed changes

Add ability to set loadBalancerClass for load balancer Service

Problem: We would like the ability to specify the loadBalanacerClass field on a load balancer service.

Solution: Add ability to set loadBalancerClass for load balancer Service.

Testing: Manually tested that deploying NGF with the nginx.service.loadBalancerClass Helm flag would correctly set the field. Also tested that modifying the NginxProxy resource would set the loadBalancerClass when the service was re-created (the field can only be set upon creation).

Closes #3303

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
