### PR TITLE
Apply PolicyAffected status for target refs

### DIFF
--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -199,28 +199,14 @@ func ConvertConditions(
 
 // HasMatchingCondition checks if the given condition matches any of the existing conditions.
 func HasMatchingCondition(existingConditions []Condition, cond Condition) bool {
-	condMap := make(map[Condition]struct{}, len(existingConditions))
-	for _, cond := range existingConditions {
-		key := Condition{
-			Type:    cond.Type,
-			Status:  cond.Status,
-			Reason:  cond.Reason,
-			Message: cond.Message,
+	for _, existing := range existingConditions {
+		if existing.Type == cond.Type &&
+			existing.Status == cond.Status &&
+			existing.Reason == cond.Reason &&
+			existing.Message == cond.Message {
+			return true
 		}
-		condMap[key] = struct{}{}
 	}
-
-	key := Condition{
-		Type:    cond.Type,
-		Status:  cond.Status,
-		Reason:  cond.Reason,
-		Message: cond.Message,
-	}
-
-	if _, exists := condMap[key]; exists {
-		return true
-	}
-
 	return false
 }
 

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -107,6 +107,18 @@ const (
 	// has an overlapping hostname:port/path combination with another Route.
 	PolicyReasonTargetConflict v1alpha2.PolicyConditionReason = "TargetConflict"
 
+	// ClientSettingsPolicyAffected is used with the "PolicyAffected" condition when a
+	// ClientSettingsPolicy is applied to a Gateway, HTTPRoute, or GRPCRoute.
+	ClientSettingsPolicyAffected v1alpha2.PolicyConditionType = "ClientSettingsPolicyAffected"
+
+	// ObservabilityPolicyAffected is used with the "PolicyAffected" condition when an
+	// ObservabilityPolicy is applied to a HTTPRoute, or GRPCRoute.
+	ObservabilityPolicyAffected v1alpha2.PolicyConditionType = "ObservabilityPolicyAffected"
+
+	// PolicyAffectedReason is used with the "PolicyAffected" condition when a
+	// ObservabilityPolicy or ClientSettingsPolicy is applied to Gateways or Routes.
+	PolicyAffectedReason v1alpha2.PolicyConditionReason = "PolicyAffected"
+
 	// GatewayResolvedRefs condition indicates whether the controller was able to resolve the
 	// parametersRef on the Gateway.
 	GatewayResolvedRefs v1.GatewayConditionType = "ResolvedRefs"
@@ -183,6 +195,33 @@ func ConvertConditions(
 	}
 
 	return apiConds
+}
+
+// HasMatchingCondition checks if the given condition matches any of the existing conditions.
+func HasMatchingCondition(existingConditions []Condition, cond Condition) bool {
+	condMap := make(map[Condition]struct{}, len(existingConditions))
+	for _, cond := range existingConditions {
+		key := Condition{
+			Type:    cond.Type,
+			Status:  cond.Status,
+			Reason:  cond.Reason,
+			Message: cond.Message,
+		}
+		condMap[key] = struct{}{}
+	}
+
+	key := Condition{
+		Type:    cond.Type,
+		Status:  cond.Status,
+		Reason:  cond.Reason,
+		Message: cond.Message,
+	}
+
+	if _, exists := condMap[key]; exists {
+		return true
+	}
+
+	return false
 }
 
 // NewDefaultGatewayClassConditions returns Conditions that indicate that the GatewayClass is accepted and that the
@@ -938,5 +977,27 @@ func NewSnippetsFilterAccepted() Condition {
 		Status:  metav1.ConditionTrue,
 		Reason:  string(ngfAPI.SnippetsFilterConditionReasonAccepted),
 		Message: "SnippetsFilter is accepted",
+	}
+}
+
+// NewObservabilityPolicyAffected returns a Condition that indicates that an ObservabilityPolicy
+// is applied to the resource.
+func NewObservabilityPolicyAffected() Condition {
+	return Condition{
+		Type:    string(ObservabilityPolicyAffected),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(PolicyAffectedReason),
+		Message: "ObservabilityPolicy is applied to the resource",
+	}
+}
+
+// NewClientSettingsPolicyAffected returns a Condition that indicates that a ClientSettingsPolicy
+// is applied to the resource.
+func NewClientSettingsPolicyAffected() Condition {
+	return Condition{
+		Type:    string(ClientSettingsPolicyAffected),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(PolicyAffectedReason),
+		Message: "ClientSettingsPolicy is applied to the resource",
 	}
 }

--- a/internal/controller/state/conditions/conditions_test.go
+++ b/internal/controller/state/conditions/conditions_test.go
@@ -105,3 +105,43 @@ func TestConvertConditions(t *testing.T) {
 	result := ConvertConditions(conds, generation, time)
 	g.Expect(result).Should(Equal(expected))
 }
+
+func TestHasMatchingConding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		condition Condition
+		name      string
+		conds     []Condition
+		expected  bool
+	}{
+		{
+			name:      "no conditions in the list",
+			conds:     nil,
+			condition: NewClientSettingsPolicyAffected(),
+			expected:  false,
+		},
+		{
+			name:      "condition matches existing condition",
+			conds:     []Condition{NewClientSettingsPolicyAffected()},
+			condition: NewClientSettingsPolicyAffected(),
+			expected:  true,
+		},
+		{
+			name:      "condition does not match existing condition",
+			conds:     []Condition{NewClientSettingsPolicyAffected()},
+			condition: NewObservabilityPolicyAffected(),
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := HasMatchingCondition(test.conds, test.condition)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}

--- a/internal/controller/state/conditions/conditions_test.go
+++ b/internal/controller/state/conditions/conditions_test.go
@@ -106,7 +106,7 @@ func TestConvertConditions(t *testing.T) {
 	g.Expect(result).Should(Equal(expected))
 }
 
-func TestHasMatchingConding(t *testing.T) {
+func TestHasMatchingCondition(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -280,6 +280,9 @@ func BuildGraph(
 		gws,
 	)
 
+	// add status conditions to each targetRef based on the policies that affect them.
+	addPolicyAffectedStatusToTargetRefs(processedPolicies, routes, gws)
+
 	setPlusSecretContent(state.Secrets, plusSecrets)
 
 	g := &Graph{

--- a/internal/controller/state/graph/graph_test.go
+++ b/internal/controller/state/graph/graph_test.go
@@ -765,6 +765,9 @@ func TestBuildGraph(t *testing.T) {
 			Rules:     []RouteRule{createValidRuleWithBackendRefsAndFilters(routeMatches, RouteTypeHTTP)},
 		},
 		Policies: []*Policy{processedRoutePolicy},
+		Conditions: []conditions.Condition{
+			conditions.NewClientSettingsPolicyAffected(),
+		},
 	}
 
 	routeTR := &L4Route{
@@ -1080,7 +1083,10 @@ func TestBuildGraph(t *testing.T) {
 							ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelError),
 						},
 					},
-					Conditions: []conditions.Condition{conditions.NewGatewayResolvedRefs()},
+					Conditions: []conditions.Condition{
+						conditions.NewGatewayResolvedRefs(),
+						conditions.NewClientSettingsPolicyAffected(),
+					},
 					DeploymentName: types.NamespacedName{
 						Namespace: "test",
 						Name:      "gateway-1-my-class",

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -450,7 +450,7 @@ func refGroupKind(group v1.Group, kind v1.Kind) string {
 }
 
 // addPolicyAffectedStatusToTargetRefs adds the policyAffected status to the target references
-// of ClientSetttingsPolicies and ObservabilityPolicies.
+// of ClientSettingsPolicies and ObservabilityPolicies.
 func addPolicyAffectedStatusToTargetRefs(
 	processedPolicies map[PolicyKey]*Policy,
 	routes map[RouteKey]*L7Route,

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -448,3 +448,60 @@ func refGroupKind(group v1.Group, kind v1.Kind) string {
 
 	return fmt.Sprintf("%s/%s", group, kind)
 }
+
+// addPolicyAffectedStatusToTargetRefs adds the policyAffected status to the target references
+// of ClientSetttingsPolicies and ObservabilityPolicies.
+func addPolicyAffectedStatusToTargetRefs(
+	processedPolicies map[PolicyKey]*Policy,
+	routes map[RouteKey]*L7Route,
+	gws map[types.NamespacedName]*Gateway,
+) {
+	for policyKey, policy := range processedPolicies {
+		for _, ref := range policy.TargetRefs {
+			switch ref.Kind {
+			case kinds.Gateway:
+				if !gatewayExists(ref.Nsname, gws) {
+					continue
+				}
+				gw := gws[ref.Nsname]
+				if gw == nil {
+					continue
+				}
+
+				// set the policy status on the Gateway.
+				policyKind := policyKey.GVK.Kind
+				addStatusToTargetRefs(policyKind, &gw.Conditions)
+			case kinds.HTTPRoute, kinds.GRPCRoute:
+				routeKey := routeKeyForKind(ref.Kind, ref.Nsname)
+				l7route, exists := routes[routeKey]
+				if !exists {
+					continue
+				}
+
+				// set the policy status on L7 routes.
+				policyKind := policyKey.GVK.Kind
+				addStatusToTargetRefs(policyKind, &l7route.Conditions)
+			default:
+				continue
+			}
+		}
+	}
+}
+
+func addStatusToTargetRefs(policyKind string, conditionsList *[]conditions.Condition) {
+	if conditionsList == nil {
+		return
+	}
+	switch policyKind {
+	case kinds.ObservabilityPolicy:
+		if conditions.HasMatchingCondition(*conditionsList, conditions.NewObservabilityPolicyAffected()) {
+			return
+		}
+		*conditionsList = append(*conditionsList, conditions.NewObservabilityPolicyAffected())
+	case kinds.ClientSettingsPolicy:
+		if conditions.HasMatchingCondition(*conditionsList, conditions.NewClientSettingsPolicyAffected()) {
+			return
+		}
+		*conditionsList = append(*conditionsList, conditions.NewClientSettingsPolicyAffected())
+	}
+}


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: As a user I would like to know which target refs are affected by ClientSettingsPolicy or ObservabilityPolicy

Solution: Adds new conditions `NewObservabilityPolicyAffected` and `NewClientSettingsPolicyAffected` 


Testing: Manual testing

Apply `ObservabilityPolicy` and `ClientSettingsPolicy` to `targetRefs` 
1. **policyAffected** status should be applied to targetRefs conditions list.
2. Apply multiple policies to targetRefs - only one **policyAffected** status is added to `targetRefs` conditions list.
3.  Remove policies -- **policyAffected** status should be removed from `targetRefs` conditions list  -- Status is removed from the resources (Gateways, HTTPRoute, GRPCRoute)

**ClientSettingsPolicy for Gateway, HTTPRoutes and GRPCRoutes**

1. CSP for gateway

```
apiVersion: gateway.nginx.org/v1alpha1
kind: ClientSettingsPolicy
metadata:
  name: gateway-client-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: gateway
  body:
    maxSize: "50" # sizes without a unit are bytes.

Status:

k describe gateways.gateway.networking.k8s.io gateway
    Message:               ClientSettingsPolicy is applied to the resource
    Observed Generation:   1
    Reason:                PolicyAffected
    Status:                True
    Type:                  ClientSettingsPolicyAffected
```

2. multiple CSP for one HTTPRoute -- one condition applied

```
apiVersion: gateway.nginx.org/v1alpha1
kind: ClientSettingsPolicy
metadata:
  name: tea-client-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: tea
  body:
    maxSize: "75" # sizes without a unit are bytes.
---
apiVersion: gateway.nginx.org/v1alpha1
kind: ClientSettingsPolicy
metadata:
  name: second-tea-client-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: tea
  body:
    maxSize: "70" # sizes without a unit are bytes.

Status
k describe httproutes.gateway.networking.k8s.io tea

      Message:               ClientSettingsPolicy is applied to the resource
      Observed Generation:   1
      Reason:                PolicyAffected
      Status:                True
      Type:                  ClientSettingsPolicyAffected
    Controller Name:         gateway.nginx.org/nginx-gateway-controller
```

3. CSP for GRPCRoutes

```
apiVersion: gateway.nginx.org/v1alpha1
kind: ClientSettingsPolicy
metadata:
  name: tea-client-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: GRPCRoute
    name: exact-matching
  body:
    maxSize: "75" # sizes without a unit are bytes.
---
apiVersion: gateway.nginx.org/v1alpha1
kind: ClientSettingsPolicy
metadata:
  name: second-tea-client-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: GRPCRoute
    name: exact-matching
  body:
    maxSize: "70" # sizes without a unit are bytes.


Status

      Message:               ClientSettingsPolicy is applied to the resource
      Observed Generation:   1
      Reason:                PolicyAffected
      Status:                True
      Type:                  ClientSettingsPolicyAffected
    Controller Name:         gateway.nginx.org/nginx-gateway-controller

```


4. Deleted all CSP Policies and status `policyAffected` was removed from the resources.


**ObservabilityPolicy for HTTPRoutes and GRPCRoutes**

1. ObservabilityPolicy for HTTPRoutes and GRPCRoutes

```
apiVersion: gateway.nginx.org/v1alpha2
kind: ObservabilityPolicy
metadata:
  name: coffee
spec:
  targetRefs:
  - group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: coffee
  tracing:
    strategy: ratio
    ratio: 75
    spanAttributes:
    - key: coffee-key
      value: coffee-value
---
apiVersion: gateway.nginx.org/v1alpha2
kind: ObservabilityPolicy
metadata:
  name: coffee-second
spec:
  targetRefs:
  - group: gateway.networking.k8s.io
    kind: GRPCRoute
    name: exact-matching
  tracing:
    strategy: ratio
    ratio: 70
    spanAttributes:
    - key: coffee-key
      value: coffee-value


Status

k describe httproutes.gateway.networking.k8s.io coffee
      Message:               ObservabilityPolicy is applied to the resource
      Observed Generation:   1
      Reason:                PolicyAffected
      Status:                True
      Type:                  ObservabilityPolicyAffected
    Controller Name:         gateway.nginx.org/nginx-gateway-controller
    
k describe grpcroutes.gateway.networking.k8s.io exact-matching
      Message:               ObservabilityPolicy is applied to the resource
      Observed Generation:   1
      Reason:                PolicyAffected
      Status:                True
      Type:                  ObservabilityPolicyAffected
    Controller Name:         gateway.nginx.org/nginx-gateway-controller
```



4. Removing policies removes status from the resource


Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1761 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Adds policyAffected status for policy target refs.
```
