### PR TITLE
Revert agent reload backoff settings

### DIFF
--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -90,12 +90,4 @@ collector:
                 receivers: ["host_metrics", "nginx_metrics"]
                 exporters: ["prometheus"]
 {{- end }}
-data_plane_config:
-    nginx:
-        reload_backoff:
-            initial_interval: .5s
-            max_interval: 1.5s
-            max_elapsed_time: 3s
-            randomization_factor: 0.5
-            multiplier: 1.5
 `


### PR DESCRIPTION
Revert changes to agent reload backoff settings due to a fix added in Agent v3.3.1. 

Tested SnippetsFilter Functional on NGINX Plus test to ensure changes work.