### PR TITLE
Move certs job service account token (#3951)

### DIFF
--- a/charts/nginx-gateway-fabric/templates/certs-job.yaml
+++ b/charts/nginx-gateway-fabric/templates/certs-job.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+automountServiceAccountToken: false
 {{- if or .Values.nginxGateway.serviceAccount.imagePullSecret .Values.nginxGateway.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- if .Values.nginxGateway.serviceAccount.imagePullSecret }}
@@ -120,6 +121,7 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -341,6 +342,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -339,6 +340,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -347,6 +348,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -344,6 +345,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -342,6 +343,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -339,6 +340,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -361,6 +362,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/snippets-filters-nginx-plus/deploy.yaml
+++ b/deploy/snippets-filters-nginx-plus/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -345,6 +346,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs

--- a/deploy/snippets-filters/deploy.yaml
+++ b/deploy/snippets-filters/deploy.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
@@ -342,6 +343,7 @@ spec:
     metadata:
       annotations: null
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - generate-certs


### PR DESCRIPTION
Cherrypick of #3951 

Problem: For security reasons, it's best practice to not have automountServiceToken on the ServiceAccount, and instead set in directly on the workloads that need the token.

Solution: Set this field on the Pods instead of the ServiceAccounts.

This was missed as part of the original PR.
