### PR TITLE
Fix index out of bounds error when building status (#3513)

### DIFF
--- a/internal/controller/status/prepare_requests.go
+++ b/internal/controller/status/prepare_requests.go
@@ -103,11 +103,11 @@ func removeDuplicateIndexParentRefs(parentRefs []graph.ParentRef) []graph.Parent
 		idxToParentRef[ref.Idx] = append(idxToParentRef[ref.Idx], ref)
 	}
 
-	results := make([]graph.ParentRef, len(idxToParentRef))
+	results := make([]graph.ParentRef, 0, len(idxToParentRef))
 
 	for idx, refs := range idxToParentRef {
 		if len(refs) == 1 {
-			results[idx] = refs[0]
+			results = append(results, refs[0])
 			continue
 		}
 
@@ -124,7 +124,7 @@ func removeDuplicateIndexParentRefs(parentRefs []graph.ParentRef) []graph.Parent
 				}
 			}
 		}
-		results[idx] = winningParentRef
+		results = append(results, winningParentRef)
 	}
 
 	return results

--- a/internal/controller/status/prepare_requests_test.go
+++ b/internal/controller/status/prepare_requests_test.go
@@ -445,7 +445,7 @@ func TestBuildHTTPRouteStatuses(t *testing.T) {
 
 		err := k8sClient.Get(context.Background(), nsname, &hr)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(helpers.Diff(expected, hr.Status)).To(BeEmpty())
+		g.Expect(expected.RouteStatus.Parents).To(ConsistOf(hr.Status.Parents))
 	}
 }
 
@@ -524,7 +524,7 @@ func TestBuildGRPCRouteStatuses(t *testing.T) {
 
 		err := k8sClient.Get(context.Background(), nsname, &hr)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(helpers.Diff(expected, hr.Status)).To(BeEmpty())
+		g.Expect(expected.RouteStatus.Parents).To(ConsistOf(hr.Status.Parents))
 	}
 }
 
@@ -601,7 +601,7 @@ func TestBuildTLSRouteStatuses(t *testing.T) {
 
 		err := k8sClient.Get(context.Background(), nsname, &hr)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(helpers.Diff(expected, hr.Status)).To(BeEmpty())
+		g.Expect(expected.RouteStatus.Parents).To(ConsistOf(hr.Status.Parents))
 	}
 }
 


### PR DESCRIPTION
Cherrypick of https://github.com/nginx/nginx-gateway-fabric/pull/3513

Problem: There's a specific scenario where we can hit an out of bounds index while building route statuses. I don't know the exact scenario, but it involves a parentRef without a sectionName, on a Gateway with a single listener. Could possibly involve having multiple implementations being deployed as well.

Solution: Adjust the logic to ensure we don't access indices that are out of bounds.

Testing: Verified that this error does not occur in the previous scenario.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix index out of bounds error when building status
```
