### PR TITLE
Fix cves for libcrpyto3 and libssl3 (#3993)

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -5,9 +5,9 @@ FROM scratch AS nginx-files
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
 
 FROM nginx:1.29.1-alpine-otel
-# the following apk update and add are to address CVE-2025-59375 and CVE-2025-8961/CVE-2025-9165 respectively,
+# the following apk update and add are to address CVE-2025-59375, CVE-2025-8961/CVE-2025-9165, CVE-2025-9230, and CVE-2025-9231/CVE-2025-9232 respectively.
 # once a new base image is available with these package updates, they can be removed.
-RUN apk update && apk add --no-cache 'libexpat>=2.7.2-r0' 'tiff>=4.7.1-r0'
+RUN apk update && apk add --no-cache 'libexpat>=2.7.2-r0' 'tiff>=4.7.1-r0' 'libcrypto3>=3.5.4-r0' 'libssl3>=3.5.4-r0'
 
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.3.1


### PR DESCRIPTION
Cherry-pick #3993. Update Dockerfile alpine packages libcrpyto3 and libssl3 to fix cves.

Verified NGINX Plus image does not contain libcrpyto3 or libssl3 alpine packages, and after these changes, the packages in the built docker image have the updated versions.