### PR TITLE
Add workerConnections field to helm chart

### DIFF
--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -305,6 +305,13 @@
               },
               "required": [],
               "type": "object"
+            },
+            "workerConnections": {
+              "description": "The number of worker connections for NGINX. Default is 1024.",
+              "maximum": 65535,
+              "minimum": 1,
+              "required": [],
+              "type": "integer"
             }
           },
           "required": [],

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -371,6 +371,11 @@ nginx:
   #                 - IPAddress
   #             value:
   #               type: string
+  #   workerConnections:
+  #     type: integer
+  #     minimum: 1
+  #     maximum: 65535
+  #     description: The number of worker connections for NGINX. Default is 1024.
   # @schema
   # -- The configuration for the data plane that is contained in the NginxProxy resource. This is applied globally to all Gateways
   # managed by this instance of NGINX Gateway Fabric.


### PR DESCRIPTION
### Proposed changes

Add workerConnections field to helm chart

Problem: workerConnections was not able to be configured by helm

Solution: I added the field to the schema.

Testing: I tested a new helm chart with workerConnections set to 2048 and saw that the NginxProxy resource had the correct value and the worker connections field appeared in the conf as well.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
