### PR TITLE
Cherry-pick: Update NGINX Plus version to R35

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following table lists the software versions NGINX Gateway Fabric supports.
 
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent |
 |----------------------|-------------|------------|-----------|------------|-------------|
-| Edge                 | 1.3.0       | 1.25+      | 1.29.0    | R34        | v3.2.0      |
+| Edge                 | 1.3.0       | 1.25+      | 1.29.0    | R35        | v3.2.0      |
 | 2.0.2                | 1.3.0       | 1.25+      | 1.28.0    | R34        | v3.0.1      |
 | 2.0.1                | 1.3.0       | 1.25+      | 1.28.0    | R34        | v3.0.1      |
 | 2.0.0                | 1.3.0       | 1.25+      | 1.28.0    | R34        | v3.0.0      |

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -4,9 +4,9 @@ FROM scratch AS nginx-files
 # the following links can be replaced with local files if needed, i.e. ADD --chown=101:1001 <local_file> <container_file>
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
 
-FROM alpine:3.21
+FROM alpine:3.22
 
-ARG NGINX_PLUS_VERSION=R34
+ARG NGINX_PLUS_VERSION=R35
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.2.0
 ARG NJS_DIR


### PR DESCRIPTION
Cherry-pick for [PR](https://github.com/nginx/nginx-gateway-fabric/pull/3726) into release 2.1