### PR TITLE
Adjust nginx agent backoff settings (#3820)

### DIFF
--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -89,4 +89,13 @@ collector:
             "ngf":
                 receivers: ["host_metrics", "nginx_metrics"]
                 exporters: ["prometheus"]
-{{- end }}`
+{{- end }}
+data_plane_config:
+    nginx:
+        reload_backoff:
+            initial_interval: .5s
+            max_interval: 1.5s
+            max_elapsed_time: 3s
+            randomization_factor: 0.5
+            multiplier: 1.5
+`


### PR DESCRIPTION
Cherry-pick #3820 

Problem: As a result to NGINX Agent adding a wait for nginx workers to reload before updating nginx configuration, any long-lived connections would result in an excessively long wait between updating nginx configurations. This cause delays in NGF and on NGINX Plus, could cause a dropping of traffic if there was a wait between updating the configuration and updating the NGINX Plus upstreams.

Solution: Adjust the NGINX Agent reload configuration to lower the maximum wait time. Reverted the test request timeout duration back to 10 seconds. 

Testing: Ran the SnippetsFilter functional test a couple of times and verified when there was a long-lived connection blocking on of the test cases, it went from a 27 second timeout -> 3 second. Also deployed nginx and verified the agent configuration was in there. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
