### PR TITLE
Skip full upgrade test suite

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -120,7 +120,7 @@ stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 
 .PHONY: .vm-nfr-test
 .vm-nfr-test: ## Runs the NFR tests on the GCP VM (called by `nfr-test`)
-	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --keep-going --fail-on-pending \
+	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --keep-going \
 		--trace -r -v --buildvcs --force-newlines $(GITHUB_OUTPUT) \
 		--label-filter "nfr" $(GINKGO_FLAGS) --timeout 5h ./suite --  --gateway-api-version=$(GW_API_VERSION) \
 		--gateway-api-prev-version=$(GW_API_PREV_VERSION) --image-tag=$(TAG) --version-under-test=$(NGF_VERSION) \
@@ -132,7 +132,7 @@ stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 .PHONY: test
 test: build-crossplane-image ## Runs the functional tests on your kind k8s cluster
 	kind load docker-image nginx-crossplane:latest --name $(CLUSTER_NAME)
-	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --keep-going --fail-on-pending \
+	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --keep-going \
 		--trace -r -v --buildvcs --force-newlines $(GITHUB_OUTPUT) \
 		--label-filter "functional" $(GINKGO_FLAGS) ./suite -- \
 		--gateway-api-version=$(GW_API_VERSION) --gateway-api-prev-version=$(GW_API_PREV_VERSION) \

--- a/tests/suite/upgrade_test.go
+++ b/tests/suite/upgrade_test.go
@@ -26,7 +26,7 @@ import (
 // This test installs the latest released version of NGF, then upgrades to the edge version (or dev version).
 // During the upgrade, traffic is continuously sent to ensure no downtime.
 // We also check that the leader election lease has been updated, and that Gateway updates are processed.
-var _ = Describe("Upgrade testing", Label("nfr", "upgrade"), func() {
+var _ = PDescribe("Upgrade testing", Label("nfr", "upgrade"), func() {
 	var (
 		files = []string{
 			"ngf-upgrade/cafe.yaml",


### PR DESCRIPTION
Mark upgrade suite as pending so none of the suite runs for NFR tests.