### PR TITLE
Fix policy attachment when ancestors slice is full

### DIFF
--- a/internal/controller/state/change_processor.go
+++ b/internal/controller/state/change_processor.go
@@ -268,6 +268,7 @@ func (c *ChangeProcessorImpl) Process() *graph.Graph {
 		c.cfg.GatewayClassName,
 		c.cfg.PlusSecrets,
 		c.cfg.Validators,
+		c.cfg.Logger,
 	)
 
 	return c.latestGraph

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -138,6 +138,15 @@ const (
 	// GatewayReasonParamsRefInvalid is used with the "GatewayResolvedRefs" condition when the
 	// parametersRef resource is invalid.
 	GatewayReasonParamsRefInvalid v1.GatewayConditionReason = "ParametersRefInvalid"
+
+	// PolicyReasonAncestorLimitReached is used with the "PolicyAccepted" condition when a policy
+	// cannot be applied because the ancestor status list has reached the maximum size of 16.
+	PolicyReasonAncestorLimitReached v1alpha2.PolicyConditionReason = "AncestorLimitReached"
+
+	// PolicyMessageAncestorLimitReached is a message used with PolicyReasonAncestorLimitReached
+	// when a policy cannot be applied due to the 16 ancestor limit being reached.
+	PolicyMessageAncestorLimitReached = "Policy cannot be applied because the ancestor status list " +
+		"has reached the maximum size of 16"
 )
 
 // Condition defines a condition to be reported in the status of resources.
@@ -965,6 +974,17 @@ func NewPolicyTargetNotFound(msg string) Condition {
 		Status:  metav1.ConditionFalse,
 		Reason:  string(v1alpha2.PolicyReasonTargetNotFound),
 		Message: msg,
+	}
+}
+
+// NewPolicyAncestorLimitReached returns a Condition that indicates that the Policy is not accepted because
+// the ancestor status list has reached the maximum size of 16.
+func NewPolicyAncestorLimitReached(_ string) Condition {
+	return Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(PolicyReasonAncestorLimitReached),
+		Message: PolicyMessageAncestorLimitReached,
 	}
 }
 

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -145,8 +145,8 @@ const (
 
 	// PolicyMessageAncestorLimitReached is a message used with PolicyReasonAncestorLimitReached
 	// when a policy cannot be applied due to the 16 ancestor limit being reached.
-	PolicyMessageAncestorLimitReached = "Policy cannot be applied because the ancestor status list " +
-		"has reached the maximum size of 16"
+	PolicyMessageAncestorLimitReached = "Policies cannot be applied because the ancestor status list " +
+		"has reached the maximum size of 16. The following policies have been ignored:"
 )
 
 // Condition defines a condition to be reported in the status of resources.
@@ -979,7 +979,7 @@ func NewPolicyTargetNotFound(msg string) Condition {
 
 // NewPolicyAncestorLimitReached returns a Condition that indicates that the Policy is not accepted because
 // the ancestor status list has reached the maximum size of 16.
-func NewPolicyAncestorLimitReached(_ string) Condition {
+func NewPolicyAncestorLimitReached() Condition {
 	return Condition{
 		Type:    string(v1alpha2.PolicyConditionAccepted),
 		Status:  metav1.ConditionFalse,

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -146,7 +146,7 @@ const (
 	// PolicyMessageAncestorLimitReached is a message used with PolicyReasonAncestorLimitReached
 	// when a policy cannot be applied due to the 16 ancestor limit being reached.
 	PolicyMessageAncestorLimitReached = "Policies cannot be applied because the ancestor status list " +
-		"has reached the maximum size of 16. The following policies have been ignored:"
+		"has reached the maximum size. The following policies have been ignored:"
 )
 
 // Condition defines a condition to be reported in the status of resources.

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -979,12 +979,12 @@ func NewPolicyTargetNotFound(msg string) Condition {
 
 // NewPolicyAncestorLimitReached returns a Condition that indicates that the Policy is not accepted because
 // the ancestor status list has reached the maximum size of 16.
-func NewPolicyAncestorLimitReached() Condition {
+func NewPolicyAncestorLimitReached(policyType string, policyName string) Condition {
 	return Condition{
 		Type:    string(v1alpha2.PolicyConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(PolicyReasonAncestorLimitReached),
-		Message: PolicyMessageAncestorLimitReached,
+		Message: fmt.Sprintf("%s %s %s", PolicyMessageAncestorLimitReached, policyType, policyName),
 	}
 }
 

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -144,7 +144,7 @@ const (
 	PolicyReasonAncestorLimitReached v1alpha2.PolicyConditionReason = "AncestorLimitReached"
 
 	// PolicyMessageAncestorLimitReached is a message used with PolicyReasonAncestorLimitReached
-	// when a policy cannot be applied due to the 16 ancestor limit being reached.
+	// when a policy cannot be applied due to the ancestor limit being reached.
 	PolicyMessageAncestorLimitReached = "Policies cannot be applied because the ancestor status list " +
 		"has reached the maximum size. The following policies have been ignored:"
 )

--- a/internal/controller/state/conditions/conditions_test.go
+++ b/internal/controller/state/conditions/conditions_test.go
@@ -151,8 +151,7 @@ func TestNewPolicyAncestorLimitReached(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	policyName := "test-policy"
-	condition := NewPolicyAncestorLimitReached(policyName)
+	condition := NewPolicyAncestorLimitReached()
 
 	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
 	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))

--- a/internal/controller/state/conditions/conditions_test.go
+++ b/internal/controller/state/conditions/conditions_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestDeduplicateConditions(t *testing.T) {
@@ -145,16 +144,4 @@ func TestHasMatchingCondition(t *testing.T) {
 			g.Expect(result).To(Equal(test.expected))
 		})
 	}
-}
-
-func TestNewPolicyAncestorLimitReached(t *testing.T) {
-	t.Parallel()
-	g := NewWithT(t)
-
-	condition := NewPolicyAncestorLimitReached()
-
-	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
-	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(condition.Reason).To(Equal(string(PolicyReasonAncestorLimitReached)))
-	g.Expect(condition.Message).To(Equal(PolicyMessageAncestorLimitReached))
 }

--- a/internal/controller/state/conditions/conditions_test.go
+++ b/internal/controller/state/conditions/conditions_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestDeduplicateConditions(t *testing.T) {
@@ -144,4 +145,17 @@ func TestHasMatchingCondition(t *testing.T) {
 			g.Expect(result).To(Equal(test.expected))
 		})
 	}
+}
+
+func TestNewPolicyAncestorLimitReached(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	policyName := "test-policy"
+	condition := NewPolicyAncestorLimitReached(policyName)
+
+	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
+	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(condition.Reason).To(Equal(string(PolicyReasonAncestorLimitReached)))
+	g.Expect(condition.Message).To(Equal(PolicyMessageAncestorLimitReached))
 }

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -390,7 +390,7 @@ func newBackendGroup(
 			UpstreamName: ref.ServicePortReference(),
 			Weight:       ref.Weight,
 			Valid:        valid,
-			VerifyTLS:    convertBackendTLS(ref.BackendTLSPolicy),
+			VerifyTLS:    convertBackendTLS(ref.BackendTLSPolicy, gatewayName),
 		})
 	}
 
@@ -401,10 +401,15 @@ func newBackendGroup(
 	}
 }
 
