### PR TITLE
Bulk delete namespaces in reconfiguration nfr test

### DIFF
--- a/tests/framework/resourcemanager.go
+++ b/tests/framework/resourcemanager.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -219,6 +220,47 @@ func (rm *ResourceManager) DeleteNamespace(name string) error {
 			}
 			return false, nil
 		})
+}
+
+func (rm *ResourceManager) DeleteNamespaces(names []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), rm.TimeoutConfig.DeleteNamespaceTimeout*2)
+	defer cancel()
+
+	var combinedErrors error
+	ns := &core.Namespace{}
+	for _, name := range names {
+		if err := rm.K8sClient.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			combinedErrors = errors.Join(combinedErrors, fmt.Errorf("error getting namespace: %w", err))
+		}
+
+		if err := rm.K8sClient.Delete(ctx, ns); err != nil {
+			combinedErrors = errors.Join(combinedErrors, fmt.Errorf("error deleting namespace: %w", err))
+		}
+	}
+
+	err := wait.PollUntilContextCancel(
+		ctx,
+		500*time.Millisecond,
+		true, /* poll immediately */
+		func(ctx context.Context) (bool, error) {
+			nsList := &core.NamespaceList{}
+			if err := rm.K8sClient.List(ctx, nsList); err != nil {
+				return false, nil //nolint:nilerr // retry on error
+			}
+
+			for _, namespace := range nsList.Items {
+				if slices.Contains(names, namespace.Name) {
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+
+	return errors.Join(combinedErrors, err)
 }
 
 // DeleteFromFiles deletes Kubernetes resources defined within the provided YAML files.

--- a/tests/framework/resourcemanager.go
+++ b/tests/framework/resourcemanager.go
@@ -227,16 +227,14 @@ func (rm *ResourceManager) DeleteNamespaces(names []string) error {
 	defer cancel()
 
 	var combinedErrors error
-	ns := &core.Namespace{}
 	for _, name := range names {
-		if err := rm.K8sClient.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+		ns := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+
+		if err := rm.K8sClient.Delete(ctx, ns); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			combinedErrors = errors.Join(combinedErrors, fmt.Errorf("error getting namespace: %w", err))
-		}
 
-		if err := rm.K8sClient.Delete(ctx, ns); err != nil {
 			combinedErrors = errors.Join(combinedErrors, fmt.Errorf("error deleting namespace: %w", err))
 		}
 	}

--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -170,16 +170,12 @@ var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("nfr", "r
 	cleanupResources := func() error {
 		var err error
 
-		// FIXME (bjee19): https://github.com/nginx/nginx-gateway-fabric/issues/2376
-		// Find a way to bulk delete these namespaces.
-		for i := 1; i <= maxResourceCount; i++ {
-			nsName := "namespace" + strconv.Itoa(i)
-			resultError := resourceManager.DeleteNamespace(nsName)
-			if resultError != nil {
-				err = resultError
-			}
+		namespaces := make([]string, maxResourceCount)
+		for i := range maxResourceCount {
+			namespaces[i] = "namespace" + strconv.Itoa(i+1)
 		}
 
+		err = resourceManager.DeleteNamespaces(namespaces)
 		Expect(resourceManager.DeleteNamespace(reconfigNamespace.Name)).To(Succeed())
 
 		return err

--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -486,7 +486,7 @@ Time To Ready Description: {{ .TimeToReadyDescription }}
 {{- end }}
 
 ### NGINX Error Logs
-{{ .NGINXErrorLogs }}
+{{ .NGINXErrorLogs -}}
 `
 
 func writeReconfigResults(dest io.Writer, results reconfigTestResults) error {


### PR DESCRIPTION
Add bulk delete namespaces function to use in reconfiguration nfr test to improve performance.

Problem: The reconfiguration nfr test takes a very long time to run because we are deleting namespaces individually, we could save a lot of time by bulk deleting them.

Solution: Add a function which deletes multiple namespaces at a single time.

Testing: Ran the nfr test and confirms it still works. 

Closes #2376

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
