### PR TITLE
Remove false condition on Routes when nginx reload fails

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -338,7 +338,6 @@ func (h *eventHandlerImpl) updateStatuses(ctx context.Context, gr *graph.Graph, 
 		gr.L4Routes,
 		gr.Routes,
 		transitionTime,
-		gw.LatestReloadResult,
 		h.cfg.gatewayCtlrName,
 	)
 

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -49,10 +49,6 @@ const (
 	// as another route.
 	RouteReasonHostnameConflict v1.RouteConditionReason = "HostnameConflict"
 
-	// RouteReasonGatewayNotProgrammed is used when the associated Gateway is not programmed.
-	// Used with Accepted (false).
-	RouteReasonGatewayNotProgrammed v1.RouteConditionReason = "GatewayNotProgrammed"
-
 	// RouteReasonUnsupportedConfiguration is used when the associated Gateway does not support the Route.
 	// Used with Accepted (false).
 	RouteReasonUnsupportedConfiguration v1.RouteConditionReason = "UnsupportedConfiguration"
@@ -489,17 +485,6 @@ func NewRouteUnsupportedConfiguration(msg string) Condition {
 		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(RouteReasonUnsupportedConfiguration),
-		Message: msg,
-	}
-}
-
-// NewRouteGatewayNotProgrammed returns a Condition that indicates that the Gateway it references is not programmed,
-// which does not guarantee that the Route has been configured.
-func NewRouteGatewayNotProgrammed(msg string) Condition {
-	return Condition{
-		Type:    string(v1.RouteConditionAccepted),
-		Status:  metav1.ConditionFalse,
-		Reason:  string(RouteReasonGatewayNotProgrammed),
 		Message: msg,
 	}
 }

--- a/internal/controller/status/prepare_requests.go
+++ b/internal/controller/status/prepare_requests.go
@@ -28,7 +28,6 @@ func PrepareRouteRequests(
 	l4routes map[graph.L4RouteKey]*graph.L4Route,
 	routes map[graph.RouteKey]*graph.L7Route,
 	transitionTime metav1.Time,
-	nginxReloadRes graph.NginxReloadResult,
 	gatewayCtlrName string,
 ) []UpdateRequest {
 	reqs := make([]UpdateRequest, 0, len(routes))
@@ -38,7 +37,6 @@ func PrepareRouteRequests(
 			gatewayCtlrName,
 			r.ParentRefs,
 			r.Conditions,
-			nginxReloadRes,
 			transitionTime,
 			r.Source.GetGeneration(),
 		)
@@ -61,7 +59,6 @@ func PrepareRouteRequests(
 			gatewayCtlrName,
 			r.ParentRefs,
 			r.Conditions,
-			nginxReloadRes,
 			transitionTime,
 			r.Source.GetGeneration(),
 		)
@@ -140,7 +137,6 @@ func prepareRouteStatus(
 	gatewayCtlrName string,
 	parentRefs []graph.ParentRef,
 	conds []conditions.Condition,
-	nginxReloadRes graph.NginxReloadResult,
 	transitionTime metav1.Time,
 	srcGeneration int64,
 ) v1.RouteStatus {
@@ -167,13 +163,6 @@ func prepareRouteStatus(
 		allConds = append(allConds, conds...)
 		if failedAttachmentCondCount > 0 {
 			allConds = append(allConds, ref.Attachment.FailedConditions...)
-		}
-
-		if nginxReloadRes.Error != nil {
-			allConds = append(
-				allConds,
-				conditions.NewRouteGatewayNotProgrammed(conditions.RouteMessageFailedNginxReload),
-			)
 		}
 
 		conds := conditions.DeduplicateConditions(allConds)


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: When nginx reload fails, all routes are marked invalid

Solution: Remove adding `GatewayNotProgrammed` condition to routes since the error should only be reflected on Gateway Listener conditions

Testing: manual tests and unit tests

Tested with  external name svc example where i have a route attached to invalid snippet filter and one route attached to valid snippet filter

Both have accepted condition: true on them but Gateway is not programmed for both listeners

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: external-gateway
spec:
  gatewayClassName: nginx
  infrastructure:
    parametersRef:
      group: gateway.nginx.org
      kind: NginxProxy
      name: external-nginx-config
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: All
  - name: tls
    port: 443
    protocol: TLS
    tls:
      mode: Passthrough
    allowedRoutes:
      namespaces:
        from: All
---
apiVersion: gateway.nginx.org/v1alpha1
kind: SnippetsFilter
metadata:
  name: rate-limiting-sf
spec:
  snippets:
    - context: http
      value: limit_req_zone;
```

Gateway condition

```
    Last Transition Time:  2025-09-18T17:57:53Z
    Message:               Gateway is accepted
    Observed Generation:   1
    Reason:                Accepted
    Status:                True
    Type:                  Accepted
    Last Transition Time:  2025-09-18T17:57:53Z
    Message:               ParametersRef resource is resolved
    Observed Generation:   1
    Reason:                ResolvedRefs
    Status:                True
    Type:                  ResolvedRefs
    Last Transition Time:  2025-09-18T17:57:53Z
    Message:               The Gateway is not programmed due to a failure to reload nginx with the configuration: msg: Config apply failed, rolling back config; error: failed to parse config invalid number of arguments in "limit_req_zone" directive in /etc/nginx/includes/SnippetsFilter_http_default_rate-limiting-sf.conf:1
    Observed Generation:   1
    Reason:                Invalid
    Status:                False
    Type:                  Programmed
```

NOTE: The route attached is configured to TRUE and ACCEPTED but not configured due to reload failures. 


Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #3866

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Removed GatewayNotProgammed condition on Routes when NGINX reload failures happen. 
```
