### PR TITLE
Add agent version to CHANGELOG template

### DIFF
--- a/.github/CHANGELOG_TEMPLATE.md
+++ b/.github/CHANGELOG_TEMPLATE.md
@@ -32,6 +32,7 @@ COMPATIBILITY:
 - Gateway API version: ``
 - NGINX version: ``
 - NGINX Plus version: ``
+- NGINX Agent version: ``
 - Kubernetes version: ``
 
 CONTAINER IMAGES:


### PR DESCRIPTION
Cherry-pick  [commit](https://github.com/nginx/nginx-gateway-fabric/pull/3467) into release-2.0 branch