### PR TITLE
add test for missing numerator case

### DIFF
--- a/internal/controller/state/dataplane/convert_test.go
+++ b/internal/controller/state/dataplane/convert_test.go
@@ -397,7 +397,25 @@ func TestConvertHTTPMirrorFilter(t *testing.T) {
 				Target:    helpers.GetPointer("/_ngf-internal-mirror-namespace/backend-test/route1-0"),
 				Percent:   helpers.GetPointer(float64(100)),
 			},
-			name: "numerator equals denominator",
+			name: "100% mirroring if numerator equals denominator",
+		},
+		{
+			filter: &v1.HTTPRequestMirrorFilter{
+				BackendRef: v1.BackendObjectReference{
+					Name:      "backend",
+					Namespace: helpers.GetPointer[v1.Namespace]("namespace"),
+				},
+				Fraction: &v1.Fraction{
+					Denominator: helpers.GetPointer(int32(2)),
+				},
+			},
+			expected: &HTTPRequestMirrorFilter{
+				Name:      helpers.GetPointer("backend"),
+				Namespace: helpers.GetPointer("namespace"),
+				Target:    helpers.GetPointer("/_ngf-internal-mirror-namespace/backend-test/route1-0"),
+				Percent:   helpers.GetPointer(float64(0)),
+			},
+			name: "0% mirroring if numerator is not specified",
 		},
 		{
 			filter: &v1.HTTPRequestMirrorFilter{


### PR DESCRIPTION
### Proposed changes

Noticed that there is no test for mirroring with Faction setting when Numerator is not specified, as i understand this case is valid and we expect 0% mirroring

Closes #[ISSUE](https://github.com/nginx/k8s-dev/issues/110)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
NONE
```