### PR TITLE
fix: remove patch label/ annotation cross contamination

### DIFF
--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -152,13 +152,28 @@ func (p *NginxProvisioner) buildNginxResourceObjects(
 		ports[int32(listener.Port)] = struct{}{}
 	}
 
-	service, err := buildNginxService(objectMeta, nProxyCfg, ports, selectorLabels)
+	// Create separate copies of objectMeta for service and deployment to avoid shared map references
+	serviceObjectMeta := metav1.ObjectMeta{
+		Name:        objectMeta.Name,
+		Namespace:   objectMeta.Namespace,
+		Labels:      maps.Clone(objectMeta.Labels),
+		Annotations: maps.Clone(objectMeta.Annotations),
+	}
+
+	deploymentObjectMeta := metav1.ObjectMeta{
+		Name:        objectMeta.Name,
+		Namespace:   objectMeta.Namespace,
+		Labels:      maps.Clone(objectMeta.Labels),
+		Annotations: maps.Clone(objectMeta.Annotations),
+	}
+
+	service, err := buildNginxService(serviceObjectMeta, nProxyCfg, ports, selectorLabels)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
 	deployment, err := p.buildNginxDeployment(
-		objectMeta,
+		deploymentObjectMeta,
 		nProxyCfg,
 		ngxIncludesConfigMapName,
 		ngxAgentConfigMapName,


### PR DESCRIPTION
### Proposed changes

Problem: Patching the Service object labels and annotations results in the Deployment also getting these labels and annotations, and vice versa, which is unexpected behavior.

Solution: Create separate copies of the base label and annotation maps for each object. Since maps are passed by reference in Go, modifying the labels for one object was affecting the other by updating the shared reference.

Testing: Manual testing and unit testing

Closes #3721 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed an issue where NginxProxy patches applied to one resource type (Service/Deployment/DaemonSet) would unintentionally modify other resource types.```
