### PR TITLE
Fix port binding with reduced privileges (#3574)

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -16,15 +16,10 @@ RUN --mount=type=bind,from=nginx-files,src=nginx_signing.rsa.pub,target=/etc/apk
     printf "%s\n" "https://packages.nginx.org/nginx-agent/alpine/v$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
     && apk add --no-cache nginx-agent=${NGINX_AGENT_VERSION#v}
 
-RUN apk add --no-cache libcap bash \
+RUN apk add --no-cache bash \
     && mkdir -p /usr/lib/nginx/modules \
-    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-    && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
-    && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
     # Update packages for CVE-2025-32414 and CVE-2025-32415
     && apk --no-cache upgrade libxml2 \
-    && apk del libcap \
     # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -22,13 +22,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
     && printf "%s\n" "https://pkgs.nginx.com/nginx-agent/alpine/v$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
     && apk add --no-cache nginx-plus nginx-plus-module-njs nginx-plus-module-otel nginx-agent=${NGINX_AGENT_VERSION#v}
 
-RUN apk add --no-cache libcap bash \
+RUN apk add --no-cache bash \
     && mkdir -p /usr/lib/nginx/modules \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
-    && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
-    && apk del libcap \
     # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log

--- a/charts/nginx-gateway-fabric/templates/scc.yaml
+++ b/charts/nginx-gateway-fabric/templates/scc.yaml
@@ -44,6 +44,7 @@ metadata:
   name: {{ include "nginx-gateway.scc-name" . }}-nginx
   labels:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
+allowPrivilegeEscalation: false
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -69,8 +70,6 @@ seLinuxContext:
   type: MustRunAs
 seccompProfiles:
 - runtime/default
-allowedCapabilities:
-- NET_BIND_SERVICE
 requiredDropCapabilities:
 - ALL
 volumes:

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -529,9 +529,8 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
-allowedCapabilities:
-- NET_BIND_SERVICE
 apiVersion: security.openshift.io/v1
 fsGroup:
   ranges:

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -617,8 +617,8 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 					ImagePullPolicy: pullPolicy,
 					Ports:           containerPorts,
 					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: helpers.GetPointer(false),
 						Capabilities: &corev1.Capabilities{
-							Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 							Drop: []corev1.Capability{"ALL"},
 						},
 						ReadOnlyRootFilesystem: helpers.GetPointer(true),
@@ -691,6 +691,12 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 			SecurityContext: &corev1.PodSecurityContext{
 				FSGroup:      helpers.GetPointer[int64](1001),
 				RunAsNonRoot: helpers.GetPointer(true),
+				Sysctls: []corev1.Sysctl{
+					{
+						Name:  "net.ipv4.ip_unprivileged_port_start",
+						Value: "0",
+					},
+				},
 			},
 			Volumes: []corev1.Volume{
 				{


### PR DESCRIPTION
Cherrypick of #3574

Problem: The nginx deployment was using extra privileges in order to bind to privileged ports (<1024). This included `allowPrivilegeEscalation` and `NET_BIND_SERVICE`. Sometimes this could cause issues in some secure environments.

Solution: Remove these extra privileges and take advantage of `sysctls` to lower the allowed port range for the pod its defined on.

Testing: Verified that everything still works, including in OpenShift.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix port binding with reduced privileges.
```