-func convertBackendTLS(btp *graph.BackendTLSPolicy) *VerifyTLS {
+func convertBackendTLS(btp *graph.BackendTLSPolicy, gwNsName types.NamespacedName) *VerifyTLS {
 	if btp == nil || !btp.Valid {
 		return nil
 	}
+
+	if !slices.Contains(btp.Gateways, gwNsName) {
+		return nil
+	}
+
 	verify := &VerifyTLS{}
 	if btp.CaCertRef.Name != "" {
 		verify.CertBundleID = generateCertBundleID(btp.CaCertRef)

--- a/internal/controller/state/graph/backend_tls_policy.go
+++ b/internal/controller/state/graph/backend_tls_policy.go
@@ -204,8 +204,7 @@ func addPolicyAncestorLimitCondition(
 		}
 	}
 
-	newCondition := conditions.NewPolicyAncestorLimitReached()
-	newCondition.Message = fmt.Sprintf("%s %s %s", newCondition.Message, policyType, policyName)
+	newCondition := conditions.NewPolicyAncestorLimitReached(policyType, policyName)
 	return append(conds, newCondition)
 }
 

--- a/internal/controller/state/graph/backend_tls_policy.go
+++ b/internal/controller/state/graph/backend_tls_policy.go
@@ -316,7 +316,7 @@ func addGatewaysForBackendTLSPolicies(
 						"Gateway not found in the graph", "policy", policyName, "ancestor", gatewayName)
 				}
 
-				LogAncestorLimitReached(logger, policyName, "BackendTLSPolicy", gatewayName)
+				logAncestorLimitReached(logger, policyName, "BackendTLSPolicy", gatewayName)
 				continue
 			}
 

--- a/internal/controller/state/graph/backend_tls_policy.go
+++ b/internal/controller/state/graph/backend_tls_policy.go
@@ -206,8 +206,7 @@ func addPolicyAncestorLimitCondition(
 
 	newCondition := conditions.NewPolicyAncestorLimitReached()
 	newCondition.Message = fmt.Sprintf("%s %s %s", newCondition.Message, policyType, policyName)
-	conds = append(conds, newCondition)
-	return conds
+	return append(conds, newCondition)
 }
 
 // collectOrderedGateways collects gateways in spec order (services) then creation time order (gateways within service).
@@ -254,8 +253,7 @@ func collectOrderedGateways(
 	sortGatewaysByCreationTime(existingGateways, gateways)
 	sortGatewaysByCreationTime(newGateways, gateways)
 
-	existingGateways = append(existingGateways, newGateways...)
-	return existingGateways
+	return append(existingGateways, newGateways...)
 }
 
 func extractExistingNGFGatewayAncestors(

--- a/internal/controller/state/graph/backend_tls_policy.go
+++ b/internal/controller/state/graph/backend_tls_policy.go
@@ -195,10 +195,8 @@ func addPolicyAncestorLimitCondition(
 	policyName string,
 	policyType string,
 ) []conditions.Condition {
-	const policyAncestorLimitReachedType = "PolicyAncestorLimitReached"
-
 	for i, condition := range conds {
-		if condition.Type == policyAncestorLimitReachedType {
+		if condition.Reason == string(conditions.PolicyReasonAncestorLimitReached) {
 			if !strings.Contains(condition.Message, policyName) {
 				conds[i].Message = fmt.Sprintf("%s, %s %s", condition.Message, policyType, policyName)
 			}

--- a/internal/controller/state/graph/backend_tls_policy_test.go
+++ b/internal/controller/state/graph/backend_tls_policy_test.go
@@ -800,7 +800,7 @@ func TestAddGatewaysForBackendTLSPoliciesAncestorLimit(t *testing.T) {
 	g.Expect(gateway2.Conditions).To(BeEmpty(), "Normal gateway should not have conditions")
 
 	// Verify logging function works - test the logging function directly
-	LogAncestorLimitReached(testLogger, "test/btp-full-ancestors", "BackendTLSPolicy", "test/gateway1")
+	logAncestorLimitReached(testLogger, "test/btp-full-ancestors", "BackendTLSPolicy", "test/gateway1")
 	logOutput := logBuf.String()
 
 	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached"))

--- a/internal/controller/state/graph/backend_tls_policy_test.go
+++ b/internal/controller/state/graph/backend_tls_policy_test.go
@@ -399,7 +399,7 @@ func TestValidateBackendTLSPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid case with too many ancestors",
+			name: "valid case with many ancestors (ancestor limit now handled during gateway assignment)",
 			tlsPolicy: &v1alpha3.BackendTLSPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-policy",
@@ -416,7 +416,7 @@ func TestValidateBackendTLSPolicy(t *testing.T) {
 					Ancestors: ancestors,
 				},
 			},
-			ignored: true,
+			isValid: true,
 		},
 	}
 
@@ -660,7 +660,7 @@ func TestAddGatewaysForBackendTLSPolicies(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			addGatewaysForBackendTLSPolicies(test.backendTLSPolicies, test.services)
+			addGatewaysForBackendTLSPolicies(test.backendTLSPolicies, test.services, "nginx-gateway")
 			g.Expect(helpers.Diff(test.backendTLSPolicies, test.expected)).To(BeEmpty())
 		})
 	}

--- a/internal/controller/state/graph/backend_tls_policy_test.go
+++ b/internal/controller/state/graph/backend_tls_policy_test.go
@@ -402,7 +402,7 @@ func TestValidateBackendTLSPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "valid case with many ancestors (ancestor limit now handled during gateway assignment)",
+			name: "valid case with many ancestors",
 			tlsPolicy: &v1alpha3.BackendTLSPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-policy",

--- a/internal/controller/state/graph/backend_tls_policy_test.go
+++ b/internal/controller/state/graph/backend_tls_policy_test.go
@@ -1,8 +1,10 @@
 package graph
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +13,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
 
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/kinds"
 )
@@ -660,8 +663,291 @@ func TestAddGatewaysForBackendTLSPolicies(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			addGatewaysForBackendTLSPolicies(test.backendTLSPolicies, test.services, "nginx-gateway")
+			addGatewaysForBackendTLSPolicies(test.backendTLSPolicies, test.services, "nginx-gateway", nil, logr.Discard())
 			g.Expect(helpers.Diff(test.backendTLSPolicies, test.expected)).To(BeEmpty())
 		})
 	}
