### PR TITLE
Don't run Mend on fork

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   mend:
-    if: ${{ github.event.repository.fork == false }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'push' && github.event.repository.fork == false) }}
     uses: nginxinc/compliance-rules/.github/workflows/mend.yml@c903bfe6c668eaba362cde6a7882278bc1564401 # v0.1
     secrets: inherit
     with:


### PR DESCRIPTION
Problem: Mend workflow was running on forks, which would fail since proper secrets aren't set.

Solution: Don't run on forks.

