### PR TITLE
Add logging for endpoint discovery issues

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -208,7 +208,7 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 			panic("expected deployment, got nil")
 		}
 
-		cfg := dataplane.BuildConfiguration(ctx, gr, gw, h.cfg.serviceResolver, h.cfg.plus)
+		cfg := dataplane.BuildConfiguration(ctx, logger, gr, gw, h.cfg.serviceResolver, h.cfg.plus)
 		depCtx, getErr := h.getDeploymentContext(ctx)
 		if getErr != nil {
 			logger.Error(getErr, "error getting deployment context for usage reporting")

--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -90,6 +90,7 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 ) {
 	msg := deployment.SetFiles(files)
 	if msg == nil {
+		n.logger.V(1).Info("No changes to nginx configuration files, not sending to agent")
 		return
 	}
 

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	apiv1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
@@ -714,6 +715,7 @@ func TestBuildConfiguration(t *testing.T) {
 
 	fakeResolver.ResolveStub = func(
 		_ context.Context,
+		_ logr.Logger,
 		nsName types.NamespacedName,
 		_ apiv1.ServicePort,
 		_ []discoveryV1.AddressType,
@@ -2533,7 +2535,8 @@ func TestBuildConfiguration(t *testing.T) {
 			g := NewWithT(t)
 
 			result := BuildConfiguration(
-				context.TODO(),
+				t.Context(),
+				logr.Discard(),
 				test.graph,
 				test.graph.Gateways[gatewayNsName],
 				fakeResolver,
@@ -2648,7 +2651,8 @@ func TestBuildConfiguration_Plus(t *testing.T) {
 			g := NewWithT(t)
 
 			result := BuildConfiguration(
-				context.TODO(),
+				t.Context(),
+				logr.Discard(),
 				test.graph,
 				test.graph.Gateways[gatewayNsName],
 				fakeResolver,
@@ -3372,6 +3376,7 @@ func TestBuildUpstreams(t *testing.T) {
 	fakeResolver := &resolverfakes.FakeServiceResolver{}
 	fakeResolver.ResolveCalls(func(
 		_ context.Context,
+		_ logr.Logger,
 		svcNsName types.NamespacedName,
 		_ apiv1.ServicePort,
 		_ []discoveryV1.AddressType,
@@ -3404,7 +3409,14 @@ func TestBuildUpstreams(t *testing.T) {
 
 	g := NewWithT(t)
 
-	upstreams := buildUpstreams(context.TODO(), gateway, fakeResolver, referencedServices, Dual)
+	upstreams := buildUpstreams(
+		t.Context(),
+		logr.Discard(),
+		gateway,
+		fakeResolver,
+		referencedServices,
+		Dual,
+	)
 	g.Expect(upstreams).To(ConsistOf(expUpstreams))
 }
 
@@ -4357,6 +4369,7 @@ func TestBuildStreamUpstreams(t *testing.T) {
 
 	fakeResolver.ResolveStub = func(
 		_ context.Context,
+		_ logr.Logger,
 		nsName types.NamespacedName,
 		_ apiv1.ServicePort,
 		_ []discoveryV1.AddressType,
@@ -4367,7 +4380,7 @@ func TestBuildStreamUpstreams(t *testing.T) {
 		return fakeEndpoints, nil
 	}
 
-	streamUpstreams := buildStreamUpstreams(context.Background(), gateway, &fakeResolver, Dual)
+	streamUpstreams := buildStreamUpstreams(t.Context(), logr.Discard(), gateway, &fakeResolver, Dual)
 
 	expectedStreamUpstreams := []Upstream{
 		{

--- a/internal/controller/state/resolver/resolverfakes/fake_service_resolver.go
+++ b/internal/controller/state/resolver/resolverfakes/fake_service_resolver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/go-logr/logr"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/resolver"
 	v1 "k8s.io/api/core/v1"
 	v1a "k8s.io/api/discovery/v1"
@@ -12,13 +13,14 @@ import (
 )
 
 type FakeServiceResolver struct {
-	ResolveStub        func(context.Context, types.NamespacedName, v1.ServicePort, []v1a.AddressType) ([]resolver.Endpoint, error)
+	ResolveStub        func(context.Context, logr.Logger, types.NamespacedName, v1.ServicePort, []v1a.AddressType) ([]resolver.Endpoint, error)
 	resolveMutex       sync.RWMutex
 	resolveArgsForCall []struct {
 		arg1 context.Context
-		arg2 types.NamespacedName
-		arg3 v1.ServicePort
-		arg4 []v1a.AddressType
+		arg2 logr.Logger
+		arg3 types.NamespacedName
+		arg4 v1.ServicePort
+		arg5 []v1a.AddressType
 	}
 	resolveReturns struct {
 		result1 []resolver.Endpoint
@@ -32,26 +34,27 @@ type FakeServiceResolver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceResolver) Resolve(arg1 context.Context, arg2 types.NamespacedName, arg3 v1.ServicePort, arg4 []v1a.AddressType) ([]resolver.Endpoint, error) {
-	var arg4Copy []v1a.AddressType
-	if arg4 != nil {
-		arg4Copy = make([]v1a.AddressType, len(arg4))
-		copy(arg4Copy, arg4)
+func (fake *FakeServiceResolver) Resolve(arg1 context.Context, arg2 logr.Logger, arg3 types.NamespacedName, arg4 v1.ServicePort, arg5 []v1a.AddressType) ([]resolver.Endpoint, error) {
+	var arg5Copy []v1a.AddressType
+	if arg5 != nil {
+		arg5Copy = make([]v1a.AddressType, len(arg5))
+		copy(arg5Copy, arg5)
 	}
 	fake.resolveMutex.Lock()
 	ret, specificReturn := fake.resolveReturnsOnCall[len(fake.resolveArgsForCall)]
 	fake.resolveArgsForCall = append(fake.resolveArgsForCall, struct {
 		arg1 context.Context
-		arg2 types.NamespacedName
-		arg3 v1.ServicePort
-		arg4 []v1a.AddressType
-	}{arg1, arg2, arg3, arg4Copy})
+		arg2 logr.Logger
+		arg3 types.NamespacedName
+		arg4 v1.ServicePort
+		arg5 []v1a.AddressType
+	}{arg1, arg2, arg3, arg4, arg5Copy})
 	stub := fake.ResolveStub
 	fakeReturns := fake.resolveReturns
-	fake.recordInvocation("Resolve", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.recordInvocation("Resolve", []interface{}{arg1, arg2, arg3, arg4, arg5Copy})
 	fake.resolveMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -65,17 +68,17 @@ func (fake *FakeServiceResolver) ResolveCallCount() int {
 	return len(fake.resolveArgsForCall)
 }
 
-func (fake *FakeServiceResolver) ResolveCalls(stub func(context.Context, types.NamespacedName, v1.ServicePort, []v1a.AddressType) ([]resolver.Endpoint, error)) {
+func (fake *FakeServiceResolver) ResolveCalls(stub func(context.Context, logr.Logger, types.NamespacedName, v1.ServicePort, []v1a.AddressType) ([]resolver.Endpoint, error)) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = stub
 }
 
-func (fake *FakeServiceResolver) ResolveArgsForCall(i int) (context.Context, types.NamespacedName, v1.ServicePort, []v1a.AddressType) {
+func (fake *FakeServiceResolver) ResolveArgsForCall(i int) (context.Context, logr.Logger, types.NamespacedName, v1.ServicePort, []v1a.AddressType) {
 	fake.resolveMutex.RLock()
 	defer fake.resolveMutex.RUnlock()
 	argsForCall := fake.resolveArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeServiceResolver) ResolveReturns(result1 []resolver.Endpoint, result2 error) {

--- a/internal/controller/state/resolver/service_resolver_test.go
+++ b/internal/controller/state/resolver/service_resolver_test.go
@@ -3,6 +3,7 @@ package resolver_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -207,7 +208,13 @@ var _ = Describe("ServiceResolver", func() {
 				},
 			}
 
-			endpoints, err := serviceResolver.Resolve(context.TODO(), svcNsName, svcPort, dualAddressType)
+			endpoints, err := serviceResolver.Resolve(
+				context.TODO(),
+				logr.Discard(),
+				svcNsName,
+				svcPort,
+				dualAddressType,
+			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(endpoints).To(ConsistOf(expectedEndpoints))
 		})
@@ -218,7 +225,13 @@ var _ = Describe("ServiceResolver", func() {
 			Expect(fakeK8sClient.Delete(context.TODO(), dupeEndpointSlice)).To(Succeed())
 			Expect(fakeK8sClient.Delete(context.TODO(), sliceIPV6)).To(Succeed())
 
-			endpoints, err := serviceResolver.Resolve(context.TODO(), svcNsName, svcPort, dualAddressType)
+			endpoints, err := serviceResolver.Resolve(
+				context.TODO(),
+				logr.Discard(),
+				svcNsName,
+				svcPort,
+				dualAddressType,
+			)
 			Expect(err).To(HaveOccurred())
 			Expect(endpoints).To(BeNil())
 		})
@@ -226,19 +239,37 @@ var _ = Describe("ServiceResolver", func() {
 			// delete remaining endpoint slices
 			Expect(fakeK8sClient.Delete(context.TODO(), sliceNoMatchingPortName)).To(Succeed())
 
-			endpoints, err := serviceResolver.Resolve(context.TODO(), svcNsName, svcPort, dualAddressType)
+			endpoints, err := serviceResolver.Resolve(
+				context.TODO(),
+				logr.Discard(),
+				svcNsName,
+				svcPort,
+				dualAddressType,
+			)
 			Expect(err).To(HaveOccurred())
 			Expect(endpoints).To(BeNil())
 		})
 		It("panics if the service NamespacedName is empty", func() {
 			resolve := func() {
-				_, _ = serviceResolver.Resolve(context.TODO(), types.NamespacedName{}, svcPort, dualAddressType)
+				_, _ = serviceResolver.Resolve(
+					context.TODO(),
+					logr.Discard(),
+					types.NamespacedName{},
+					svcPort,
+					dualAddressType,
+				)
 			}
 			Expect(resolve).Should(Panic())
 		})
 		It("panics if the ServicePort is empty", func() {
 			resolve := func() {
-				_, _ = serviceResolver.Resolve(context.TODO(), types.NamespacedName{}, v1.ServicePort{}, dualAddressType)
+				_, _ = serviceResolver.Resolve(
+					context.TODO(),
+					logr.Discard(),
+					types.NamespacedName{},
+					v1.ServicePort{},
+					dualAddressType,
+				)
 			}
 			Expect(resolve).Should(Panic())
 		})


### PR DESCRIPTION
Problem: A couple of issues have arisen relating to endpoint discovery, and we don't have much visibility into them.

Solution: Add some logs (both error and debug level) to help diagnose when endpoints are not found or have issues.