### PR TITLE
Feat: Add helm values for cert-generator Job pod placement

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -252,11 +252,15 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
-| `certGenerator` | The certGenerator section contains the configuration for the cert-generator Job. | object | `{"agentTLSSecretName":"agent-tls","annotations":{},"overwrite":false,"serverTLSSecretName":"server-tls"}` |
+| `certGenerator` | The certGenerator section contains the configuration for the cert-generator Job. | object | `{"affinity":{},"agentTLSSecretName":"agent-tls","annotations":{},"nodeSelector":{},"overwrite":false,"serverTLSSecretName":"server-tls","tolerations":[],"topologySpreadConstraints":[]}` |
+| `certGenerator.affinity` | The affinity of the cert-generator pod. | object | `{}` |
 | `certGenerator.agentTLSSecretName` | The name of the base Secret containing TLS CA, certificate, and key for the NGINX Agent to securely communicate with the NGINX Gateway Fabric control plane. Must exist in the same namespace that the NGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway). | string | `"agent-tls"` |
 | `certGenerator.annotations` | The annotations of the cert-generator Job. | object | `{}` |
+| `certGenerator.nodeSelector` | The nodeSelector of the cert-generator pod. | object | `{}` |
 | `certGenerator.overwrite` | Overwrite existing TLS Secrets on startup. | bool | `false` |
 | `certGenerator.serverTLSSecretName` | The name of the Secret containing TLS CA, certificate, and key for the NGINX Gateway Fabric control plane to securely communicate with the NGINX Agent. Must exist in the same namespace that the NGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway). | string | `"server-tls"` |
+| `certGenerator.tolerations` | Tolerations for the cert-generator pod. | list | `[]` |
+| `certGenerator.topologySpreadConstraints` | The topology spread constraints for the cert-generator pod. | list | `[]` |
 | `clusterDomain` | The DNS cluster domain of your Kubernetes cluster. | string | `"cluster.local"` |
 | `gateways` | A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference. | list | `[]` |
 | `nginx` | The nginx section contains the configuration for all NGINX data plane deployments installed by the NGINX Gateway Fabric control plane. | object | `{"config":{},"container":{},"debug":false,"image":{"pullPolicy":"Always","repository":"ghcr.io/nginx/nginx-gateway-fabric/nginx","tag":"edge"},"imagePullSecret":"","imagePullSecrets":[],"kind":"deployment","plus":false,"pod":{},"replicas":1,"service":{"externalTrafficPolicy":"Local","loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"nodePorts":[],"type":"LoadBalancer"},"usage":{"caSecretName":"","clientSSLSecretName":"","endpoint":"","resolver":"","secretName":"nplus-license","skipVerify":false}}` |

--- a/charts/nginx-gateway-fabric/templates/certs-job.yaml
+++ b/charts/nginx-gateway-fabric/templates/certs-job.yaml
@@ -153,4 +153,20 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
+      {{- if .Values.certGenerator.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.certGenerator.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+      {{- if .Values.certGenerator.affinity }}
+      affinity:
+      {{- toYaml .Values.certGenerator.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.certGenerator.tolerations }}
+      tolerations:
+      {{- toYaml .Values.certGenerator.tolerations | nindent 6 }}
+      {{- end }}
+      {{- if .Values.certGenerator.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.certGenerator.nodeSelector | nindent 8 }}
+      {{- end }}
   ttlSecondsAfterFinished: 0

--- a/charts/nginx-gateway-fabric/templates/certs-job.yaml
+++ b/charts/nginx-gateway-fabric/templates/certs-job.yaml
@@ -155,7 +155,7 @@ spec:
         runAsNonRoot: true
       {{- if .Values.certGenerator.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml .Values.certGenerator.topologySpreadConstraints | nindent 8 }}
+      {{- toYaml .Values.certGenerator.topologySpreadConstraints | nindent 6 }}
       {{- end }}
       {{- if .Values.certGenerator.affinity }}
       affinity:

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -4,6 +4,12 @@
     "certGenerator": {
       "description": "The certGenerator section contains the configuration for the cert-generator Job.",
       "properties": {
+        "affinity": {
+          "description": "The affinity of the cert-generator pod.",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "agentTLSSecretName": {
           "default": "agent-tls",
           "description": "The name of the base Secret containing TLS CA, certificate, and key for the NGINX Agent to securely\ncommunicate with the NGINX Gateway Fabric control plane. Must exist in the same namespace that the\nNGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway).",
@@ -15,6 +21,12 @@
           "description": "The annotations of the cert-generator Job.",
           "required": [],
           "title": "annotations",
+          "type": "object"
+        },
+        "nodeSelector": {
+          "description": "The nodeSelector of the cert-generator pod.",
+          "required": [],
+          "title": "nodeSelector",
           "type": "object"
         },
         "overwrite": {
@@ -30,6 +42,24 @@
           "required": [],
           "title": "serverTLSSecretName",
           "type": "string"
+        },
+        "tolerations": {
+          "description": "Tolerations for the cert-generator pod.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "The topology spread constraints for the cert-generator pod.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "topologySpreadConstraints",
+          "type": "array"
         }
       },
       "required": [],

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -479,6 +479,18 @@ certGenerator:
   # -- Overwrite existing TLS Secrets on startup.
   overwrite: false
 
+  # -- Tolerations for the cert-generator pod.
+  tolerations: []
+
+  # -- The nodeSelector of the cert-generator pod.
+  nodeSelector: {}
+
+  # -- The affinity of the cert-generator pod.
+  affinity: {}
+
+  # -- The topology spread constraints for the cert-generator pod.
+  topologySpreadConstraints: []
+
 # -- A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference.
 gateways: []
 


### PR DESCRIPTION
### Proposed changes

Problem: Deploying the new version `2.0.0` chart we see the Job/foo-cert-generator pod stuck on pending scheduling when all cluster nodes have taints.

Solution: Add the ability to inject `job.spec.template.spec.{affinity,nodeSelector,tolerations,topologySpreadConstraints}` to alter pod placement. If you prefer to only add a subset of these, like only `tolerations` was needed in my case, please do inform and I can adjust.

Testing: Local `helm template` testing.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Expose cert-generator Job pod scheduling values.
```
