### PR TITLE
Move automountServiceAccountToken to Pod (#3573)

### DIFF
--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/charts/nginx-gateway-fabric/templates/serviceaccount.yaml
+++ b/charts/nginx-gateway-fabric/templates/serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.nginxGateway.serviceAccount.annotations | nindent 4 }}
+automountServiceAccountToken: false
 {{- if or .Values.nginxGateway.serviceAccount.imagePullSecret .Values.nginxGateway.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- if .Values.nginxGateway.serviceAccount.imagePullSecret }}

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -252,6 +253,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -252,6 +253,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -256,6 +257,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -256,6 +257,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -252,6 +253,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -252,6 +253,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -273,6 +274,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/snippets-filters-nginx-plus/deploy.yaml
+++ b/deploy/snippets-filters-nginx-plus/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -254,6 +255,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/deploy/snippets-filters/deploy.yaml
+++ b/deploy/snippets-filters/deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -254,6 +255,7 @@ spec:
         app.kubernetes.io/instance: nginx-gateway
         app.kubernetes.io/name: nginx-gateway
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - controller

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -117,7 +117,8 @@ func (p *NginxProvisioner) buildNginxResourceObjects(
 	)
 
 	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: objectMeta,
+		ObjectMeta:                   objectMeta,
+		AutomountServiceAccountToken: helpers.GetPointer(false),
 	}
 
 	var openshiftObjs []client.Object
@@ -608,6 +609,7 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 			Annotations: podAnnotations,
 		},
 		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: helpers.GetPointer(true),
 			Containers: []corev1.Container{
 				{
 					Name:            "nginx",


### PR DESCRIPTION
Cherrypick of #3573 

Problem: For security reasons, it's best practice to not have `automountServiceToken` on the ServiceAccount, and instead set in directly on the workloads that need the token.

Solution: Set this field on the Pods instead of the ServiceAccounts.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Disable automountServiceAccountToken on ServiceAccount, and instead enable on the Pods directly.
```
