### PR TITLE
fix: removes Extra keyword from volumeMounts and Volumes for the data…

### DIFF
--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -394,9 +394,9 @@ nginx:
     # -- The topology spread constraints for the NGINX data plane pod.
     # topologySpreadConstraints: []
 
-    # -- extraVolumes for the NGINX data plane pod. Use in conjunction with
-    # nginx.container.extraVolumeMounts mount additional volumes to the container.
-    # extraVolumes: []
+    # -- Volumes for the NGINX data plane pod. Use in conjunction with
+    # nginx.container.VolumeMounts mount additional volumes to the container.
+    # Volumes: []
 
   # -- The container configuration for the NGINX container. This is applied globally to all Gateways managed by this
   # instance of NGINX Gateway Fabric.
@@ -407,8 +407,8 @@ nginx:
     # -- The lifecycle of the NGINX container.
     # lifecycle: {}
 
-    # -- extraVolumeMounts are the additional volume mounts for the NGINX container.
-    # extraVolumeMounts: []
+    # -- VolumeMounts are the additional volume mounts for the NGINX container.
+    # VolumeMounts: []
 
   # -- The service configuration for the NGINX data plane. This is applied globally to all Gateways managed by this
   # instance of NGINX Gateway Fabric.


### PR DESCRIPTION
… plane

### Proposed changes

Fixing [3585](https://github.com/nginx/nginx-gateway-fabric/issues/3585)

Problem: Incorrect Helm Schema for the data plane volume mounts.

Solution: Explain the approach you took to implement the solution, highlighting any significant design decisions or
considerations.

Testing: Deployed it on my cluster to see if failure of schema validation does not occur anymore

Closes #3585 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes
fix: removes Extra keyword from volumeMounts and Volumes for the data…

```release-note
fix: removes Extra keyword from volumeMounts and Volumes for the data…
```