+}
+
+func TestAddGatewaysForBackendTLSPoliciesAncestorLimit(t *testing.T) {
+	t.Parallel()
+
+	// Create a test logger that captures log output
+	var logBuf bytes.Buffer
+	testLogger := logr.New(&testLogSink{buffer: &logBuf})
+
+	// Create BackendTLSPolicy with 16 ancestors (full)
+	getAncestorRef := func(ctlrName, parentName string) v1alpha2.PolicyAncestorStatus {
+		return v1alpha2.PolicyAncestorStatus{
+			ControllerName: gatewayv1.GatewayController(ctlrName),
+			AncestorRef: gatewayv1.ParentReference{
+				Name:      gatewayv1.ObjectName(parentName),
+				Namespace: helpers.GetPointer(gatewayv1.Namespace("test")),
+				Group:     helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
+				Kind:      helpers.GetPointer[gatewayv1.Kind](kinds.Gateway),
+			},
+		}
+	}
+
+	// Create 16 ancestors from different controllers to simulate full list
+	fullAncestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+	for i := range 16 {
+		fullAncestors[i] = getAncestorRef("other-controller", "other-gateway")
+	}
+
+	btpWithFullAncestors := &BackendTLSPolicy{
+		Source: &v1alpha3.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "btp-full-ancestors",
+				Namespace: "test",
+			},
+			Spec: v1alpha3.BackendTLSPolicySpec{
+				TargetRefs: []v1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: v1alpha2.LocalPolicyTargetReference{
+							Kind: "Service",
+							Name: "service1",
+						},
+					},
+				},
+			},
+			Status: v1alpha2.PolicyStatus{
+				Ancestors: fullAncestors,
+			},
+		},
+	}
+
+	btpNormal := &BackendTLSPolicy{
+		Source: &v1alpha3.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "btp-normal",
+				Namespace: "test",
+			},
+			Spec: v1alpha3.BackendTLSPolicySpec{
+				TargetRefs: []v1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: v1alpha2.LocalPolicyTargetReference{
+							Kind: "Service",
+							Name: "service2",
+						},
+					},
+				},
+			},
+			Status: v1alpha2.PolicyStatus{
+				Ancestors: []v1alpha2.PolicyAncestorStatus{}, // Empty ancestors list
+			},
+		},
+	}
+
+	services := map[types.NamespacedName]*ReferencedService{
+		{Namespace: "test", Name: "service1"}: {
+			GatewayNsNames: map[types.NamespacedName]struct{}{
+				{Namespace: "test", Name: "gateway1"}: {},
+			},
+		},
+		{Namespace: "test", Name: "service2"}: {
+			GatewayNsNames: map[types.NamespacedName]struct{}{
+				{Namespace: "test", Name: "gateway2"}: {},
+			},
+		},
+	}
+
+	// Create gateways - one will receive ancestor limit condition
+	gateways := map[types.NamespacedName]*Gateway{
+		{Namespace: "test", Name: "gateway1"}: {
+			Source: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gateway1", Namespace: "test"},
+			},
+			Conditions: []conditions.Condition{}, // Start with empty conditions
+		},
+		{Namespace: "test", Name: "gateway2"}: {
+			Source: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gateway2", Namespace: "test"},
+			},
+			Conditions: []conditions.Condition{}, // Start with empty conditions
+		},
+	}
+
+	backendTLSPolicies := map[types.NamespacedName]*BackendTLSPolicy{
+		{Namespace: "test", Name: "btp-full-ancestors"}: btpWithFullAncestors,
+		{Namespace: "test", Name: "btp-normal"}:         btpNormal,
+	}
+
+	g := NewWithT(t)
+
+	// Execute the function
+	addGatewaysForBackendTLSPolicies(backendTLSPolicies, services, "nginx-gateway", gateways, testLogger)
+
+	// Verify that the policy with full ancestors doesn't get any gateways assigned
+	g.Expect(btpWithFullAncestors.Gateways).To(BeEmpty(), "Policy with full ancestors should not get gateways assigned")
+
+	// Verify that the normal policy gets its gateway assigned
+	g.Expect(btpNormal.Gateways).To(HaveLen(1))
+	g.Expect(btpNormal.Gateways[0]).To(Equal(types.NamespacedName{Namespace: "test", Name: "gateway2"}))
+
+	// Verify that gateway1 received the ancestor limit condition
+	gateway1 := gateways[types.NamespacedName{Namespace: "test", Name: "gateway1"}]
+	g.Expect(gateway1.Conditions).To(HaveLen(1), "Gateway should have received ancestor limit condition")
+
+	condition := gateway1.Conditions[0]
+	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
+	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(condition.Reason).To(Equal(string(conditions.PolicyReasonAncestorLimitReached)))
+	g.Expect(condition.Message).To(ContainSubstring("ancestor status list has reached the maximum size of 16"))
+
+	// Verify that gateway2 did not receive any conditions (normal case)
+	gateway2 := gateways[types.NamespacedName{Namespace: "test", Name: "gateway2"}]
+	g.Expect(gateway2.Conditions).To(BeEmpty(), "Normal gateway should not have conditions")
+
+	// Verify logging function works - test the logging function directly
+	LogAncestorLimitReached(testLogger, "test/btp-full-ancestors", "BackendTLSPolicy", "test/gateway1")
+	logOutput := logBuf.String()
+
+	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached"))
+	g.Expect(logOutput).To(ContainSubstring("policy=test/btp-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("policyKind=BackendTLSPolicy"))
+	g.Expect(logOutput).To(ContainSubstring("ancestor=test/gateway1"))
+}
+
+func TestBackendTLSPolicyAncestorsFullFunc(t *testing.T) {
+	t.Parallel()
+
+	getAncestorRef := func(ctlrName, parentName string) v1alpha2.PolicyAncestorStatus {
+		return v1alpha2.PolicyAncestorStatus{
+			ControllerName: gatewayv1.GatewayController(ctlrName),
+			AncestorRef: gatewayv1.ParentReference{
+				Name:      gatewayv1.ObjectName(parentName),
+				Namespace: helpers.GetPointer(gatewayv1.Namespace("test")),
+				Group:     helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
+				Kind:      helpers.GetPointer[gatewayv1.Kind](kinds.Gateway),
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		ctlrName  string
+		ancestors []v1alpha2.PolicyAncestorStatus
+		expected  bool
+	}{
+		{
+			name:      "empty ancestors list",
+			ancestors: []v1alpha2.PolicyAncestorStatus{},
+			ctlrName:  "nginx-gateway",
+			expected:  false,
+		},
+		{
+			name: "less than 16 ancestors",
+			ancestors: []v1alpha2.PolicyAncestorStatus{
+				getAncestorRef("other-controller", "gateway1"),
+				getAncestorRef("other-controller", "gateway2"),
+			},
+			ctlrName: "nginx-gateway",
+			expected: false,
+		},
+		{
+			name: "exactly 16 ancestors, none from our controller",
+			ancestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+				for i := range 16 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				return ancestors
+			}(),
+			ctlrName: "nginx-gateway",
+			expected: true,
+		},
+		{
+			name: "exactly 16 ancestors, one from our controller",
+			ancestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+				for i := range 15 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				ancestors[15] = getAncestorRef("nginx-gateway", "our-gateway")
+				return ancestors
+			}(),
+			ctlrName: "nginx-gateway",
+			expected: false, // Not full because we can overwrite our own entry
+		},
+		{
+			name: "more than 16 ancestors, none from our controller",
+			ancestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 20)
+				for i := range 20 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				return ancestors
+			}(),
+			ctlrName: "nginx-gateway",
+			expected: true,
+		},
+		{
+			name: "more than 16 ancestors, one from our controller",
+			ancestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 20)
+				for i := range 19 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				ancestors[19] = getAncestorRef("nginx-gateway", "our-gateway")
+				return ancestors
+			}(),
+			ctlrName: "nginx-gateway",
+			expected: false, // Not full because we can overwrite our own entry
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := backendTLSPolicyAncestorsFull(test.ancestors, test.ctlrName)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+// testLogSink implements logr.LogSink for testing.
+type testLogSink struct {
+	buffer *bytes.Buffer
+}
+
+func (s *testLogSink) Init(_ logr.RuntimeInfo) {}
+
+func (s *testLogSink) Enabled(_ int) bool {
+	return true
+}
+
+func (s *testLogSink) Info(_ int, msg string, keysAndValues ...interface{}) {
+	s.buffer.WriteString(msg)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		if i+1 < len(keysAndValues) {
+			s.buffer.WriteString(" ")
+			if key, ok := keysAndValues[i].(string); ok {
+				s.buffer.WriteString(key)
+			}
+			s.buffer.WriteString("=")
+			if value, ok := keysAndValues[i+1].(string); ok {
+				s.buffer.WriteString(value)
+			}
+		}
+	}
+	s.buffer.WriteString("\n")
+}
+
+func (s *testLogSink) Error(err error, msg string, _ ...interface{}) {
+	s.buffer.WriteString("ERROR: ")
+	s.buffer.WriteString(msg)
+	s.buffer.WriteString(" error=")
+	s.buffer.WriteString(err.Error())
+	s.buffer.WriteString("\n")
+}
+
+func (s *testLogSink) WithValues(_ ...interface{}) logr.LogSink {
+	return s
+}
+
+func (s *testLogSink) WithName(_ string) logr.LogSink {
+	return s
 }

