### PR TITLE
Improve connection reset handling during ServiceAccountToken rotation…

### DIFF
--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -66,7 +66,8 @@ func TestUpdateConfig(t *testing.T) {
 			updater.UpdateConfig(deployment, []File{file})
 
 			g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
-			g.Expect(deployment.GetFile(file.Meta.Name, file.Meta.Hash)).To(Equal(file.Contents))
+			fileContents, _ := deployment.GetFile(file.Meta.Name, file.Meta.Hash)
+			g.Expect(fileContents).To(Equal(file.Contents))
 
 			if test.expErr {
 				g.Expect(deployment.GetLatestConfigError()).To(Equal(testErr))

--- a/internal/controller/nginx/agent/command.go
+++ b/internal/controller/nginx/agent/command.go
@@ -155,6 +155,8 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 	channels := broadcaster.Subscribe()
 	defer broadcaster.CancelSubscription(channels.ID)
 
+	var pendingBroadcastRequest *broadcast.NginxAgentMessage
+
 	for {
 		// When a message is received over the ListenCh, it is assumed and required that the
 		// deployment object is already LOCKED. This lock is acquired by the event handler before calling
@@ -191,12 +193,19 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 
 				return grpcStatus.Error(codes.Internal, err.Error())
 			}
+
+			// Track this broadcast request to distinguish it from initial config operations.
+			// Only broadcast operations should signal ResponseCh for coordination.
+			pendingBroadcastRequest = &msg
 		case err = <-msgr.Errors():
 			cs.logger.Error(err, "connection error", "pod", conn.PodName)
 			deployment.SetPodErrorStatus(conn.PodName, err)
 			select {
 			case channels.ResponseCh <- struct{}{}:
 			default:
+			}
+			if pendingBroadcastRequest != nil {
+				cs.logger.V(1).Info("Connection error during pending request, operation failed")
 			}
 
 			if errors.Is(err, io.EOF) {
@@ -215,7 +224,15 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 			} else {
 				deployment.SetPodErrorStatus(conn.PodName, nil)
 			}
-			channels.ResponseCh <- struct{}{}
+
+			// Signal broadcast completion only for tracked broadcast operations.
+			// Initial config responses are ignored to prevent spurious success messages.
+			if pendingBroadcastRequest != nil {
+				pendingBroadcastRequest = nil
+				channels.ResponseCh <- struct{}{}
+			} else {
+				cs.logger.V(1).Info("Received response for non-broadcast request (likely initial config)", "pod", conn.PodName)
+			}
 		}
 	}
 }
@@ -265,6 +282,9 @@ func (cs *commandService) setInitialConfig(
 	defer deployment.FileLock.Unlock()
 
 	fileOverviews, configVersion := deployment.GetFileOverviews()
+
+	cs.logger.Info("Sending initial configuration to agent", "pod", conn.PodName, "configVersion", configVersion)
+
 	if err := msgr.Send(ctx, buildRequest(fileOverviews, conn.InstanceID, configVersion)); err != nil {
 		cs.logAndSendErrorStatus(deployment, conn, err)
 
@@ -348,9 +368,11 @@ func (cs *commandService) waitForInitialConfigApply(
 			res := msg.GetCommandResponse()
 			if res.GetStatus() != pb.CommandResponse_COMMAND_STATUS_OK {
 				applyErr := fmt.Errorf("msg: %s; error: %s", res.GetMessage(), res.GetError())
+				cs.logger.V(1).Info("Received initial config response with error", "error", applyErr)
 				return applyErr, nil
 			}
 
+			cs.logger.V(1).Info("Received successful initial config response")
 			return applyErr, connectionErr
 		}
 	}

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -161,14 +161,18 @@ func (d *Deployment) GetNGINXPlusActions() []*pb.NGINXPlusAction {
 
 // GetFile gets the requested file for the deployment and returns its contents.
 // The deployment FileLock MUST already be locked before calling this function.
-func (d *Deployment) GetFile(name, hash string) []byte {
+func (d *Deployment) GetFile(name, hash string) ([]byte, string) {
+	var fileFoundHash string
 	for _, file := range d.files {
-		if name == file.Meta.GetName() && hash == file.Meta.GetHash() {
-			return file.Contents
+		if name == file.Meta.GetName() {
+			fileFoundHash = file.Meta.GetHash()
+			if hash == file.Meta.GetHash() {
+				return file.Contents, file.Meta.GetHash()
+			}
 		}
 	}
 
-	return nil
+	return nil, fileFoundHash
 }
 
 // SetFiles updates the nginx files and fileOverviews for the deployment and returns the message to send.

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -52,11 +52,13 @@ func TestSetAndGetFiles(t *testing.T) {
 	g.Expect(msg.FileOverviews).To(HaveLen(9)) // 1 file + 8 ignored files
 	g.Expect(fileOverviews).To(Equal(msg.FileOverviews))
 
-	file := deployment.GetFile("test.conf", "12345")
+	file, _ := deployment.GetFile("test.conf", "12345")
 	g.Expect(file).To(Equal([]byte("test content")))
 
-	g.Expect(deployment.GetFile("invalid", "12345")).To(BeNil())
-	g.Expect(deployment.GetFile("test.conf", "invalid")).To(BeNil())
+	invalidFile, _ := deployment.GetFile("invalid", "12345")
+	g.Expect(invalidFile).To(BeNil())
+	wrongHashFile, _ := deployment.GetFile("test.conf", "invalid")
+	g.Expect(wrongHashFile).To(BeNil())
 
 	// Set the same files again
 	msg = deployment.SetFiles(files)

--- a/internal/controller/nginx/agent/file.go
+++ b/internal/controller/nginx/agent/file.go
@@ -143,12 +143,22 @@ func (fs *fileService) getFileContents(req *pb.GetFileRequest, connKey string) (
 	}
 
 	filename := req.GetFileMeta().GetName()
-	contents := deployment.GetFile(filename, req.GetFileMeta().GetHash())
+	contents, fileFoundHash := deployment.GetFile(filename, req.GetFileMeta().GetHash())
 	if len(contents) == 0 {
+		fs.logger.V(1).Info("Error getting file for agent", "file", filename)
+		if fileFoundHash != "" {
+			fs.logger.V(1).Info(
+				"File found had wrong hash",
+				"hashWanted",
+				req.GetFileMeta().GetHash(),
+				"hashFound",
+				fileFoundHash,
+			)
+		}
 		return nil, status.Errorf(codes.NotFound, "file not found")
 	}
 
-	fs.logger.V(1).Info("Getting file for agent", "file", filename)
+	fs.logger.V(1).Info("Getting file for agent", "file", filename, "fileHash", fileFoundHash)
 
 	return contents, nil
 }


### PR DESCRIPTION
### Proposed changes

Cherry-picked from #3905

Problem: During ServiceAccountToken rotation, nginx-gateway-fabric was sometimes experiencing deadlocks due to the Subscribe method incorrectly intercepting initial configuration operations after a ServiceAccountToken rotation and incorrect signaling broadcast completion

Solution: Implemented a pendingRequest tracking mechanism to distinguish between initial setup operations and broadcast operations.
Testing: Describe any testing that you did.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed a bug where the subscribe method was incorrectly intercepting initial configuration operations after a ServiceAccountToken rotation and signaling broadcast completion
```
