### PR TITLE
Add GKE router to nfr workflow

### DIFF
--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Create and setup Router
         working-directory: ./tests
-        run: make create-gke-router
+        run: make create-gke-router || true
 
       - name: Run Tests
         working-directory: ./tests

--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -168,6 +168,7 @@ jobs:
         if: always()
         run: |
           bash scripts/cleanup-vm.sh true
+          bash scripts/cleanup-router.sh true
           make delete-gke-cluster
           rm -rf scripts/vars.env
 

--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -144,6 +144,10 @@ jobs:
         working-directory: ./tests
         run: make create-and-setup-vm
 
+      - name: Create and setup Router
+        working-directory: ./tests
+        run: make create-gke-router
+
       - name: Run Tests
         working-directory: ./tests
         run: |

--- a/tests/scripts/create-gke-router.sh
+++ b/tests/scripts/create-gke-router.sh
@@ -11,5 +11,5 @@ gcloud compute routers create "${RESOURCE_NAME}" \
 gcloud compute routers nats create "${RESOURCE_NAME}" \
     --router-region "${GKE_CLUSTER_REGION}" \
     --router "${RESOURCE_NAME}" \
-    --auto-allocate-nat-external-ips \
-    --nat-custom-subnet-ip-ranges="default"
+    --nat-all-subnet-ip-ranges \
+    --auto-allocate-nat-external-ips

--- a/tests/scripts/create-gke-router.sh
+++ b/tests/scripts/create-gke-router.sh
@@ -11,5 +11,5 @@ gcloud compute routers create "${RESOURCE_NAME}" \
 gcloud compute routers nats create "${RESOURCE_NAME}" \
     --router-region "${GKE_CLUSTER_REGION}" \
     --router "${RESOURCE_NAME}" \
-    --nat-all-subnet-ip-ranges \
-    --auto-allocate-nat-external-ips
+    --auto-allocate-nat-external-ips \
+    --nat-custom-subnet-ip-ranges="default"


### PR DESCRIPTION
Add a small fix to the nfr workflow which involves creating a GKE router.

Passing nfr workflow action: https://github.com/nginx/nginx-gateway-fabric/actions/runs/15143764098

PR containing nfr workflow test results is here: https://github.com/nginx/nginx-gateway-fabric/pull/3391 

