### PR TITLE
Set proper IP family policy on NGINX LB Service (#3475)

### DIFF
--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -161,6 +161,7 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 	validateMeta(svc)
 	g.Expect(svc.Spec.Type).To(Equal(defaultServiceType))
 	g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(defaultServicePolicy))
+	g.Expect(*svc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicyPreferDualStack))
 
 	// service ports is sorted in ascending order by port number when we make the nginx object
 	g.Expect(svc.Spec.Ports).To(Equal([]corev1.ServicePort{
@@ -260,6 +261,7 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 
 	resourceName := "gw-nginx"
 	nProxyCfg := &graph.EffectiveNginxProxy{
+		IPFamily: helpers.GetPointer(ngfAPIv1alpha2.IPv4),
 		Logging: &ngfAPIv1alpha2.NginxLogging{
 			ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
 			AgentLevel: helpers.GetPointer(ngfAPIv1alpha2.AgentLogLevelDebug),
@@ -321,6 +323,8 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 	g.Expect(svc.Spec.LoadBalancerIP).To(Equal("1.2.3.4"))
 	g.Expect(*svc.Spec.LoadBalancerClass).To(Equal("myLoadBalancerClass"))
 	g.Expect(svc.Spec.LoadBalancerSourceRanges).To(Equal([]string{"5.6.7.8"}))
+	g.Expect(*svc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicySingleStack))
+	g.Expect(svc.Spec.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
 
 	depObj := objects[5]
 	dep, ok := depObj.(*appsv1.Deployment)
@@ -960,4 +964,41 @@ func TestBuildNginxResourceObjectsForDeletion_OpenShift(t *testing.T) {
 	roleBinding, ok := roleBindingObj.(*rbacv1.RoleBinding)
 	g.Expect(ok).To(BeTrue())
 	validateMeta(roleBinding, deploymentNSName.Name)
+}
+
+func TestSetIPFamily(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	newSvc := func() *corev1.Service {
+		return &corev1.Service{
+			Spec: corev1.ServiceSpec{},
+		}
+	}
+
+	// nProxyCfg is nil, should not set anything
+	svc := newSvc()
+	setIPFamily(nil, svc)
+	g.Expect(svc.Spec.IPFamilyPolicy).To(BeNil())
+	g.Expect(svc.Spec.IPFamilies).To(BeNil())
+
+	// nProxyCfg.IPFamily is nil, should not set anything
+	svc = newSvc()
+	setIPFamily(&graph.EffectiveNginxProxy{}, svc)
+	g.Expect(svc.Spec.IPFamilyPolicy).To(BeNil())
+	g.Expect(svc.Spec.IPFamilies).To(BeNil())
+
+	// nProxyCfg.IPFamily is IPv4, should set SingleStack and IPFamilies to IPv4
+	svc = newSvc()
+	ipFamily := ngfAPIv1alpha2.IPv4
+	setIPFamily(&graph.EffectiveNginxProxy{IPFamily: &ipFamily}, svc)
+	g.Expect(svc.Spec.IPFamilyPolicy).To(Equal(helpers.GetPointer(corev1.IPFamilyPolicySingleStack)))
+	g.Expect(svc.Spec.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+
+	// nProxyCfg.IPFamily is IPv6, should set SingleStack and IPFamilies to IPv6
+	svc = newSvc()
+	ipFamily = ngfAPIv1alpha2.IPv6
+	setIPFamily(&graph.EffectiveNginxProxy{IPFamily: &ipFamily}, svc)
+	g.Expect(svc.Spec.IPFamilyPolicy).To(Equal(helpers.GetPointer(corev1.IPFamilyPolicySingleStack)))
+	g.Expect(svc.Spec.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv6Protocol}))
 }


### PR DESCRIPTION
Problem: When provisioning the NGINX LoadBalancer Service, the IPFamily that's set in the NginxProxy resource (default dual) was not honored.

Solution: By default, set the IPFamily to PreferDualStack. If a user has specified otherwise in the NginxProxy resource, then set to SingleStack. The IPFamilies list is populated automatically by k8s based on the policy.
