### PR TITLE
Improve connection reset handling during ServiceAccountToken rotation

### DIFF
--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -66,7 +66,8 @@ func TestUpdateConfig(t *testing.T) {
 			updater.UpdateConfig(deployment, []File{file})
 
 			g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
-			g.Expect(deployment.GetFile(file.Meta.Name, file.Meta.Hash)).To(Equal(file.Contents))
+			fileContents, _ := deployment.GetFile(file.Meta.Name, file.Meta.Hash)
+			g.Expect(fileContents).To(Equal(file.Contents))
 
 			if test.expErr {
 				g.Expect(deployment.GetLatestConfigError()).To(Equal(testErr))

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -161,14 +161,18 @@ func (d *Deployment) GetNGINXPlusActions() []*pb.NGINXPlusAction {
 
 // GetFile gets the requested file for the deployment and returns its contents.
 // The deployment FileLock MUST already be locked before calling this function.
-func (d *Deployment) GetFile(name, hash string) []byte {
+func (d *Deployment) GetFile(name, hash string) ([]byte, string) {
+	var fileFoundHash string
 	for _, file := range d.files {
-		if name == file.Meta.GetName() && hash == file.Meta.GetHash() {
-			return file.Contents
+		if name == file.Meta.GetName() {
+			fileFoundHash = file.Meta.GetHash()
+			if hash == file.Meta.GetHash() {
+				return file.Contents, file.Meta.GetHash()
+			}
 		}
 	}
 
-	return nil
+	return nil, fileFoundHash
 }
 
 // SetFiles updates the nginx files and fileOverviews for the deployment and returns the message to send.

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -52,11 +52,13 @@ func TestSetAndGetFiles(t *testing.T) {
 	g.Expect(msg.FileOverviews).To(HaveLen(9)) // 1 file + 8 ignored files
 	g.Expect(fileOverviews).To(Equal(msg.FileOverviews))
 
-	file := deployment.GetFile("test.conf", "12345")
+	file, _ := deployment.GetFile("test.conf", "12345")
 	g.Expect(file).To(Equal([]byte("test content")))
 
-	g.Expect(deployment.GetFile("invalid", "12345")).To(BeNil())
-	g.Expect(deployment.GetFile("test.conf", "invalid")).To(BeNil())
+	invalidFile, _ := deployment.GetFile("invalid", "12345")
+	g.Expect(invalidFile).To(BeNil())
+	wrongHashFile, _ := deployment.GetFile("test.conf", "invalid")
+	g.Expect(wrongHashFile).To(BeNil())
 
 	// Set the same files again
 	msg = deployment.SetFiles(files)

--- a/internal/controller/nginx/agent/file.go
+++ b/internal/controller/nginx/agent/file.go
@@ -143,12 +143,22 @@ func (fs *fileService) getFileContents(req *pb.GetFileRequest, connKey string) (
 	}
 
 	filename := req.GetFileMeta().GetName()
-	contents := deployment.GetFile(filename, req.GetFileMeta().GetHash())
+	contents, fileFoundHash := deployment.GetFile(filename, req.GetFileMeta().GetHash())
 	if len(contents) == 0 {
+		fs.logger.V(1).Info("Error getting file for agent", "file", filename)
+		if fileFoundHash != "" {
+			fs.logger.V(1).Info(
+				"File found had wrong hash",
+				"hashWanted",
+				req.GetFileMeta().GetHash(),
+				"hashFound",
+				fileFoundHash,
+			)
+		}
 		return nil, status.Errorf(codes.NotFound, "file not found")
 	}
 
-	fs.logger.V(1).Info("Getting file for agent", "file", filename)
+	fs.logger.V(1).Info("Getting file for agent", "file", filename, "fileHash", fileFoundHash)
 
 	return contents, nil
 }


### PR DESCRIPTION
### Proposed changes

Problem: During ServiceAccountToken rotation, nginx-gateway-fabric was sometimes experiencing deadlocks due to the Subscribe method incorrectly intercepting initial configuration operations after a ServiceAccountToken rotation and incorrect signaling broadcast completion

Solution: Implemented a `pendingRequest` tracking mechanism to distinguish between initial setup operations and broadcast operations:
- Initial config operations: Do not signal `ResponseCh` (prevents spurious broadcast signals)
- Broadcast operations: Only signal `ResponseCh` when there's a pending broadcast request

Also added additional logging to improve debugging

Testing: Updated unit tests, existing functional and conformance tests pass, and reran longevity (with the corresponding Agent fixes) which now works

Partially closes #3626 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed a bug where the subscribe method was incorrectly intercepting initial configuration operations after a ServiceAccountToken rotation and signaling broadcast completion
```
