### PR TITLE
Update Dockerfile alpine packages for cve fixes  (#3973)

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -5,6 +5,9 @@ FROM scratch AS nginx-files
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
 
 FROM nginx:1.29.1-alpine-otel
+# the following apk update and add are to address CVE-2025-59375 and CVE-2025-8961/CVE-2025-9165 respectively,
+# once a new base image is available with these package updates, they can be removed.
+RUN apk update && apk add --no-cache 'libexpat>=2.7.2-r0' 'tiff>=4.7.1-r0'
 
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.3.1


### PR DESCRIPTION
Cherry-pick #3973. Update Dockerfile alpine packages libexpat and tiff to fix cves.

Verified NGINX Plus image does not contain libexpat or tiff alpine packages, and after these changes, the packages in the built docker image have the updated versions.