### PR TITLE
Update provision nginx log statement to be more clear

### DIFF
--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -224,10 +224,16 @@ func (p *NginxProvisioner) provisionNginx(
 		return nil
 	}
 
+	objNames := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		objNames = append(objNames, obj.GetName())
+	}
+
 	p.cfg.Logger.Info(
 		"Creating/Updating nginx resources",
 		"namespace", gateway.GetNamespace(),
-		"name", resourceName,
+		"nginx resource name", resourceName,
+		"resource names", objNames,
 	)
 
 	var agentConfigMapUpdated, deploymentCreated bool


### PR DESCRIPTION
The current provision nginx log statement doesn't state the object names for the objects that are being updated, only the name of the nginx resource. This change includes the object names in the log so users can see what resources are being updated.