### PR TITLE
Support provisioning of Gateway(s) in helm chart

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -214,8 +214,8 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
 > [!NOTE]
 >
-> More information on container lifecycle hooks can be found
-> [here](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) and a detailed
+> More information on container lifecycle hooks can be found in the official
+> [kubernetes documentation](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) and a detailed
 > description of Pod termination behavior can be found in
 > [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/Pods/Pod-lifecycle/#Pod-termination).
 
@@ -258,6 +258,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `certGenerator.overwrite` | Overwrite existing TLS Secrets on startup. | bool | `false` |
 | `certGenerator.serverTLSSecretName` | The name of the Secret containing TLS CA, certificate, and key for the NGINX Gateway Fabric control plane to securely communicate with the NGINX Agent. Must exist in the same namespace that the NGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway). | string | `"server-tls"` |
 | `clusterDomain` | The DNS cluster domain of your Kubernetes cluster. | string | `"cluster.local"` |
+| `gateways` | A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference. | list | `[]` |
 | `nginx` | The nginx section contains the configuration for all NGINX data plane deployments installed by the NGINX Gateway Fabric control plane. | object | `{"config":{},"container":{},"debug":false,"image":{"pullPolicy":"Always","repository":"ghcr.io/nginx/nginx-gateway-fabric/nginx","tag":"edge"},"imagePullSecret":"","imagePullSecrets":[],"kind":"deployment","plus":false,"pod":{},"replicas":1,"service":{"externalTrafficPolicy":"Local","loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"nodePorts":[],"type":"LoadBalancer"},"usage":{"caSecretName":"","clientSSLSecretName":"","endpoint":"","resolver":"","secretName":"nplus-license","skipVerify":false}}` |
 | `nginx.config` | The configuration for the data plane that is contained in the NginxProxy resource. This is applied globally to all Gateways managed by this instance of NGINX Gateway Fabric. | object | `{}` |
 | `nginx.container` | The container configuration for the NGINX container. This is applied globally to all Gateways managed by this instance of NGINX Gateway Fabric. | object | `{}` |

--- a/charts/nginx-gateway-fabric/README.md.gotmpl
+++ b/charts/nginx-gateway-fabric/README.md.gotmpl
@@ -212,8 +212,8 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
 > [!NOTE]
 >
-> More information on container lifecycle hooks can be found
-> [here](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) and a detailed
+> More information on container lifecycle hooks can be found in the official
+> [kubernetes documentation](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) and a detailed
 > description of Pod termination behavior can be found in
 > [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/Pods/Pod-lifecycle/#Pod-termination).
 

--- a/charts/nginx-gateway-fabric/templates/gateway.yaml
+++ b/charts/nginx-gateway-fabric/templates/gateway.yaml
@@ -1,0 +1,41 @@
+{{- range .Values.gateways }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ default "gateway" .name }}
+  {{- with .namespace }}
+  namespace: {{ .}}
+  {{- end }}
+  {{- with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ default "nginx" .spec.gatewayClassName }}
+  {{- with .spec.infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  listeners:
+    {{- range $listener := .spec.listeners }}
+    - name: {{ $listener.name }}
+      {{- with $listener.hostname }}
+      hostname: {{ . | toYaml }}
+      {{- end }}
+      port: {{ $listener.port }}
+      protocol: {{ $listener.protocol }}
+      {{- with $listener.allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $listener.tls }}
+      tls:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- end }}
+{{- end }}

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -43,6 +43,15 @@
       "title": "clusterDomain",
       "type": "string"
     },
+    "gateways": {
+      "description": "A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference.",
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "gateways",
+      "type": "array"
+    },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -477,3 +477,32 @@ certGenerator:
 
   # -- Overwrite existing TLS Secrets on startup.
   overwrite: false
+
+# Example gateway object:
+# name: nginx-gateway
+# namespace: default
+# labels:
+#   key: value
+# annotations:
+#   annotationKey: annotationValue
+# spec:
+#   gatewayClassName: nginx
+#   infrastructure:
+#     annotations:
+#       service.annotations.networking.gke.io/load-balancer-type: Internal
+#   listeners:
+#     - name: https
+#       port: 80
+#       protocol: HTTPS
+#       tls:
+#         mode: Terminate
+#         certificateRefs:
+#           - kind: Secret
+#             name: my-secret
+#             namespace: certificate
+#       allowedRoutes:
+#         namespaces:
+#           from: Same
+
+# -- A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference.
+gateways: []

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -478,6 +478,9 @@ certGenerator:
   # -- Overwrite existing TLS Secrets on startup.
   overwrite: false
 
+# -- A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference.
+gateways: []
+
 # Example gateway object:
 # name: nginx-gateway
 # namespace: default
@@ -503,6 +506,3 @@ certGenerator:
 #       allowedRoutes:
 #         namespaces:
 #           from: Same
-
-# -- A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference.
-gateways: []


### PR DESCRIPTION
### Proposed changes

Support provisioning of Gateway(s) in helm chart. 

Problem: Users would like to provision a Gateway through the helm chart.

Solution: Support provisioning of Gateway(s) in helm chart. 

Testing: Manually tested templating and installation of an example values.yaml file.

Closes #1533

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Support provisioning Gateway resources through helm chart. 
```