--- a/internal/controller/state/graph/backend_tls_policy_test.go
+++ b/internal/controller/state/graph/backend_tls_policy_test.go
@@ -803,8 +803,8 @@ func TestAddGatewaysForBackendTLSPoliciesAncestorLimit(t *testing.T) {
 	logAncestorLimitReached(testLogger, "test/btp-full-ancestors", "BackendTLSPolicy", "test/gateway1")
 	logOutput := logBuf.String()
 
-	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached"))
-	g.Expect(logOutput).To(ContainSubstring("policy=test/btp-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached for test/btp-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("test/btp-full-ancestors"))
 	g.Expect(logOutput).To(ContainSubstring("policyKind=BackendTLSPolicy"))
 	g.Expect(logOutput).To(ContainSubstring("ancestor=test/gateway1"))
 }

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -202,8 +202,6 @@ func BuildGraph(
 	validators validation.Validators,
 	logger logr.Logger,
 ) *Graph {
-	// Set the logger for the graph package
-	SetLogger(logger)
 	processedGwClasses, gcExists := processGatewayClasses(state.GatewayClasses, gcName, controllerName)
 	if gcExists && processedGwClasses.Winner == nil {
 		// configured GatewayClass does not reference this controller
@@ -274,7 +272,7 @@ func BuildGraph(
 
 	referencedServices := buildReferencedServices(routes, l4routes, gws)
 
-	addGatewaysForBackendTLSPolicies(processedBackendTLSPolicies, referencedServices, controllerName)
+	addGatewaysForBackendTLSPolicies(processedBackendTLSPolicies, referencedServices, controllerName, gws, logger)
 
 	// policies must be processed last because they rely on the state of the other resources in the graph
 	processedPolicies := processPolicies(
@@ -307,7 +305,7 @@ func BuildGraph(
 		PlusSecrets:                plusSecrets,
 	}
 
-	g.attachPolicies(validators.PolicyValidator, controllerName)
+	g.attachPolicies(validators.PolicyValidator, controllerName, logger)
 
 	return g
 }

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,8 +13,6 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/go-logr/logr"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -239,7 +239,6 @@ func BuildGraph(
 		state.BackendTLSPolicies,
 		configMapResolver,
 		secretResolver,
-		controllerName,
 		gws,
 	)
 

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/go-logr/logr"
+
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
@@ -198,7 +200,10 @@ func BuildGraph(
 	gcName string,
 	plusSecrets map[types.NamespacedName][]PlusSecretFile,
 	validators validation.Validators,
+	logger logr.Logger,
 ) *Graph {
+	// Set the logger for the graph package
+	SetLogger(logger)
 	processedGwClasses, gcExists := processGatewayClasses(state.GatewayClasses, gcName, controllerName)
 	if gcExists && processedGwClasses.Winner == nil {
 		// configured GatewayClass does not reference this controller
@@ -269,7 +274,7 @@ func BuildGraph(
 
 	referencedServices := buildReferencedServices(routes, l4routes, gws)
 
-	addGatewaysForBackendTLSPolicies(processedBackendTLSPolicies, referencedServices)
+	addGatewaysForBackendTLSPolicies(processedBackendTLSPolicies, referencedServices, controllerName)
 
 	// policies must be processed last because they rely on the state of the other resources in the graph
 	processedPolicies := processPolicies(

--- a/internal/controller/state/graph/graph_test.go
+++ b/internal/controller/state/graph/graph_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	v1 "k8s.io/api/core/v1"
@@ -1309,6 +1310,7 @@ func TestBuildGraph(t *testing.T) {
 					GenericValidator:    &validationfakes.FakeGenericValidator{},
 					PolicyValidator:     fakePolicyValidator,
 				},
+				logr.Discard(),
 			)
 
 			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())

--- a/internal/controller/state/graph/multiple_gateways_test.go
+++ b/internal/controller/state/graph/multiple_gateways_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	v1 "k8s.io/api/core/v1"
@@ -398,6 +399,7 @@ func Test_MultipleGateways_WithNginxProxy(t *testing.T) {
 					GenericValidator:    &validationfakes.FakeGenericValidator{},
 					PolicyValidator:     fakePolicyValidator,
 				},
+				logr.Discard(),
 			)
 
 			g.Expect(helpers.Diff(test.expGraph, result)).To(BeEmpty())
@@ -886,6 +888,7 @@ func Test_MultipleGateways_WithListeners(t *testing.T) {
 					GenericValidator:    &validationfakes.FakeGenericValidator{},
 					PolicyValidator:     fakePolicyValidator,
 				},
+				logr.Discard(),
 			)
 
 			g.Expect(helpers.Diff(test.expGraph, result)).To(BeEmpty())

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -113,8 +113,7 @@ func collectOrderedGatewaysForService(
 	sortGatewaysByCreationTime(existingGateways, gateways)
 	sortGatewaysByCreationTime(newGateways, gateways)
 
-	existingGateways = append(existingGateways, newGateways...)
-	return existingGateways
+	return append(existingGateways, newGateways...)
 }
 
 func (g *Graph) attachPolicies(validator validation.PolicyValidator, ctlrName string, logger logr.Logger) {

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -200,7 +200,7 @@ func attachPolicyToService(
 			policyKind := getPolicyKind(policy.Source)
 
 			gw.Conditions = addPolicyAncestorLimitCondition(gw.Conditions, policyName, policyKind)
-			LogAncestorLimitReached(logger, policyName, policyKind, gwNsName.String())
+			logAncestorLimitReached(logger, policyName, policyKind, gwNsName.String())
 
 			// Mark this gateway as invalid for the policy due to ancestor limits
 			policy.InvalidForGateways[gwNsName] = struct{}{}
@@ -248,7 +248,7 @@ func attachPolicyToRoute(
 		routeName := getAncestorName(ancestorRef)
 
 		route.Conditions = addPolicyAncestorLimitCondition(route.Conditions, policyName, policyKind)
-		LogAncestorLimitReached(logger, policyName, policyKind, routeName)
+		logAncestorLimitReached(logger, policyName, policyKind, routeName)
 
 		return
 	}
@@ -326,7 +326,7 @@ func attachPolicyToGateway(
 			// Log in the controller log.
 			logger.Info("Gateway target not found and ancestors slice is full.", "policy", policyName, "ancestor", ancestorName)
 		}
-		LogAncestorLimitReached(logger, policyName, policyKind, ancestorName)
+		logAncestorLimitReached(logger, policyName, policyKind, ancestorName)
 
 		policy.InvalidForGateways[ref.Nsname] = struct{}{}
 		return

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -575,7 +575,6 @@ func TestAttachPolicyToGateway(t *testing.T) {
 			gws: newGatewayMap(true, []types.NamespacedName{gatewayNsName}),
 			expAncestors: []PolicyAncestor{
 				{Ancestor: getGatewayParentRef(gatewayNsName)},
-				{Ancestor: getGatewayParentRef(gatewayNsName)},
 			},
 			expAttached: true,
 		},

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -2304,8 +2304,8 @@ func TestNGFPolicyAncestorLimitHandling(t *testing.T) {
 
 	// Verify logging occurred
 	logOutput := logBuf.String()
-	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached"))
-	g.Expect(logOutput).To(ContainSubstring("policy=test/policy-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached for test/policy-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("test/policy-full-ancestors"))
 	g.Expect(logOutput).To(ContainSubstring("policyKind=TestPolicy"))
 	g.Expect(logOutput).To(ContainSubstring("ancestor=test/gateway1"))
 }

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -1,9 +1,11 @@
 package graph
 
 import (
+	"bytes"
 	"slices"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -241,7 +243,7 @@ func TestAttachPolicies(t *testing.T) {
 				NGFPolicies:        test.ngfPolicies,
 			}
 
-			graph.attachPolicies(nil, "nginx-gateway")
+			graph.attachPolicies(nil, "nginx-gateway", logr.Discard())
 			for _, expect := range test.expects {
 				expect(g, graph)
 			}
@@ -498,7 +500,7 @@ func TestAttachPolicyToRoute(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			attachPolicyToRoute(test.policy, test.route, test.validator, "nginx-gateway")
+			attachPolicyToRoute(test.policy, test.route, test.validator, "nginx-gateway", logr.Discard())
 
 			if test.expAttached {
 				g.Expect(test.route.Policies).To(HaveLen(1))
@@ -643,7 +645,7 @@ func TestAttachPolicyToGateway(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			attachPolicyToGateway(test.policy, test.policy.TargetRefs[0], test.gws, "nginx-gateway")
+			attachPolicyToGateway(test.policy, test.policy.TargetRefs[0], test.gws, "nginx-gateway", logr.Discard())
 
 			if test.expAttached {
 				for _, gw := range test.gws {
@@ -830,7 +832,7 @@ func TestAttachPolicyToService(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			attachPolicyToService(test.policy, test.svc, test.gws, "ctlr")
+			attachPolicyToService(test.policy, test.svc, test.gws, "ctlr", logr.Discard())
 			if test.expAttached {
 				g.Expect(test.svc.Policies).To(HaveLen(1))
 			} else {
@@ -1962,4 +1964,359 @@ func TestAddStatusToTargetRefs(t *testing.T) {
 	g.Expect(func() {
 		addStatusToTargetRefs(policyKind, nil)
 	}).ToNot(Panic())
+}
+
+func TestNGFPolicyAncestorsFullFunc(t *testing.T) {
+	t.Parallel()
+
+	createPolicyWithAncestors := func(ancestors []v1alpha2.PolicyAncestorStatus) *Policy {
+		fakePolicy := &policiesfakes.FakePolicy{
+			GetPolicyStatusStub: func() v1alpha2.PolicyStatus {
+				return v1alpha2.PolicyStatus{
+					Ancestors: ancestors,
+				}
+			},
+		}
+		return &Policy{
+			Source:    fakePolicy,
+			Ancestors: []PolicyAncestor{}, // Updated ancestors list (starts empty)
+		}
+	}
+
+	getAncestorRef := func(ctlrName, parentName string) v1alpha2.PolicyAncestorStatus {
+		return v1alpha2.PolicyAncestorStatus{
+			ControllerName: v1.GatewayController(ctlrName),
+			AncestorRef: v1.ParentReference{
+				Name:      v1.ObjectName(parentName),
+				Namespace: helpers.GetPointer(v1.Namespace("test")),
+				Group:     helpers.GetPointer[v1.Group](v1.GroupName),
+				Kind:      helpers.GetPointer[v1.Kind](kinds.Gateway),
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		ctlrName            string
+		currentAncestors    []v1alpha2.PolicyAncestorStatus
+		updatedAncestorsLen int
+		expected            bool
+	}{
+		{
+			name:                "empty current ancestors, no updated ancestors",
+			currentAncestors:    []v1alpha2.PolicyAncestorStatus{},
+			updatedAncestorsLen: 0,
+			ctlrName:            "nginx-gateway",
+			expected:            false,
+		},
+		{
+			name: "less than 16 total (current + updated)",
+			currentAncestors: []v1alpha2.PolicyAncestorStatus{
+				getAncestorRef("other-controller", "gateway1"),
+				getAncestorRef("other-controller", "gateway2"),
+			},
+			updatedAncestorsLen: 2,
+			ctlrName:            "nginx-gateway",
+			expected:            false,
+		},
+		{
+			name: "exactly 16 non-NGF ancestors, no updated ancestors",
+			currentAncestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+				for i := range 16 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				return ancestors
+			}(),
+			updatedAncestorsLen: 1, // Trying to add 1 NGF ancestor
+			ctlrName:            "nginx-gateway",
+			expected:            true,
+		},
+		{
+			name: "15 non-NGF + 1 NGF ancestor, adding 1 more NGF ancestor",
+			currentAncestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+				for i := range 15 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				ancestors[15] = getAncestorRef("nginx-gateway", "our-gateway")
+				return ancestors
+			}(),
+			updatedAncestorsLen: 1,
+			ctlrName:            "nginx-gateway",
+			expected:            true, // Full because 15 non-NGF + 1 new NGF = 16 which is the limit
+		},
+		{
+			name: "10 non-NGF ancestors, trying to add 7 NGF ancestors (would exceed 16)",
+			currentAncestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 10)
+				for i := range 10 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				return ancestors
+			}(),
+			updatedAncestorsLen: 7,
+			ctlrName:            "nginx-gateway",
+			expected:            true,
+		},
+		{
+			name: "5 non-NGF + 5 NGF ancestors, trying to add 6 more NGF ancestors",
+			currentAncestors: func() []v1alpha2.PolicyAncestorStatus {
+				ancestors := make([]v1alpha2.PolicyAncestorStatus, 10)
+				for i := range 5 {
+					ancestors[i] = getAncestorRef("other-controller", "gateway")
+				}
+				for i := 5; i < 10; i++ {
+					ancestors[i] = getAncestorRef("nginx-gateway", "our-gateway")
+				}
+				return ancestors
+			}(),
+			updatedAncestorsLen: 6,
+			ctlrName:            "nginx-gateway",
+			expected:            false, // 5 non-NGF + 6 new NGF = 11 total (within limit)
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			policy := createPolicyWithAncestors(test.currentAncestors)
+			// Simulate the updated ancestors list
+			for range test.updatedAncestorsLen {
+				policy.Ancestors = append(policy.Ancestors, PolicyAncestor{
+					Ancestor: createParentReference(v1.GroupName, kinds.Gateway,
+						types.NamespacedName{Namespace: "test", Name: "new-gateway"}),
+				})
+			}
+
+			result := ngfPolicyAncestorsFull(policy, test.ctlrName)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestNGFPolicyAncestorLimitHandling(t *testing.T) {
+	t.Parallel()
+
+	// Create a test logger that captures log output
+	var logBuf bytes.Buffer
+	testLogger := logr.New(&testNGFLogSink{buffer: &logBuf})
+
+	policyGVK := schema.GroupVersionKind{Group: "Group", Version: "Version", Kind: "TestPolicy"}
+
+	// Create a policy with 16 non-NGF ancestors (ancestor limit reached)
+	getAncestorRef := func(ctlrName, parentName string) v1alpha2.PolicyAncestorStatus {
+		return v1alpha2.PolicyAncestorStatus{
+			ControllerName: v1.GatewayController(ctlrName),
+			AncestorRef: v1.ParentReference{
+				Name:      v1.ObjectName(parentName),
+				Namespace: helpers.GetPointer(v1.Namespace("test")),
+				Group:     helpers.GetPointer[v1.Group](v1.GroupName),
+				Kind:      helpers.GetPointer[v1.Kind](kinds.Gateway),
+			},
+		}
+	}
+
+	// Create 16 ancestors from different controllers to simulate full list
+	fullAncestors := make([]v1alpha2.PolicyAncestorStatus, 16)
+	for i := range 16 {
+		fullAncestors[i] = getAncestorRef("other-controller", "other-gateway")
+	}
+
+	policyWithFullAncestors := &policiesfakes.FakePolicy{
+		GetNameStub: func() string {
+			return "policy-full-ancestors"
+		},
+		GetNamespaceStub: func() string {
+			return "test"
+		},
+		GetPolicyStatusStub: func() v1alpha2.PolicyStatus {
+			return v1alpha2.PolicyStatus{
+				Ancestors: fullAncestors,
+			}
+		},
+		GetObjectKindStub: func() schema.ObjectKind {
+			return &policiesfakes.FakeObjectKind{
+				GroupVersionKindStub: func() schema.GroupVersionKind {
+					return policyGVK
+				},
+			}
+		},
+		GetTargetRefsStub: func() []v1alpha2.LocalPolicyTargetReference {
+			return []v1alpha2.LocalPolicyTargetReference{
+				{
+					Group: v1.GroupName,
+					Kind:  kinds.Gateway,
+					Name:  v1.ObjectName("gateway1"),
+				},
+			}
+		},
+	}
+
+	// Create a policy with fewer ancestors (normal case)
+	normalPolicy := &policiesfakes.FakePolicy{
+		GetNameStub: func() string {
+			return "policy-normal"
+		},
+		GetNamespaceStub: func() string {
+			return "test"
+		},
+		GetPolicyStatusStub: func() v1alpha2.PolicyStatus {
+			return v1alpha2.PolicyStatus{
+				Ancestors: []v1alpha2.PolicyAncestorStatus{}, // Empty ancestors list
+			}
+		},
+		GetObjectKindStub: func() schema.ObjectKind {
+			return &policiesfakes.FakeObjectKind{
+				GroupVersionKindStub: func() schema.GroupVersionKind {
+					return policyGVK
+				},
+			}
+		},
+		GetTargetRefsStub: func() []v1alpha2.LocalPolicyTargetReference {
+			return []v1alpha2.LocalPolicyTargetReference{
+				{
+					Group: v1.GroupName,
+					Kind:  kinds.Gateway,
+					Name:  v1.ObjectName("gateway2"),
+				},
+			}
+		},
+	}
+
+	// Create gateways
+	gateways := map[types.NamespacedName]*Gateway{
+		{Namespace: "test", Name: "gateway1"}: {
+			Source: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gateway1", Namespace: "test"},
+			},
+			Conditions: []conditions.Condition{}, // Start with empty conditions
+		},
+		{Namespace: "test", Name: "gateway2"}: {
+			Source: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gateway2", Namespace: "test"},
+			},
+			Conditions: []conditions.Condition{}, // Start with empty conditions
+		},
+	}
+
+	// Create test policies map
+	testPolicies := map[PolicyKey]policies.Policy{
+		{
+			NsName: types.NamespacedName{Namespace: "test", Name: "policy-full-ancestors"},
+			GVK:    policyGVK,
+		}: policyWithFullAncestors,
+		{
+			NsName: types.NamespacedName{Namespace: "test", Name: "policy-normal"},
+			GVK:    policyGVK,
+		}: normalPolicy,
+	}
+
+	// Create fake validator
+	validator := &policiesfakes.FakeValidator{
+		ValidateStub: func(_ policies.Policy) []conditions.Condition {
+			return nil
+		},
+		ConflictsStub: func(_, _ policies.Policy) bool {
+			return false
+		},
+	}
+
+	// Create empty routes and services for the test
+	routes := map[RouteKey]*L7Route{}
+	referencedServices := map[types.NamespacedName]*ReferencedService{}
+
+	g := NewWithT(t)
+
+	// Process policies which should trigger ancestor limit handling
+	processedPolicies := processPolicies(testPolicies, validator, routes, referencedServices, gateways)
+
+	// Create a graph and attach policies to trigger ancestor limit handling
+	graph := &Graph{
+		Gateways:    gateways,
+		NGFPolicies: processedPolicies,
+	}
+
+	// Call attachPolicies to trigger the ancestor limit logic
+	graph.attachPolicies(validator, "nginx-gateway", testLogger)
+
+	// Verify that the policy with full ancestors has no actual ancestors assigned
+	policyFullKey := PolicyKey{
+		NsName: types.NamespacedName{Namespace: "test", Name: "policy-full-ancestors"},
+		GVK:    policyGVK,
+	}
+	policyFull := graph.NGFPolicies[policyFullKey]
+	g.Expect(policyFull.Ancestors).To(BeEmpty(), "Policy with full ancestors should have no ancestors assigned")
+
+	// Verify that the normal policy gets its ancestor assigned
+	policyNormalKey := PolicyKey{NsName: types.NamespacedName{Namespace: "test", Name: "policy-normal"}, GVK: policyGVK}
+	policyNormal := graph.NGFPolicies[policyNormalKey]
+	g.Expect(policyNormal.Ancestors).To(HaveLen(1), "Normal policy should have ancestor assigned")
+
+	// Verify that gateway1 received the ancestor limit condition
+	gateway1 := gateways[types.NamespacedName{Namespace: "test", Name: "gateway1"}]
+	g.Expect(gateway1.Conditions).To(HaveLen(1), "Gateway should have received ancestor limit condition")
+
+	condition := gateway1.Conditions[0]
+	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
+	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(condition.Reason).To(Equal(string(conditions.PolicyReasonAncestorLimitReached)))
+	g.Expect(condition.Message).To(ContainSubstring("ancestor status list has reached the maximum size of 16"))
+
+	// Verify that gateway2 did not receive any conditions (normal case)
+	gateway2 := gateways[types.NamespacedName{Namespace: "test", Name: "gateway2"}]
+	g.Expect(gateway2.Conditions).To(BeEmpty(), "Normal gateway should not have conditions")
+
+	// Verify logging occurred
+	logOutput := logBuf.String()
+	g.Expect(logOutput).To(ContainSubstring("Policy ancestor limit reached"))
+	g.Expect(logOutput).To(ContainSubstring("policy=test/policy-full-ancestors"))
+	g.Expect(logOutput).To(ContainSubstring("policyKind=TestPolicy"))
+	g.Expect(logOutput).To(ContainSubstring("ancestor=test/gateway1"))
+}
+
+// testNGFLogSink implements logr.LogSink for testing NGF policies.
+type testNGFLogSink struct {
+	buffer *bytes.Buffer
+}
+
+func (s *testNGFLogSink) Init(_ logr.RuntimeInfo) {}
+
+func (s *testNGFLogSink) Enabled(_ int) bool {
+	return true
+}
+
+func (s *testNGFLogSink) Info(_ int, msg string, keysAndValues ...interface{}) {
+	s.buffer.WriteString(msg)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		if i+1 < len(keysAndValues) {
+			s.buffer.WriteString(" ")
+			if key, ok := keysAndValues[i].(string); ok {
+				s.buffer.WriteString(key)
+			}
+			s.buffer.WriteString("=")
+			if value, ok := keysAndValues[i+1].(string); ok {
+				s.buffer.WriteString(value)
+			}
+		}
+	}
+	s.buffer.WriteString("\n")
+}
+
+func (s *testNGFLogSink) Error(err error, msg string, _ ...interface{}) {
+	s.buffer.WriteString("ERROR: ")
+	s.buffer.WriteString(msg)
+	s.buffer.WriteString(" error=")
+	s.buffer.WriteString(err.Error())
+	s.buffer.WriteString("\n")
+}
+
+func (s *testNGFLogSink) WithValues(_ ...interface{}) logr.LogSink {
+	return s
+}
+
+func (s *testNGFLogSink) WithName(_ string) logr.LogSink {
+	return s
 }

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -2303,7 +2303,7 @@ func TestNGFPolicyAncestorLimitHandling(t *testing.T) {
 	g.Expect(condition.Type).To(Equal(string(v1alpha2.PolicyConditionAccepted)))
 	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(condition.Reason).To(Equal(string(conditions.PolicyReasonAncestorLimitReached)))
-	g.Expect(condition.Message).To(ContainSubstring("ancestor status list has reached the maximum size of 16"))
+	g.Expect(condition.Message).To(ContainSubstring("ancestor status list has reached the maximum size"))
 
 	// Verify that gateway2 did not receive any conditions (normal case)
 	gateway2 := gateways[types.NamespacedName{Namespace: "test", Name: "gateway2"}]

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -15,7 +15,7 @@ const maxAncestors = 16
 
 // logAncestorLimitReached logs when a policy ancestor limit is reached.
 func logAncestorLimitReached(logger logr.Logger, policyName, policyKind, ancestorName string) {
-	logger.Info("Policy ancestor limit reached", "policy", policyName, "policyKind", policyKind, "ancestor", ancestorName)
+	logger.Info("Policy ancestor limit reached for "+policyName, "policyKind", policyKind, "ancestor", ancestorName)
 }
 
 // ngfPolicyAncestorsFull returns whether or not an ancestor list is full. A list is full when

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
@@ -17,27 +16,6 @@ const maxAncestors = 16
 // LogAncestorLimitReached logs when a policy ancestor limit is reached.
 func LogAncestorLimitReached(logger logr.Logger, policyName, policyKind, ancestorName string) {
 	logger.Info("Policy ancestor limit reached", "policy", policyName, "policyKind", policyKind, "ancestor", ancestorName)
-}
-
-// backendTLSPolicyAncestorsFull returns whether or not an ancestor list is full. A list is not full when:
-// - the number of current ancestors is less than the maximum allowed
-// - an entry for an NGF managed resource already exists in the ancestor list. This means that we are overwriting
-// that status entry with the current status entry, since there is only one ancestor (Gateway) for this policy.
-func backendTLSPolicyAncestorsFull(
-	ancestors []v1alpha2.PolicyAncestorStatus,
-	ctlrName string,
-) bool {
-	if len(ancestors) < maxAncestors {
-		return false
-	}
-
-	for _, ancestor := range ancestors {
-		if string(ancestor.ControllerName) == ctlrName {
-			return false
-		}
-	}
-
-	return true
 }
 
 // ngfPolicyAncestorsFull returns whether or not an ancestor list is full. A list is full when

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -13,16 +13,8 @@ import (
 
 const maxAncestors = 16
 
-// Package-level logger.
-var logger logr.Logger
-
-// SetLogger sets the logger for the graph package.
-func SetLogger(l logr.Logger) {
-	logger = l
-}
-
 // LogAncestorLimitReached logs when a policy ancestor limit is reached.
-func LogAncestorLimitReached(policyName, policyKind, ancestorName string) {
+func LogAncestorLimitReached(logger logr.Logger, policyName, policyKind, ancestorName string) {
 	logger.Info("Policy ancestor limit reached", "policy", policyName, "policyKind", policyKind, "ancestor", ancestorName)
 }
 

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -83,10 +83,7 @@ func parentRefEqual(ref1, ref2 v1.ParentReference) bool {
 	return true
 }
 
-// Helper functions to eliminate code duplication
-
-// getAncestorName generates a human-readable name for an ancestor from a ParentReference.
-// Returns namespace/name format if namespace is specified, otherwise just name.
+// getAncestorName returns namespace/name format if namespace is specified, otherwise just name.
 func getAncestorName(ancestorRef v1.ParentReference) string {
 	ancestorName := string(ancestorRef.Name)
 	if ancestorRef.Namespace != nil {
@@ -95,15 +92,14 @@ func getAncestorName(ancestorRef v1.ParentReference) string {
 	return ancestorName
 }
 
-// getPolicyName generates a human-readable name for a policy in namespace/name format.
+// getPolicyName returns a human-readable name for a policy in namespace/name format.
 func getPolicyName(policy policies.Policy) string {
 	return policy.GetNamespace() + "/" + policy.GetName()
 }
 
-// getPolicyKind returns the policy kind with defensive programming for test environments.
-// Returns "Policy" as fallback if GetObjectKind() returns nil.
+// getPolicyKind returns the policy kind or "Policy" if GetObjectKind() returns nil.
 func getPolicyKind(policy policies.Policy) string {
-	policyKind := "Policy" // Default fallback
+	policyKind := "Policy"
 	if objKind := policy.GetObjectKind(); objKind != nil {
 		policyKind = objKind.GroupVersionKind().Kind
 	}

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -13,8 +13,8 @@ import (
 
 const maxAncestors = 16
 
-// LogAncestorLimitReached logs when a policy ancestor limit is reached.
-func LogAncestorLimitReached(logger logr.Logger, policyName, policyKind, ancestorName string) {
+// logAncestorLimitReached logs when a policy ancestor limit is reached.
+func logAncestorLimitReached(logger logr.Logger, policyName, policyKind, ancestorName string) {
 	logger.Info("Policy ancestor limit reached", "policy", policyName, "policyKind", policyKind, "ancestor", ancestorName)
 }
 

--- a/internal/controller/state/graph/policy_ancestor.go
+++ b/internal/controller/state/graph/policy_ancestor.go
@@ -5,10 +5,26 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/go-logr/logr"
+
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
 )
 
 const maxAncestors = 16
+
+// Package-level logger.
+var logger logr.Logger
+
+// SetLogger sets the logger for the graph package.
+func SetLogger(l logr.Logger) {
+	logger = l
+}
+
+// LogAncestorLimitReached logs when a policy ancestor limit is reached.
+func LogAncestorLimitReached(policyName, policyKind, ancestorName string) {
+	logger.Info("Policy ancestor limit reached", "policy", policyName, "policyKind", policyKind, "ancestor", ancestorName)
+}
 
 // backendTLSPolicyAncestorsFull returns whether or not an ancestor list is full. A list is not full when:
 // - the number of current ancestors is less than the maximum allowed
@@ -94,4 +110,31 @@ func parentRefEqual(ref1, ref2 v1.ParentReference) bool {
 	}
 
 	return true
+}
+
+// Helper functions to eliminate code duplication
+
+// getAncestorName generates a human-readable name for an ancestor from a ParentReference.
+// Returns namespace/name format if namespace is specified, otherwise just name.
+func getAncestorName(ancestorRef v1.ParentReference) string {
+	ancestorName := string(ancestorRef.Name)
+	if ancestorRef.Namespace != nil {
+		ancestorName = string(*ancestorRef.Namespace) + "/" + ancestorName
+	}
+	return ancestorName
+}
+
+// getPolicyName generates a human-readable name for a policy in namespace/name format.
+func getPolicyName(policy policies.Policy) string {
+	return policy.GetNamespace() + "/" + policy.GetName()
+}
+
+// getPolicyKind returns the policy kind with defensive programming for test environments.
+// Returns "Policy" as fallback if GetObjectKind() returns nil.
+func getPolicyKind(policy policies.Policy) string {
+	policyKind := "Policy" // Default fallback
+	if objKind := policy.GetObjectKind(); objKind != nil {
+		policyKind = objKind.GroupVersionKind().Kind
+	}
+	return policyKind
 }

--- a/internal/controller/state/graph/policy_ancestor_test.go
+++ b/internal/controller/state/graph/policy_ancestor_test.go
@@ -2,13 +2,19 @@ package graph
 
 import (
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr/testr"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/kinds"
 )
 
@@ -229,6 +235,234 @@ func TestParentRefEqual(t *testing.T) {
 			g := NewWithT(t)
 
 			g.Expect(parentRefEqual(ref1, test.ref)).To(Equal(test.equal))
+		})
+	}
+}
+
+func TestLogAncestorLimitReached(t *testing.T) {
+	t.Parallel()
+	logger := testr.New(t)
+	logAncestorLimitReached(logger, "test-policy", "TestPolicy", "test-ancestor")
+}
+
+func TestGetAncestorName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ref      v1.ParentReference
+		expected string
+	}{
+		{
+			name: "with namespace",
+			ref: v1.ParentReference{
+				Name:      "test-gw",
+				Namespace: func() *v1.Namespace { ns := v1.Namespace("test-ns"); return &ns }(),
+			},
+			expected: "test-ns/test-gw",
+		},
+		{
+			name: "without namespace",
+			ref: v1.ParentReference{
+				Name: "test-gw",
+			},
+			expected: "test-gw",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(getAncestorName(test.ref)).To(Equal(test.expected))
+		})
+	}
+}
+
+type mockPolicy struct {
+	name      string
+	namespace string
+	kind      string
+}
+
+func (m *mockPolicy) GetName() string               { return m.name }
+func (m *mockPolicy) SetName(name string)           { m.name = name }
+func (m *mockPolicy) GetNamespace() string          { return m.namespace }
+func (m *mockPolicy) SetNamespace(namespace string) { m.namespace = namespace }
+func (m *mockPolicy) GetObjectKind() schema.ObjectKind {
+	if m.kind == "" {
+		return nil
+	}
+	return &mockObjectKind{kind: m.kind}
+}
+func (m *mockPolicy) GetTargetRefs() []v1alpha2.LocalPolicyTargetReference { return nil }
+func (m *mockPolicy) GetPolicyStatus() v1alpha2.PolicyStatus               { return v1alpha2.PolicyStatus{} }
+func (m *mockPolicy) SetPolicyStatus(_ v1alpha2.PolicyStatus)              {}
+func (m *mockPolicy) DeepCopyObject() runtime.Object                       { return m }
+func (m *mockPolicy) GetUID() types.UID                                    { return "" }
+func (m *mockPolicy) GetResourceVersion() string                           { return "" }
+func (m *mockPolicy) SetUID(_ types.UID)                                   {}
+func (m *mockPolicy) SetResourceVersion(_ string)                          {}
+func (m *mockPolicy) GetGeneration() int64                                 { return 0 }
+func (m *mockPolicy) SetGeneration(_ int64)                                {}
+func (m *mockPolicy) GetCreationTimestamp() metav1.Time                    { return metav1.Time{} }
+func (m *mockPolicy) SetCreationTimestamp(_ metav1.Time)                   {}
+func (m *mockPolicy) GetDeletionTimestamp() *metav1.Time                   { return nil }
+func (m *mockPolicy) SetDeletionTimestamp(_ *metav1.Time)                  {}
+func (m *mockPolicy) GetDeletionGracePeriodSeconds() *int64                { return nil }
+func (m *mockPolicy) SetDeletionGracePeriodSeconds(*int64)                 {}
+func (m *mockPolicy) GetLabels() map[string]string                         { return nil }
+func (m *mockPolicy) SetLabels(_ map[string]string)                        {}
+func (m *mockPolicy) GetAnnotations() map[string]string                    { return nil }
+func (m *mockPolicy) SetAnnotations(_ map[string]string)                   {}
+func (m *mockPolicy) GetFinalizers() []string                              { return nil }
+func (m *mockPolicy) SetFinalizers(_ []string)                             {}
+func (m *mockPolicy) GetOwnerReferences() []metav1.OwnerReference          { return nil }
+func (m *mockPolicy) SetOwnerReferences([]metav1.OwnerReference)           {}
+func (m *mockPolicy) GetManagedFields() []metav1.ManagedFieldsEntry        { return nil }
+func (m *mockPolicy) SetManagedFields(_ []metav1.ManagedFieldsEntry)       {}
+func (m *mockPolicy) GetGenerateName() string                              { return "" }
+func (m *mockPolicy) SetGenerateName(_ string)                             {}
+func (m *mockPolicy) GetSelfLink() string                                  { return "" }
+func (m *mockPolicy) SetSelfLink(_ string)                                 {}
+
+type mockObjectKind struct{ kind string }
+
+func (m *mockObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Kind: m.kind}
+}
+func (m *mockObjectKind) SetGroupVersionKind(_ schema.GroupVersionKind) {}
+
+func TestGetPolicyName(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	policy := &mockPolicy{name: "test-policy", namespace: "test-ns"}
+	g.Expect(getPolicyName(policy)).To(Equal("test-ns/test-policy"))
+}
+
+func TestGetPolicyKind(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		policy   policies.Policy
+		expected string
+	}{
+		{
+			name:     "with kind",
+			policy:   &mockPolicy{kind: "TestPolicy"},
+			expected: "TestPolicy",
+		},
+		{
+			name:     "without kind",
+			policy:   &mockPolicy{},
+			expected: "Policy",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(getPolicyKind(test.policy)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestCompareNamespacedNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		a, b     types.NamespacedName
+		expected bool
+	}{
+		{
+			name:     "same namespace, a name < b name",
+			a:        types.NamespacedName{Namespace: "ns", Name: "a"},
+			b:        types.NamespacedName{Namespace: "ns", Name: "b"},
+			expected: true,
+		},
+		{
+			name:     "same namespace, a name > b name",
+			a:        types.NamespacedName{Namespace: "ns", Name: "b"},
+			b:        types.NamespacedName{Namespace: "ns", Name: "a"},
+			expected: false,
+		},
+		{
+			name:     "a namespace < b namespace",
+			a:        types.NamespacedName{Namespace: "a", Name: "z"},
+			b:        types.NamespacedName{Namespace: "b", Name: "a"},
+			expected: true,
+		},
+		{
+			name:     "a namespace > b namespace",
+			a:        types.NamespacedName{Namespace: "b", Name: "a"},
+			b:        types.NamespacedName{Namespace: "a", Name: "z"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(compareNamespacedNames(test.a, test.b)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestSortGatewaysByCreationTime(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	gw1Name := types.NamespacedName{Namespace: "test", Name: "gw1"}
+	gw2Name := types.NamespacedName{Namespace: "test", Name: "gw2"}
+
+	tests := []struct {
+		name     string
+		gateways map[types.NamespacedName]*Gateway
+		names    []types.NamespacedName
+		expected []types.NamespacedName
+	}{
+		{
+			name: "sort by creation time",
+			gateways: map[types.NamespacedName]*Gateway{
+				gw1Name: {Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now.Add(time.Hour))},
+				}},
+				gw2Name: {Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+				}},
+			},
+			names:    []types.NamespacedName{gw1Name, gw2Name},
+			expected: []types.NamespacedName{gw2Name, gw1Name},
+		},
+		{
+			name: "same creation time, sort by namespace/name",
+			gateways: map[types.NamespacedName]*Gateway{
+				gw2Name: {Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+				}},
+				gw1Name: {Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+				}},
+			},
+			names:    []types.NamespacedName{gw2Name, gw1Name},
+			expected: []types.NamespacedName{gw1Name, gw2Name},
+		},
+		{
+			name:     "nil gateway fallback to namespace/name",
+			gateways: map[types.NamespacedName]*Gateway{gw1Name: nil},
+			names:    []types.NamespacedName{gw2Name, gw1Name},
+			expected: []types.NamespacedName{gw1Name, gw2Name},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			names := make([]types.NamespacedName, len(test.names))
+			copy(names, test.names)
+			sortGatewaysByCreationTime(names, test.gateways)
+			g.Expect(names).To(Equal(test.expected))
 		})
 	}
 }

--- a/internal/controller/state/graph/policy_ancestor_test.go
+++ b/internal/controller/state/graph/policy_ancestor_test.go
@@ -12,53 +12,6 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/kinds"
 )
 
-func TestBackendTLSPolicyAncestorsFull(t *testing.T) {
-	t.Parallel()
-	createCurStatus := func(numAncestors int, ctlrName string) []v1alpha2.PolicyAncestorStatus {
-		statuses := make([]v1alpha2.PolicyAncestorStatus, 0, numAncestors)
-
-		for range numAncestors {
-			statuses = append(statuses, v1alpha2.PolicyAncestorStatus{
-				ControllerName: v1.GatewayController(ctlrName),
-			})
-		}
-
-		return statuses
-	}
-
-	tests := []struct {
-		name      string
-		curStatus []v1alpha2.PolicyAncestorStatus
-		expFull   bool
-	}{
-		{
-			name:      "not full",
-			curStatus: createCurStatus(15, "controller"),
-			expFull:   false,
-		},
-		{
-			name:      "full; ancestor does not exist in current status",
-			curStatus: createCurStatus(16, "controller"),
-			expFull:   true,
-		},
-		{
-			name:      "full, but ancestor does exist in current status",
-			curStatus: createCurStatus(16, "nginx-gateway"),
-			expFull:   false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewWithT(t)
-
-			full := backendTLSPolicyAncestorsFull(test.curStatus, "nginx-gateway")
-			g.Expect(full).To(Equal(test.expFull))
-		})
-	}
-}
-
 func TestNGFPolicyAncestorsFull(t *testing.T) {
 	t.Parallel()
 	type ancestorConfig struct {

--- a/internal/framework/kinds/kinds.go
+++ b/internal/framework/kinds/kinds.go
@@ -21,6 +21,8 @@ const (
 	GRPCRoute = "GRPCRoute"
 	// TLSRoute is the TLSRoute kind.
 	TLSRoute = "TLSRoute"
+	// BackendTLSPolicy is the BackendTLSPolicy kind.
+	BackendTLSPolicy = "BackendTLSPolicy"
 )
 
 // Core API Kinds.


### PR DESCRIPTION
### Proposed changes

Problem: Multiple bugs when ancestor slice was full:
- BackendTLSPolicy became invalid
- NGF Policies would not partially attach policies to services when multiple ancestor refs were created from a single service but attach to the whole service
- No condition was added to ancestor 
- No logs on controller

Solution: Added conditions to ancestor and logs to controller. I fixed BackendTLSPolicy to add attachments until ancestors became full and fixed NGF policies as well

Testing: Currently unit tests and manual tested

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1987

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
