### PR TITLE
Use server side apply for NGF CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ generate-crds: ## Generate CRDs and Go types using kubebuilder
 
 .PHONY: install-crds
 install-crds: ## Install CRDs
-	kubectl kustomize $(SELF_DIR)config/crd | kubectl apply -f -
+	kubectl kustomize $(SELF_DIR)config/crd | kubectl apply --server-side -f -
 
 .PHONY: install-gateway-crds
 install-gateway-crds: ## Install Gateway API CRDs

--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -139,7 +139,7 @@ Helm does not upgrade the NGINX Gateway Fabric CRDs during a release upgrade. Be
 must [pull the chart](#pulling-the-chart) from GitHub and run the following command to upgrade the CRDs:
 
 ```shell
-kubectl apply -f crds/
+kubectl apply --server-side -f crds/
 ```
 
 The following warning is expected and can be ignored:

--- a/charts/nginx-gateway-fabric/README.md.gotmpl
+++ b/charts/nginx-gateway-fabric/README.md.gotmpl
@@ -137,7 +137,7 @@ Helm does not upgrade the NGINX Gateway Fabric CRDs during a release upgrade. Be
 must [pull the chart](#pulling-the-chart) from GitHub and run the following command to upgrade the CRDs:
 
 ```shell
-kubectl apply -f crds/
+kubectl apply --server-side -f crds/
 ```
 
 The following warning is expected and can be ignored:

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -201,7 +201,7 @@ This will build the docker images `nginx-gateway-fabric:<your-user>` and `nginx-
      If the only change is the image repository and tag, you can update the `kustomization.yaml` file in `deploy/` with the desired values and deployment mainifest and run the following commands:
 
      ```shell
-      kubectl apply -f deploy/crds.yaml
+      kubectl apply --server-side -f deploy/crds.yaml
       kubectl kustomize deploy | kubectl apply -f -
      ```
 


### PR DESCRIPTION
### Proposed changes

Update docs and Makefile to use kubectl server side apply for NGF CRDs.

Problem: The NginxProxy CRD is getting too large for the normal client side kubectl apply to handle.

Solution: Update docs and Makefile to use kubectl server side apply for NGF CRDs.

Testing: Deployed NGF through manifests using server-side applied CRDs and manually ran through the policy examples and the cafe-example to make sure NGF still works.

Closes #3549

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Switch to recommending using kubectl server-side apply for Nginx Gateway Fabric CRDs. 
```
