### PR TITLE
Update docs for Release 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ This document includes a curated changelog for each release. We also publish a c
 a [GitHub release](https://github.com/nginx/nginx-gateway-fabric/releases), which, by contrast, is auto-generated
 and includes links to all PRs that went into the release.
 
+## Release 2.1.2
+
+_September 25, 2025_
+
+BUG FIXES:
+
+- Fixes a bug where the subscribe method was incorrectly intercepting initial configuration operations after a ServiceAccountToken rotation and signaling broadcast completion. [3905](https://github.com/nginx/nginx-gateway-fabric/pull/3905)
+- Fixes an issue where a failed configuration reload caused all HTTPRoutes to be marked as invalid (Accepted: false). This led to external-dns removing DNS records even though the configuration had been rolled back. Routes now retain their valid state during reload failures, preventing unnecessary DNS disruptions. [3936](https://github.com/nginx/nginx-gateway-fabric/pull/3936)
+- Adds NGINX image version validation during agent connections to prevent newer config being sent to pods running previous image versions during upgrades. [3928](https://github.com/nginx/nginx-gateway-fabric/pull/3928)
+
+NGINX AGENT BUG FIXES:
+
+- The NGINX Agent v3.3.1 update fixes connection reset issues during config apply by reusing existing connections, adds rollback on failures, and improves logging for more reliable configuration updates. [1261](https://github.com/nginx/agent/pull/1261)
+
+HELM CHART:
+
+- The version of the Helm chart is now 2.1.2
+
+COMPATIBILITY:
+
+- Gateway API version: `1.3.0`
+- NGINX version: `1.29.1`
+- NGINX Plus version: `R35`
+- NGINX Agent version: `v3.3.1`
+- Kubernetes version: `1.25+`
+
+CONTAINER IMAGES:
+
+- Control plane: `ghcr.io/nginx/nginx-gateway-fabric:2.1.2`
+- Data plane: `ghcr.io/nginx/nginx-gateway-fabric/nginx:2.1.2`
+- Data plane with NGINX Plus: `private-registry.nginx.com/nginx-gateway-fabric/nginx-plus:2.1.2`
+
 ## Release 2.1.1
 
 _September 3, 2025_

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following table lists the software versions NGINX Gateway Fabric supports.
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent |
 |----------------------|-------------|------------|-----------|------------|-------------|
 | Edge                 | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.3.1      |
-| 2.1.2.               | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.3.1      |
+| 2.1.2               | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.3.1      |
 | 2.1.1                | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.2.1      |
 | 2.1.0                | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.2.1      |
 | 2.0.2                | 1.3.0       | 1.25+      | 1.28.0    | R34        | v3.0.1      |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can find the comprehensive NGINX Gateway Fabric user documentation on the [N
 We publish NGINX Gateway Fabric releases on GitHub. See
 our [releases page](https://github.com/nginx/nginx-gateway-fabric/releases).
 
-The latest release is [2.1.1](https://github.com/nginx/nginx-gateway-fabric/releases/tag/v2.1.1).
+The latest release is [2.1.2](https://github.com/nginx/nginx-gateway-fabric/releases/tag/v2.1.2).
 
 The edge version is useful for experimenting with new features that are not yet published in a release. To use, choose
 the _edge_ version built from the [latest commit](https://github.com/nginx/nginx-gateway-fabric/commits/main)
@@ -47,7 +47,7 @@ to the correct versions:
 
 | Version        | Description                              | Installation Manifests                                                         | Documentation and Examples                                                                                                                                           |
 |----------------|------------------------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Latest release | For production use                       | [Manifests](https://github.com/nginx/nginx-gateway-fabric/tree/v2.1.1/deploy). | [Documentation](https://docs.nginx.com/nginx-gateway-fabric). [Examples](https://github.com/nginx/nginx-gateway-fabric/tree/v2.1.1/examples).                        |
+| Latest release | For production use                       | [Manifests](https://github.com/nginx/nginx-gateway-fabric/tree/v2.1.2/deploy). | [Documentation](https://docs.nginx.com/nginx-gateway-fabric). [Examples](https://github.com/nginx/nginx-gateway-fabric/tree/v2.1.2/examples).                        |
 | Edge           | For experimental use and latest features | [Manifests](https://github.com/nginx/nginx-gateway-fabric/tree/main/deploy).   | [Examples](https://github.com/nginx/nginx-gateway-fabric/tree/main/examples). |
 
 ### Versioning
@@ -69,6 +69,7 @@ The following table lists the software versions NGINX Gateway Fabric supports.
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent |
 |----------------------|-------------|------------|-----------|------------|-------------|
 | Edge                 | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.3.1      |
+| 2.1.2.               | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.3.1      |
 | 2.1.1                | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.2.1      |
 | 2.1.0                | 1.3.0       | 1.25+      | 1.29.1    | R35        | v3.2.1      |
 | 2.0.2                | 1.3.0       | 1.25+      | 1.28.0    | R34        | v3.0.1      |

--- a/charts/nginx-gateway-fabric/Chart.yaml
+++ b/charts/nginx-gateway-fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-gateway-fabric
 description: NGINX Gateway Fabric
 type: application
-version: 2.1.1
+version: 2.1.2
 appVersion: "edge"
 kubeVersion: ">= 1.25.0-0"
 home: https://github.com/nginx/nginx-gateway-fabric

--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -1,7 +1,7 @@
 
 # NGINX Gateway Fabric Helm Chart
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![AppVersion: edge](https://img.shields.io/badge/AppVersion-edge-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![AppVersion: edge](https://img.shields.io/badge/AppVersion-edge-informational?style=flat-square)
 
 - [NGINX Gateway Fabric Helm Chart](#nginx-gateway-fabric-helm-chart)
   - [Introduction](#introduction)


### PR DESCRIPTION
Update docs for Release 2.1.2

There was one update for Gateway Compatibility [doc](https://github.com/nginx/documentation/blob/main/content/ngf/overview/gateway-api-compatibility.md) that's already in main branch so no updates needed there.