### PR TITLE
Chore: Use F5 artifactory GOPROXY and self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       packages: write # for docker/build-push-action to push to GHCR
       id-token: write # for docker/login to login to NGINX registry
-    runs-on: ${{ github.event_name != 'pull_request' && contains(inputs.image, 'plus') && 'kic-plus' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'nginx' && (github.ref_type == 'tag' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
     services:
       registry:
         image: registry:3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GOPROXY: ${{ github.repository_owner == 'nginx' && format('https://{0}:{1}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev', secrets.ARTIFACTORY_USER, secrets.ARTIFACTORY_TOKEN) || 'direct' }}
+
 concurrency:
   group: ${{ github.ref_name }}-ci
   cancel-in-progress: true
@@ -128,7 +131,7 @@ jobs:
 
   binary:
     name: Build Binary
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'nginx' && (github.ref_type == 'tag' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
     needs: [vars, unit-tests, njs-unit-tests]
     permissions:
       contents: write # for goreleaser/goreleaser-action and lucacome/draft-release to create/update releases
@@ -147,6 +150,12 @@ jobs:
           cache-dependency-path: |
             go.sum
             .github/.cache/buster-for-binary
+
+      - name: Set Go module cache
+        run: |
+          mkdir -p ${{ github.workspace }}/.gocache
+          echo "GOMODCACHE=${{ github.workspace }}/.gocache" >> $GITHUB_ENV
+          echo "GOCACHE=${{ github.workspace }}/.gocache" >> $GITHUB_ENV
 
       - name: Create/Update Draft
         uses: lucacome/draft-release@00f74370c044c322da6cb52acc707d62c7762c71 # v1.2.4
@@ -285,7 +294,7 @@ jobs:
 
   publish-helm:
     name: Package and Publish Helm Chart
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'nginx' && (github.ref_type == 'tag' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
     needs: [vars, helm-tests]
     if: ${{ github.event_name == 'push' && ! startsWith(github.ref, 'refs/heads/release-') }}
     permissions:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -20,6 +20,7 @@ defaults:
 env:
   PLUS_USAGE_ENDPOINT: ${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}
   ENABLE_EXPERIMENTAL: ${{ inputs.enable-experimental }}
+  GOPROXY: ${{ github.repository_owner == 'nginx' && format('https://{0}:{1}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev', secrets.ARTIFACTORY_USER, secrets.ARTIFACTORY_TOKEN) || 'direct' }}
 
 permissions:
   contents: read

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -16,6 +16,7 @@ defaults:
 
 env:
   PLUS_USAGE_ENDPOINT: ${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}
+  GOPROXY: ${{ github.repository_owner == 'nginx' && format('https://{0}:{1}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev', secrets.ARTIFACTORY_USER, secrets.ARTIFACTORY_TOKEN) || 'direct' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GOPROXY: ${{ github.repository_owner == 'nginx' && format('https://{0}:{1}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev', secrets.ARTIFACTORY_USER, secrets.ARTIFACTORY_TOKEN) || 'direct' }}
+
 concurrency:
   group: ${{ github.ref_name }}-lint
   cancel-in-progress: true

--- a/.github/workflows/renovate-build.yml
+++ b/.github/workflows/renovate-build.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GOPROXY: ${{ github.repository_owner == 'nginx' && format('https://{0}:{1}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev', secrets.ARTIFACTORY_USER, secrets.ARTIFACTORY_TOKEN) || 'direct' }}
+
 concurrency:
   group: ${{ github.ref_name }}-renovate
   cancel-in-progress: true


### PR DESCRIPTION
### Proposed changes

- Use F5 Artifactory goproxy for all CI runs that do not originate from forks
- Use self hosted runners for jobs that produce artifacts (so on builds from main and tags)

Testing: https://github.com/nginx/nginx-gateway-fabric/actions/runs/16878757544 (the relevant jobs are the build binary and images jobs, the failed test jobs can be ignored - I had to make temp changes to test the runners work correctly)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
