### PR TITLE
Add OverlappingTLSConfig condition

### DIFF
--- a/internal/controller/state/graph/gateway_listener_test.go
+++ b/internal/controller/state/graph/gateway_listener_test.go
@@ -865,6 +865,38 @@ func TestOverlappingTLSConfigCondition(t *testing.T) {
 			},
 			expectedCondition: false,
 		},
+		{
+			name: "no overlap - HTTP and HTTPS listeners with same hostname and port",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     80,
+							Protocol: v1.HTTPProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+						},
+						{
+							Name:     "listener2",
+							Port:     80,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/controller/state/graph/gateway_listener_test.go
+++ b/internal/controller/state/graph/gateway_listener_test.go
@@ -637,3 +637,279 @@ func TestValidateTLSFieldOnTLSListener(t *testing.T) {
 		})
 	}
 }
+
+func TestOverlappingTLSConfigCondition(t *testing.T) {
+	t.Parallel()
+
+	protectedPorts := ProtectedPorts{9113: "MetricsPort"}
+
+	tests := []struct {
+		gateway           *v1.Gateway
+		name              string
+		conditionReason   v1.ListenerConditionReason
+		expectedCondition bool
+	}{
+		{
+			name: "overlapping hostnames on same port",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("*.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+						{
+							Name:     "listener2",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: true,
+			conditionReason:   v1.ListenerReasonOverlappingHostnames,
+		},
+		{
+			name: "no overlap - different ports",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("*.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+						{
+							Name:     "listener2",
+							Port:     8443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: false,
+		},
+		{
+			name: "no overlap - different hostnames same port",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+						{
+							Name:     "listener2",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("cafe.example.org"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: false,
+		},
+		{
+			name: "overlap between HTTPS and TLS listeners",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("*.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+						{
+							Name:     "listener2",
+							Port:     443,
+							Protocol: v1.TLSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModePassthrough),
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: true,
+			conditionReason:   v1.ListenerReasonOverlappingHostnames,
+		},
+		{
+			name: "overlap with nil hostnames",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: nil, // nil hostname matches everything
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret1"},
+								},
+							},
+						},
+						{
+							Name:     "listener2",
+							Port:     443,
+							Protocol: v1.HTTPSProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+							TLS: &v1.GatewayTLSConfig{
+								Mode: helpers.GetPointer(v1.TLSModeTerminate),
+								CertificateRefs: []v1.SecretObjectReference{
+									{Name: "secret2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: true,
+			conditionReason:   v1.ListenerReasonOverlappingHostnames,
+		},
+		{
+			name: "no overlap - HTTP listener excluded",
+			gateway: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "test-ns",
+				},
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "listener1",
+							Port:     80,
+							Protocol: v1.HTTPProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("*.example.com"),
+						},
+						{
+							Name:     "listener2",
+							Port:     80,
+							Protocol: v1.HTTPProtocolType,
+							Hostname: helpers.GetPointer[v1.Hostname]("app.example.com"),
+						},
+					},
+				},
+			},
+			expectedCondition: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			// Create mock resolvers
+			secretResolver := newSecretResolver(nil)
+			refGrantResolver := newReferenceGrantResolver(nil)
+
+			// Build listeners
+			listeners := buildListeners(test.gateway, secretResolver, refGrantResolver, protectedPorts)
+
+			if test.expectedCondition {
+				// Check that the expected listeners have the OverlappingTLSConfig condition
+				listenersWithCondition := 0
+				for _, listener := range listeners {
+					found := false
+					for _, cond := range listener.Conditions {
+						if cond.Type == string(v1.ListenerConditionOverlappingTLSConfig) {
+							g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+							g.Expect(cond.Reason).To(Equal(string(test.conditionReason)))
+							found = true
+							break
+						}
+					}
+					if found {
+						listenersWithCondition++
+					}
+				}
+				// At least 2 listeners should have the condition when there's overlap
+				g.Expect(listenersWithCondition).To(
+					BeNumerically(">=", 2),
+					"at least 2 listeners should have OverlappingTLSConfig condition",
+				)
+			} else {
+				// No listener should have the OverlappingTLSConfig condition
+				for i, listener := range listeners {
+					for _, cond := range listener.Conditions {
+						g.Expect(cond.Type).ToNot(Equal(string(v1.ListenerConditionOverlappingTLSConfig)),
+							"listener %d should not have OverlappingTLSConfig condition", i)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/state/graph/gateway_test.go
+++ b/internal/controller/state/graph/gateway_test.go
@@ -1250,7 +1250,13 @@ func TestBuildGateway(t *testing.T) {
 							Attachable:  true,
 							Routes:      map[RouteKey]*L7Route{},
 							L4Routes:    map[L4RouteKey]*L4Route{},
-							Conditions:  conditions.NewListenerHostnameConflict(conflict443HostnameMsg),
+							Conditions: append(
+								conditions.NewListenerHostnameConflict(conflict443HostnameMsg),
+								conditions.NewListenerOverlappingTLSConfig(
+									v1.ListenerReasonOverlappingHostnames,
+									"Listener hostname overlaps with hostname(s) of other Listener(s) on the same port",
+								),
+							),
 							SupportedKinds: []v1.RouteGroupKind{
 								{Kind: kinds.TLSRoute, Group: helpers.GetPointer[v1.Group](v1.GroupName)},
 							},
@@ -1264,7 +1270,13 @@ func TestBuildGateway(t *testing.T) {
 							ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
 							Routes:         map[RouteKey]*L7Route{},
 							L4Routes:       map[L4RouteKey]*L4Route{},
-							Conditions:     conditions.NewListenerHostnameConflict(conflict443HostnameMsg),
+							Conditions: append(
+								conditions.NewListenerHostnameConflict(conflict443HostnameMsg),
+								conditions.NewListenerOverlappingTLSConfig(
+									v1.ListenerReasonOverlappingHostnames,
+									"Listener hostname overlaps with hostname(s) of other Listener(s) on the same port",
+								),
+							),
 							SupportedKinds: supportedKindsForListeners,
 						},
 					},

--- a/internal/controller/status/prepare_requests.go
+++ b/internal/controller/status/prepare_requests.go
@@ -283,13 +283,11 @@ func prepareGatewayRequest(
 
 	validListenerCount := 0
 	for _, l := range gateway.Listeners {
-		var conds []conditions.Condition
+		conds := l.Conditions
 
 		if l.Valid {
-			conds = conditions.NewDefaultListenerConditions()
+			conds = append(conds, conditions.NewDefaultListenerConditions(conds)...)
 			validListenerCount++
-		} else {
-			conds = l.Conditions
 		}
 
 		if nginxReloadRes.Error != nil {


### PR DESCRIPTION
### Proposed changes

Problem: Currently, our controller does not set the OverlappingTLSConfig condition on Listeners when overlapping TLS configuration is detected (e.g., overlapping hostnames or certificates on the same port). This means users are not warned about potentially conflicting TLS configurations, which can lead to confusing runtime behavior, especially with HTTP connection coalescing.

Solution: Implement logic to detect overlapping TLS hostnames between Listeners on the same port, and set the OverlappingTLSConfig condition with the reason OverlappingHostnames on all affected Listeners, as required by the Gateway API spec. OverlappingCertificates is not being implemented as it is optional, and is far too complicated (we would have to inspect the Certificate itself)

Testing: Manually tested creating Gateways with various overlapping conditions

Closes #3696 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Implemented logic to detect overlapping TLS hostnames between Listeners on the same port, and set the OverlappingTLSConfig condition with the reason OverlappingHostnames on all affected Listeners
```
