### PR TITLE
Set proper IP family policy on NGINX LB Service

### DIFF
--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -161,6 +161,7 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 	validateMeta(svc)
 	g.Expect(svc.Spec.Type).To(Equal(defaultServiceType))
 	g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(defaultServicePolicy))
+	g.Expect(*svc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicyPreferDualStack))
 
 	// service ports is sorted in ascending order by port number when we make the nginx object
 	g.Expect(svc.Spec.Ports).To(Equal([]corev1.ServicePort{
@@ -260,6 +261,7 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 
 	resourceName := "gw-nginx"
 	nProxyCfg := &graph.EffectiveNginxProxy{
+		IPFamily: helpers.GetPointer(ngfAPIv1alpha2.IPv4),
 		Logging: &ngfAPIv1alpha2.NginxLogging{
 			ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
 			AgentLevel: helpers.GetPointer(ngfAPIv1alpha2.AgentLogLevelDebug),
@@ -321,6 +323,8 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 	g.Expect(svc.Spec.LoadBalancerIP).To(Equal("1.2.3.4"))
 	g.Expect(*svc.Spec.LoadBalancerClass).To(Equal("myLoadBalancerClass"))
 	g.Expect(svc.Spec.LoadBalancerSourceRanges).To(Equal([]string{"5.6.7.8"}))
+	g.Expect(*svc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicySingleStack))
+	g.Expect(svc.Spec.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
 
 	depObj := objects[5]
 	dep, ok := depObj.(*appsv1.Deployment)


### PR DESCRIPTION
Problem: When provisioning the NGINX LoadBalancer Service, the IPFamily that's set in the NginxProxy resource (default dual) was not honored.

Solution: By default, set the IPFamily to PreferDualStack. If a user has specified otherwise in the NginxProxy resource, then set to SingleStack.

Testing: Verified that the NGINX Service has the proper IPFamily set based on what is in the NginxProxy resource, with DualStack being the default.

Closes #3473

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue where the NGINX Service was not configured with the proper IPFamily.
```
