### PR TITLE
Feat: Add user-provided helm values for additional control plane service labels

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -318,6 +318,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `nginxGateway.resources` | The resource requests and/or limits of the nginx-gateway container. | object | `{}` |
 | `nginxGateway.service` | The service configuration for the NGINX Gateway Fabric control plane. | object | `{"annotations":{}}` |
 | `nginxGateway.service.annotations` | The annotations of the NGINX Gateway Fabric control plane service. | object | `{}` |
+| `nginxGateway.service.labels` | The labels of the NGINX Gateway Fabric control plane service. | object | `{}` |
 | `nginxGateway.serviceAccount` | The serviceaccount configuration for the NGINX Gateway Fabric control plane. | object | `{"annotations":{},"imagePullSecret":"","imagePullSecrets":[],"name":""}` |
 | `nginxGateway.serviceAccount.annotations` | Set of custom annotations for the NGINX Gateway Fabric control plane service account. | object | `{}` |
 | `nginxGateway.serviceAccount.imagePullSecret` | The name of the secret containing docker registry credentials for the control plane. Secret must exist in the same namespace as the helm release. | string | `""` |

--- a/charts/nginx-gateway-fabric/templates/service.yaml
+++ b/charts/nginx-gateway-fabric/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-gateway.labels" . | nindent 4 }}
+{{- if .Values.nginxGateway.service.labels }}
+{{ toYaml .Values.nginxGateway.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.nginxGateway.service.annotations }}
   annotations:
 {{ toYaml .Values.nginxGateway.service.annotations | indent 4 }}

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -804,6 +804,12 @@
               "required": [],
               "title": "annotations",
               "type": "object"
+            },
+            "labels": {
+              "description": "The labels of the NGINX Gateway Fabric control plane service.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
             }
           },
           "required": [],

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -59,6 +59,9 @@ nginxGateway:
     # -- The annotations of the NGINX Gateway Fabric control plane service.
     annotations: {}
 
+    # -- The labels of the NGINX Gateway Fabric control plane service.
+    labels: {}
+
   # -- The serviceaccount configuration for the NGINX Gateway Fabric control plane.
   serviceAccount:
     # -- Set of custom annotations for the NGINX Gateway Fabric control plane service account.


### PR DESCRIPTION
### Proposed changes

Problem: As a user that uses prometheus for everything metrics, I would like to target the control plane service with a specific label.

Solution: Add the ability for users to provide additional service labels for the NGINX Gateway Fabric control plane service in the helm chart.

Testing: Local helm lint/install testing

Closes #3498

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
All additional labels for the NGINX Gateway Fabric control plane service.
```
