### PR TITLE
Group NGINX Agent updates with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,14 @@
       "/examples/.+\\.yaml$/",
       "/suite/.+\\.yaml$/"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "nginx/agent",
+        "github.com/nginx/agent/v3"
+      ],
+      "groupName": "NGINX Agent"
+    }
+  ]
 }


### PR DESCRIPTION
Problem: We have two different agent dependencies, which would be updated in separate pull requests.

Solution: Group these updates into a single PR.
