### PR TITLE
Add functional tests for WAFPolicy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,11 @@ jobs:
         image: [nginx, plus]
         build-os: ${{ github.event_name == 'pull_request' && fromJSON('[""]') || fromJSON('["", "ubi"]') }}
         k8s-version: ${{ github.event_name == 'pull_request' && fromJSON(format('["{0}"]', needs.vars.outputs.k8s_latest)) || fromJSON(format('["{0}", "{1}"]', needs.vars.outputs.min_k8s_version, needs.vars.outputs.k8s_latest)) }}
+        include:
+          # plus-waf: always run once with latest k8s, no build-os suffix
+          - image: plus-waf
+            build-os: ''
+            k8s-version: ${{ needs.vars.outputs.k8s_latest }}
     uses: ./.github/workflows/functional.yml
     with:
       image: ${{ matrix.image }}

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Compile WAF policy bundles
         if: ${{ inputs.image == 'plus-waf' }}
-        run: make compile-waf-bundles
+        run: make compile-waf-bundles-ci
         working-directory: ./tests
 
       - name: Install cloud-provider-kind

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -28,7 +28,7 @@ jobs:
   functional-tests:
     name: Run Tests
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.head.repo.fork || inputs.image != 'plus' }}
+    if: ${{ !github.event.pull_request.head.repo.fork || !contains(inputs.image, 'plus') }}
     env:
       DOCKER_BUILD_SUMMARY: false
     steps:
@@ -66,7 +66,7 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
-            name=ghcr.io/nginx/nginx-gateway-fabric/${{ inputs.image == 'plus' && 'nginx-plus' || inputs.image }}
+            name=ghcr.io/nginx/nginx-gateway-fabric/${{ contains(inputs.image, 'plus') && 'nginx-plus' || inputs.image }}
           tags: |
             type=semver,pattern={{version}},suffix=${{ inputs.build-os != '' && format('-{0}', inputs.build-os) || '' }}
             type=schedule,suffix=${{ inputs.build-os != '' && format('-{0}', inputs.build-os) || '' }}
@@ -97,7 +97,7 @@ jobs:
       - name: Build NGINX Docker Image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          file: build${{ inputs.build-os != '' && format('/{0}', inputs.build-os) || '' }}/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ inputs.image == 'plus' && '.nginxplus' || '' }}
+          file: build${{ inputs.build-os != '' && format('/{0}', inputs.build-os) || '' }}/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ contains(inputs.image, 'plus') && '.nginxplus' || '' }}
           tags: ${{ steps.nginx-meta.outputs.tags }}
           context: "."
           load: true
@@ -107,15 +107,35 @@ jobs:
             NJS_DIR=internal/controller/nginx/modules/src
             NGINX_CONF_DIR=internal/controller/nginx/conf
             BUILD_AGENT=gha
+            ${{ inputs.image == 'plus-waf' && 'INCLUDE_NAP_WAF=true' || '' }}
           secrets: |
             ${{ contains(inputs.image, 'plus') && format('"nginx-repo.crt={0}"', secrets.NGINX_CRT) || '' }}
             ${{ contains(inputs.image, 'plus') && format('"nginx-repo.key={0}"', secrets.NGINX_KEY) || '' }}
 
       - name: Setup license file for plus
-        if: ${{ inputs.image == 'plus' }}
+        if: ${{ contains(inputs.image, 'plus') }}
         env:
           PLUS_LICENSE: ${{ secrets.JWT_PLUS_REPORTING }}
         run: echo "${PLUS_LICENSE}" > license.jwt
+
+      - name: Setup image pull secret for waf
+        if: ${{ inputs.image == 'plus-waf' }}
+        env:
+          IMAGE_PULL_SECRET: ${{ secrets.JWT_PLUS_REGISTRY }}
+        run: echo "${IMAGE_PULL_SECRET}" > dockerconfig.jwt
+
+      - name: Login to NGINX private registry
+        if: ${{ inputs.image == 'plus-waf' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: private-registry.nginx.com
+          username: ${{ secrets.JWT_PLUS_REGISTRY }}
+          password: none
+
+      - name: Compile WAF policy bundles
+        if: ${{ inputs.image == 'plus-waf' }}
+        run: make compile-waf-bundles
+        working-directory: ./tests
 
       - name: Install cloud-provider-kind
         run: |
@@ -132,6 +152,7 @@ jobs:
           kind load docker-image ${{ join(fromJSON(steps.ngf-meta.outputs.json).tags, ' ') }} ${{ join(fromJSON(steps.nginx-meta.outputs.json).tags, ' ') }} --name ${{ github.run_id }}
 
       - name: Run functional telemetry tests
+        if: ${{ inputs.image != 'plus-waf' }}
         run: |
           ngf_prefix=ghcr.io/nginx/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
@@ -139,6 +160,7 @@ jobs:
         working-directory: ./tests
 
       - name: Run functional graceful-recovery tests
+        if: ${{ inputs.image != 'plus-waf' }}
         run: |
           ngf_prefix=ghcr.io/nginx/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
@@ -146,8 +168,17 @@ jobs:
         working-directory: ./tests
 
       - name: Run functional tests
+        if: ${{ inputs.image != 'plus-waf' }}
         run: |
           ngf_prefix=ghcr.io/nginx/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
           make test${{ inputs.image == 'plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag} GW_SERVICE_TYPE=LoadBalancer CLUSTER_NAME=${{ github.run_id }} CI=true
+        working-directory: ./tests
+
+      - name: Run WAF tests
+        if: ${{ inputs.image == 'plus-waf' }}
+        run: |
+          ngf_prefix=ghcr.io/nginx/nginx-gateway-fabric
+          ngf_tag=${{ steps.ngf-meta.outputs.version }}
+          make test-waf PREFIX=${ngf_prefix} TAG=${ngf_tag} NGINX_PLUS_PREFIX=${ngf_prefix}/nginx-plus GW_SERVICE_TYPE=LoadBalancer CLUSTER_NAME=${{ github.run_id }} CI=true
         working-directory: ./tests

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ config/base/deploy.yaml.bak
 # Temporary API documentation file, which should be committed
 # to the main documentation repository instead
 docs/api/content.md
+
+# Test tgz files for WAF bundles
+tests/**/*.tgz

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -261,32 +261,50 @@ test-cel-validation:
 		go test -v ./cel -run "$(CEL_TEST_TARGET)"; \
 	fi
 
-NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:5.12.1
+NAP_VERSION = $(shell grep -oP 'Release\s*=\s*"\K[^"]+' $(SELF_DIR)internal/framework/waf/waf.go)
+NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:$(NAP_VERSION)
 WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
+
+NAP_COMPILE_RUN = docker run --rm -v $(SELF_DIR):$(SELF_DIR) $(NAP_COMPILER_IMAGE)
 
 .PHONY: compile-waf-bundles
 compile-waf-bundles: check-for-docker ## Compile NAP WAF policy bundles for functional tests. Requires Docker and access to private-registry.nginx.com.
 	@echo "Compiling dataguard-blocking.tgz..."
+	$(NAP_COMPILE_RUN) -p $(WAF_POLICY_DIR)/dataguard-blocking.json -o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
+	@echo "Compiling attack-signatures-blocking.tgz..."
+	$(NAP_COMPILE_RUN) -p $(WAF_POLICY_DIR)/attack-signatures-blocking.json -o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
+	@echo "Compiling logconf.tgz..."
+	$(NAP_COMPILE_RUN) -l $(WAF_POLICY_DIR)/log-illegal.json -o $(WAF_POLICY_DIR)/logconf.tgz
+	@echo "WAF bundles compiled to $(WAF_POLICY_DIR)/"
+
+.PHONY: compile-waf-bundles-ci
+compile-waf-bundles-ci: check-for-docker ## Compile NAP WAF policy bundles for CI (Linux only).
+	$(eval NAP_LOG_DIR := $(shell mktemp -d))
+	$(eval NAP_CACHE_DIR := $(shell mktemp -d))
+	chmod o+w $(WAF_POLICY_DIR) $(NAP_LOG_DIR) $(NAP_CACHE_DIR)
+	@echo "Compiling dataguard-blocking.tgz..."
 	docker run --rm \
-		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
+		-v $(NAP_LOG_DIR):/var/log/app_protect \
+		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
 		$(NAP_COMPILER_IMAGE) \
-		-p $(WAF_POLICY_DIR)/dataguard-blocking.json \
-		-o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
+		-p $(WAF_POLICY_DIR)/dataguard-blocking.json -o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
 	@echo "Compiling attack-signatures-blocking.tgz..."
 	docker run --rm \
-		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
+		-v $(NAP_LOG_DIR):/var/log/app_protect \
+		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
 		$(NAP_COMPILER_IMAGE) \
-		-p $(WAF_POLICY_DIR)/attack-signatures-blocking.json \
-		-o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
+		-p $(WAF_POLICY_DIR)/attack-signatures-blocking.json -o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
 	@echo "Compiling logconf.tgz..."
 	docker run --rm \
-		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
+		-v $(NAP_LOG_DIR):/var/log/app_protect \
+		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
 		$(NAP_COMPILER_IMAGE) \
-		-l $(WAF_POLICY_DIR)/log-illegal.json \
-		-o $(WAF_POLICY_DIR)/logconf.tgz
+		-l $(WAF_POLICY_DIR)/log-illegal.json -o $(WAF_POLICY_DIR)/logconf.tgz
+	chmod o-w $(WAF_POLICY_DIR)
+	rm -rf $(NAP_LOG_DIR) $(NAP_CACHE_DIR)
 	@echo "WAF bundles compiled to $(WAF_POLICY_DIR)/"
 
 .PHONY: test-waf

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -279,32 +279,20 @@ compile-waf-bundles: check-for-docker ## Compile NAP WAF policy bundles for func
 
 .PHONY: compile-waf-bundles-ci
 compile-waf-bundles-ci: check-for-docker ## Compile NAP WAF policy bundles for CI (Linux only).
-	$(eval NAP_LOG_DIR := $(shell mktemp -d))
-	$(eval NAP_CACHE_DIR := $(shell mktemp -d))
-	chmod o+w $(WAF_POLICY_DIR) $(NAP_LOG_DIR) $(NAP_CACHE_DIR)
+	chmod o+w $(WAF_POLICY_DIR)
 	@echo "Compiling dataguard-blocking.tgz..."
-	docker run --rm \
-		-v $(SELF_DIR):$(SELF_DIR) \
-		-v $(NAP_LOG_DIR):/var/log/app_protect \
-		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
-		$(NAP_COMPILER_IMAGE) \
+	-docker run --rm -v $(SELF_DIR):$(SELF_DIR) $(NAP_COMPILER_IMAGE) \
 		-p $(WAF_POLICY_DIR)/dataguard-blocking.json -o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
+	test -s $(WAF_POLICY_DIR)/dataguard-blocking.tgz
 	@echo "Compiling attack-signatures-blocking.tgz..."
-	docker run --rm \
-		-v $(SELF_DIR):$(SELF_DIR) \
-		-v $(NAP_LOG_DIR):/var/log/app_protect \
-		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
-		$(NAP_COMPILER_IMAGE) \
+	-docker run --rm -v $(SELF_DIR):$(SELF_DIR) $(NAP_COMPILER_IMAGE) \
 		-p $(WAF_POLICY_DIR)/attack-signatures-blocking.json -o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
+	test -s $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
 	@echo "Compiling logconf.tgz..."
-	docker run --rm \
-		-v $(SELF_DIR):$(SELF_DIR) \
-		-v $(NAP_LOG_DIR):/var/log/app_protect \
-		-v $(NAP_CACHE_DIR):/opt/app_protect/config \
-		$(NAP_COMPILER_IMAGE) \
+	-docker run --rm -v $(SELF_DIR):$(SELF_DIR) $(NAP_COMPILER_IMAGE) \
 		-l $(WAF_POLICY_DIR)/log-illegal.json -o $(WAF_POLICY_DIR)/logconf.tgz
+	test -s $(WAF_POLICY_DIR)/logconf.tgz
 	chmod o-w $(WAF_POLICY_DIR)
-	rm -rf $(NAP_LOG_DIR) $(NAP_CACHE_DIR)
 	@echo "WAF bundles compiled to $(WAF_POLICY_DIR)/"
 
 .PHONY: test-waf

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -261,7 +261,7 @@ test-cel-validation:
 		go test -v ./cel -run "$(CEL_TEST_TARGET)"; \
 	fi
 
-NAP_VERSION = $(shell grep -oP 'Release\s*=\s*"\K[^"]+' $(SELF_DIR)internal/framework/waf/waf.go)
+NAP_VERSION = $(shell sed -n 's/.*Release[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' $(SELF_DIR)internal/framework/waf/waf.go)
 NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:$(NAP_VERSION)
 WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -260,3 +260,60 @@ test-cel-validation:
 		echo "Running test: $(CEL_TEST_TARGET) in ./cel"; \
 		go test -v ./cel -run "$(CEL_TEST_TARGET)"; \
 	fi
+
+NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:5.11.2
+WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
+
+.PHONY: compile-waf-bundles
+compile-waf-bundles: check-for-docker ## Compile NAP WAF policy bundles for functional tests. Requires Docker and access to private-registry.nginx.com.
+	@echo "Compiling dataguard-blocking.tgz..."
+	docker run --rm \
+		-v $(SELF_DIR):$(SELF_DIR) \
+		$(NAP_COMPILER_IMAGE) \
+		-p $(WAF_POLICY_DIR)/dataguard-blocking.json \
+		-o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
+	@echo "Compiling attack-signatures-blocking.tgz..."
+	docker run --rm \
+		-v $(SELF_DIR):$(SELF_DIR) \
+		$(NAP_COMPILER_IMAGE) \
+		-p $(WAF_POLICY_DIR)/attack-signatures-blocking.json \
+		-o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
+	@echo "Compiling logconf.tgz..."
+	docker run --rm \
+		-v $(SELF_DIR):$(SELF_DIR) \
+		$(NAP_COMPILER_IMAGE) \
+		-l $(WAF_POLICY_DIR)/log-illegal.json \
+		-o $(WAF_POLICY_DIR)/logconf.tgz
+	@echo "WAF bundles compiled to $(WAF_POLICY_DIR)/"
+
+.PHONY: test-waf
+test-waf: PLUS_ENABLED=true
+test-waf: build-crossplane-image ## Runs the WAF tests on a kind cluster. Bundles must already be compiled (run compile-waf-bundles first).
+	kind load docker-image nginx-crossplane:latest --name $(CLUSTER_NAME)
+	go run github.com/onsi/ginkgo/v2/ginkgo --race --randomize-all --keep-going --fail-on-pending \
+		--trace -r -v --buildvcs --force-newlines $(GITHUB_OUTPUT) \
+		--label-filter "waf" $(GINKGO_FLAGS) ./suite -- \
+		--gateway-api-version=$(GW_API_VERSION) --gateway-api-prev-version=$(GW_API_PREV_VERSION) \
+		--image-tag=$(TAG) --version-under-test=$(NGF_VERSION) \
+		--ngf-image-repo=$(PREFIX) --nginx-image-repo=$(NGINX_PLUS_PREFIX) --nginx-plus-image-repo=$(NGINX_PLUS_PREFIX) \
+		--pull-policy=$(PULL_POLICY) --service-type=$(GW_SERVICE_TYPE) \
+		--cluster-name=$(CLUSTER_NAME) --plus-enabled=$(PLUS_ENABLED) \
+		--plus-license-file-name=$(PLUS_LICENSE_FILE) --plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) \
+		--waf-enabled=true --nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE)
+
+.PHONY: test-waf-gke
+test-waf-gke: PLUS_ENABLED=true
+test-waf-gke: GOARCH=amd64
+test-waf-gke: compile-waf-bundles check-for-plus-usage-endpoint build-crossplane-image ## Runs the WAF tests on a GKE cluster (amd64 only).
+	./scripts/push-crossplane-image.sh
+	go run github.com/onsi/ginkgo/v2/ginkgo --race --randomize-all --keep-going --fail-on-pending \
+		--trace -r -v --buildvcs --force-newlines $(GITHUB_OUTPUT) \
+		--label-filter "waf" $(GINKGO_FLAGS) ./suite -- \
+		--gateway-api-version=$(GW_API_VERSION) --gateway-api-prev-version=$(GW_API_PREV_VERSION) \
+		--image-tag=$(TAG) --version-under-test=$(NGF_VERSION) \
+		--ngf-image-repo=$(PREFIX) --nginx-image-repo=$(NGINX_PLUS_PREFIX) --nginx-plus-image-repo=$(NGINX_PLUS_PREFIX) \
+		--pull-policy=Always --service-type=LoadBalancer \
+		--plus-enabled=$(PLUS_ENABLED) \
+		--plus-license-file-name=$(PLUS_LICENSE_FILE) --plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) \
+		--gke-project=$(GKE_PROJECT) \
+		--waf-enabled=true --nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -268,18 +268,21 @@ WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
 compile-waf-bundles: check-for-docker ## Compile NAP WAF policy bundles for functional tests. Requires Docker and access to private-registry.nginx.com.
 	@echo "Compiling dataguard-blocking.tgz..."
 	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
 		$(NAP_COMPILER_IMAGE) \
 		-p $(WAF_POLICY_DIR)/dataguard-blocking.json \
 		-o $(WAF_POLICY_DIR)/dataguard-blocking.tgz
 	@echo "Compiling attack-signatures-blocking.tgz..."
 	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
 		$(NAP_COMPILER_IMAGE) \
 		-p $(WAF_POLICY_DIR)/attack-signatures-blocking.json \
 		-o $(WAF_POLICY_DIR)/attack-signatures-blocking.tgz
 	@echo "Compiling logconf.tgz..."
 	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
 		-v $(SELF_DIR):$(SELF_DIR) \
 		$(NAP_COMPILER_IMAGE) \
 		-l $(WAF_POLICY_DIR)/log-illegal.json \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -261,7 +261,7 @@ test-cel-validation:
 		go test -v ./cel -run "$(CEL_TEST_TARGET)"; \
 	fi
 
-NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:5.11.2
+NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:5.12.1
 WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
 
 .PHONY: compile-waf-bundles

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,7 @@ This directory contains the tests for NGINX Gateway Fabric. The tests are divide
     - [Run the functional tests locally](#run-the-functional-tests-locally)
     - [Run the NFR tests on a GKE cluster from a GCP VM](#run-the-nfr-tests-on-a-gke-cluster-from-a-gcp-vm)
       - [Longevity testing](#longevity-testing)
+    - [Run the WAF tests on a GKE cluster](#run-the-waf-tests-on-a-gke-cluster)
   - [Common test amendments](#common-test-amendments)
   - [Step 2 - Cleanup](#step-2---cleanup)
 
@@ -382,6 +383,20 @@ make stop-longevity-test
 <!--  -->
 
 > Note if running from your machine instead of the pipeline: If you want to re-run the longevity test, you need to clear out the `cafe.example.com` entry from the `/etc/hosts` file on your VM.
+
+#### Run the WAF tests on a GKE cluster
+
+WAF tests require NGINX Plus with NAP WAF images and run on GKE (amd64 only). Before running:
+
+1. Ensure you have access to `private-registry.nginx.com` and a `dockerconfig.jwt` file at the repo root (used to create the image pull secret).
+
+2. Run the WAF tests, passing the required variables directly:
+
+   ```makefile
+   make test-waf-gke TAG=$(whoami) PLUS_USAGE_ENDPOINT=<endpoint> GKE_PROJECT=<project>
+   ```
+
+   This will compile the WAF policy bundles from the JSON sources in `suite/manifests/waf-policy/`, create the image pull secret in the `nginx-gateway` namespace so the WAF sidecar images (`waf-enforcer`, `waf-config-mgr`) can be pulled from `private-registry.nginx.com`, and run the tests labelled `waf` against the GKE cluster.
 
 ### Common test amendments
 

--- a/tests/framework/exec.go
+++ b/tests/framework/exec.go
@@ -13,10 +13,20 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-// execResult holds the output of an exec command.
-type execResult struct {
+// ExecResult holds the output of an exec command.
+type ExecResult struct {
 	Stdout string
 	Stderr string
+}
+
+// ExecInPod executes a command inside a container of a Kubernetes pod.
+// If container is empty, the first container in the pod is used.
+func (rm *ResourceManager) ExecInPod(
+	ctx context.Context,
+	namespace, podName, container string,
+	command []string,
+) (ExecResult, error) {
+	return execInPod(ctx, rm.ClientGoClient, rm.K8sConfig, namespace, podName, container, command)
 }
 
 // execInPod executes a command inside a container of a Kubernetes pod.
@@ -27,7 +37,7 @@ func execInPod(
 	k8sConfig *rest.Config,
 	namespace, podName, container string,
 	command []string,
-) (execResult, error) {
+) (ExecResult, error) {
 	opts := &core.PodExecOptions{
 		Command:   command,
 		Container: container,
@@ -44,7 +54,7 @@ func execInPod(
 
 	exec, err := remotecommand.NewSPDYExecutor(k8sConfig, http.MethodPost, req.URL())
 	if err != nil {
-		return execResult{}, fmt.Errorf("failed to create executor: %w", err)
+		return ExecResult{}, fmt.Errorf("failed to create executor: %w", err)
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -53,13 +63,13 @@ func execInPod(
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}); err != nil {
-		return execResult{
+		return ExecResult{
 			Stdout: stdout.String(),
 			Stderr: stderr.String(),
 		}, fmt.Errorf("exec failed: %w (stderr: %s)", err, stderr.String())
 	}
 
-	return execResult{
+	return ExecResult{
 		Stdout: stdout.String(),
 		Stderr: stderr.String(),
 	}, nil

--- a/tests/framework/ngf.go
+++ b/tests/framework/ngf.go
@@ -2,6 +2,8 @@ package framework
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,14 +16,16 @@ import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph/shared/secrets"
 )
 
 const (
-	gwInstallBasePath = "https://github.com/kubernetes-sigs/gateway-api/releases/download"
-	PlusSecretName    = "nplus-license"
-	NgfControllerName = "gateway.nginx.org/nginx-gateway-controller"
+	gwInstallBasePath       = "https://github.com/kubernetes-sigs/gateway-api/releases/download"
+	PlusSecretName          = "nplus-license"
+	PlusImagePullSecretName = "nginx-plus-registry-secret" //nolint:gosec // not hardcoded credentials
+	NgfControllerName       = "gateway.nginx.org/nginx-gateway-controller"
 )
 
 // InstallationConfig contains the configuration for the NGF installation.
@@ -37,6 +41,7 @@ type InstallationConfig struct {
 	ServiceType          string
 	PlusUsageEndpoint    string
 	GatewayClassName     string
+	NginxImagePullSecret string
 	Plus                 bool
 	Telemetry            bool
 	SkipCRDCleanup       bool
@@ -175,6 +180,71 @@ func CreateLicenseSecret(rm ResourceManager, namespace, filename string) error {
 	return nil
 }
 
+const nginxPlusRegistry = "private-registry.nginx.com"
+
+func CreateImagePullSecret(rm ResourceManager, namespace, filename string) error {
+	GinkgoWriter.Printf("Creating NGINX Plus Image Pull secret in namespace %q from file %q\n", namespace, filename)
+
+	jwtBytes, err := os.ReadFile(filename)
+	if err != nil {
+		readFileErr := fmt.Errorf("error reading file %q: %w", filename, err)
+		GinkgoWriter.Printf("%v\n", readFileErr)
+
+		return readFileErr
+	}
+
+	jwt := strings.TrimSpace(string(jwtBytes))
+	auth := base64.StdEncoding.EncodeToString([]byte(jwt + ":none"))
+
+	dockerConfig := map[string]interface{}{
+		"auths": map[string]interface{}{
+			nginxPlusRegistry: map[string]string{
+				"username": jwt,
+				"password": "none",
+				"auth":     auth,
+			},
+		},
+	}
+
+	dockerConfigJSON, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return fmt.Errorf("error marshaling docker config: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeoutConfig().CreateTimeout)
+	defer cancel()
+
+	ns := &core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	if err := rm.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating namespace: %w", err)
+	}
+
+	secret := &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PlusImagePullSecretName,
+			Namespace: namespace,
+		},
+		Type: core.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			core.DockerConfigJsonKey: dockerConfigJSON,
+		},
+	}
+
+	if err := rm.Apply([]client.Object{secret}); err != nil {
+		createSecretErr := fmt.Errorf("error applying secret: %w", err)
+		GinkgoWriter.Printf("%v\n", createSecretErr)
+
+		return createSecretErr
+	}
+
+	return nil
+}
+
 // UpgradeNGF upgrades NGF. CRD upgrades assume the chart is local.
 func UpgradeNGF(cfg InstallationConfig, extraArgs ...string) ([]byte, error) {
 	crdPath := filepath.Join(cfg.ChartPath, "crds") + "/"
@@ -305,6 +375,10 @@ func setImageArgs(cfg InstallationConfig) []string {
 
 	if cfg.ServiceType != "" {
 		args = append(args, formatValueSet("nginx.service.type", cfg.ServiceType)...)
+	}
+
+	if cfg.NginxImagePullSecret != "" {
+		args = append(args, formatValueSet("nginx.imagePullSecret", cfg.NginxImagePullSecret)...)
 	}
 
 	return args

--- a/tests/framework/ngf.go
+++ b/tests/framework/ngf.go
@@ -26,6 +26,7 @@ const (
 	PlusSecretName          = "nplus-license"
 	PlusImagePullSecretName = "nginx-plus-registry-secret" //nolint:gosec // not hardcoded credentials
 	NgfControllerName       = "gateway.nginx.org/nginx-gateway-controller"
+	nginxPlusRegistry       = "private-registry.nginx.com"
 )
 
 // InstallationConfig contains the configuration for the NGF installation.
@@ -180,8 +181,6 @@ func CreateLicenseSecret(rm ResourceManager, namespace, filename string) error {
 	return nil
 }
 
-const nginxPlusRegistry = "private-registry.nginx.com"
-
 func CreateImagePullSecret(rm ResourceManager, namespace, filename string) error {
 	GinkgoWriter.Printf("Creating NGINX Plus Image Pull secret in namespace %q from file %q\n", namespace, filename)
 
@@ -196,8 +195,8 @@ func CreateImagePullSecret(rm ResourceManager, namespace, filename string) error
 	jwt := strings.TrimSpace(string(jwtBytes))
 	auth := base64.StdEncoding.EncodeToString([]byte(jwt + ":none"))
 
-	dockerConfig := map[string]interface{}{
-		"auths": map[string]interface{}{
+	dockerConfig := map[string]any{
+		"auths": map[string]any{
 			nginxPlusRegistry: map[string]string{
 				"username": jwt,
 				"password": "none",

--- a/tests/framework/resourcemanager.go
+++ b/tests/framework/resourcemanager.go
@@ -1258,7 +1258,7 @@ func (rm *ResourceManager) GetNginxConfig(
 
 	crossplaneCmd := []string{"./crossplane", "/etc/nginx/nginx.conf"}
 
-	var result execResult
+	var result ExecResult
 	if err := wait.PollUntilContextCancel(
 		ctx,
 		500*time.Millisecond,

--- a/tests/suite/manifests/waf-policy/attack-signatures-blocking.json
+++ b/tests/suite/manifests/waf-policy/attack-signatures-blocking.json
@@ -1,0 +1,17 @@
+{
+  "policy": {
+    "name": "attack-signatures-blocking",
+    "template": {
+      "name": "POLICY_TEMPLATE_NGINX_BASE"
+    },
+    "applicationLanguage": "utf-8",
+    "enforcementMode": "blocking",
+    "signature-sets": [
+      {
+        "name": "All Signatures",
+        "block": true,
+        "alarm": true
+      }
+    ]
+  }
+}

--- a/tests/suite/manifests/waf-policy/bundle-server.yaml
+++ b/tests/suite/manifests/waf-policy/bundle-server.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bundle-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bundle-server
+  template:
+    metadata:
+      labels:
+        app: bundle-server
+    spec:
+      containers:
+      - name: bundle-server
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: bundles
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: bundles
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bundle-server
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: bundle-server

--- a/tests/suite/manifests/waf-policy/cafe-routes.yaml
+++ b/tests/suite/manifests/waf-policy/cafe-routes.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coffee
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "cafe.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /coffee
+    backendRefs:
+    - name: coffee
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tea
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "cafe.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tea
+    backendRefs:
+    - name: tea
+      port: 80

--- a/tests/suite/manifests/waf-policy/cafe.yaml
+++ b/tests/suite/manifests/waf-policy/cafe.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: hashicorp/http-echo:latest
+        args:
+        - "-listen=:8080"
+        - "-text=Customer List:\n\nName: John Doe\nCredit Card: 4111-1111-1111-1111\nSSN: 123-45-6789\n"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/tests/suite/manifests/waf-policy/dataguard-blocking.json
+++ b/tests/suite/manifests/waf-policy/dataguard-blocking.json
@@ -1,0 +1,15 @@
+{
+  "policy": {
+    "name": "dataguard-blocking",
+    "template": {
+      "name": "POLICY_TEMPLATE_NGINX_BASE"
+    },
+    "applicationLanguage": "utf-8",
+    "enforcementMode": "blocking",
+    "data-guard": {
+      "enabled": true,
+      "creditCardNumbers": true,
+      "usSocialSecurityNumbers": true
+    }
+  }
+}

--- a/tests/suite/manifests/waf-policy/gateway.yaml
+++ b/tests/suite/manifests/waf-policy/gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  gatewayClassName: nginx
+  infrastructure:
+    parametersRef:
+      name: waf-enabled-proxy
+      group: gateway.nginx.org
+      kind: NginxProxy
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"

--- a/tests/suite/manifests/waf-policy/invalid-wafpolicy.yaml
+++ b/tests/suite/manifests/waf-policy/invalid-wafpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-waf-invalid
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: nonexistent-gateway
+  type: HTTP
+  policySource:
+    httpSource:
+      url: http://bundle-server.waf-policy.svc.cluster.local/dataguard-blocking.tgz

--- a/tests/suite/manifests/waf-policy/log-illegal.json
+++ b/tests/suite/manifests/waf-policy/log-illegal.json
@@ -1,0 +1,10 @@
+{
+  "filter": {
+    "request_type": "illegal"
+  },
+  "content": {
+    "format": "default",
+    "max_request_size": "any",
+    "max_message_size": "15k"
+  }
+}

--- a/tests/suite/manifests/waf-policy/nginx-proxy.yaml
+++ b/tests/suite/manifests/waf-policy/nginx-proxy.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: waf-enabled-proxy
+spec:
+  wafEnabled: true

--- a/tests/suite/manifests/waf-policy/wafpolicy-missing-bundle.yaml
+++ b/tests/suite/manifests/waf-policy/wafpolicy-missing-bundle.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-waf-missing-bundle
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  type: HTTP
+  policySource:
+    httpSource:
+      url: http://bundle-server.waf-policy.svc.cluster.local/nonexistent-bundle.tgz

--- a/tests/suite/manifests/waf-policy/wafpolicy-polling.yaml
+++ b/tests/suite/manifests/waf-policy/wafpolicy-polling.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-waf-polling
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  type: HTTP
+  policySource:
+    httpSource:
+      url: http://bundle-server.waf-policy.svc.cluster.local/attack-signatures-blocking.tgz
+    polling:
+      enabled: true
+      interval: 15s

--- a/tests/suite/manifests/waf-policy/wafpolicy-route.yaml
+++ b/tests/suite/manifests/waf-policy/wafpolicy-route.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: coffee-route-waf
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: coffee
+  type: HTTP
+  policySource:
+    httpSource:
+      url: http://bundle-server.waf-policy.svc.cluster.local/dataguard-blocking.tgz

--- a/tests/suite/manifests/waf-policy/wafpolicy.yaml
+++ b/tests/suite/manifests/waf-policy/wafpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-waf
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  type: HTTP
+  policySource:
+    httpSource:
+      url: http://bundle-server.waf-policy.svc.cluster.local/attack-signatures-blocking.tgz
+  securityLogs:
+  - logSource:
+      httpSource:
+        url: http://bundle-server.waf-policy.svc.cluster.local/logconf.tgz
+    destination:
+      type: stderr

--- a/tests/suite/system_suite_test.go
+++ b/tests/suite/system_suite_test.go
@@ -283,7 +283,7 @@ func createNGFInstallConfig(cfg setupConfig, extraInstallArgs ...string) framewo
 
 	if *plusEnabled {
 		Expect(framework.CreateLicenseSecret(resourceManager, ngfNamespace, *plusLicenseFileName)).To(Succeed())
-		if nginxImageJWTFileName != nil {
+		if *nginxImageJWTFileName != "" {
 			Expect(framework.CreateImagePullSecret(resourceManager, ngfNamespace, *nginxImageJWTFileName)).To(Succeed())
 			extraInstallArgs = append(
 				extraInstallArgs,

--- a/tests/suite/system_suite_test.go
+++ b/tests/suite/system_suite_test.go
@@ -173,7 +173,9 @@ func setup(cfg setupConfig, extraInstallArgs ...string) {
 		version = "edge"
 	}
 
-	nginxCrossplanePath = "us-docker.pkg.dev/" + *gkeProject + "/nginx-gateway-fabric"
+	if *gkeProject != "" {
+		nginxCrossplanePath = "us-docker.pkg.dev/" + *gkeProject + "/nginx-gateway-fabric"
+	}
 
 	// Set text replacements for per-proc resource names so manifests reference the correct
 	// GatewayClass and NginxGateway config for this parallel process.

--- a/tests/suite/system_suite_test.go
+++ b/tests/suite/system_suite_test.go
@@ -59,6 +59,8 @@ var (
 	imageTag                 = flag.String("image-tag", "", "Image tag for NGF images")
 	versionUnderTest         = flag.String("version-under-test", "", "Version of NGF that is being tested")
 	imagePullPolicy          = flag.String("pull-policy", "", "Image pull policy for NGF images")
+	nginxImageJWTFileName    = flag.String("nginx-image-jwt-file-name", "", "Name of JWT file name for N+ images")
+	wafEnabled               = flag.Bool("waf-enabled", false, "Is NAP WAF enabled (NGINX Plus with WAF images)")
 	serviceType              = flag.String("service-type", "NodePort", "Type of service fronting NGF to be deployed")
 	plusEnabled              = flag.Bool("plus-enabled", false, "Is NGINX Plus enabled")
 	plusLicenseFileName      = flag.String("plus-license-file-name", "", "File name containing the NGINX Plus JWT")
@@ -243,14 +245,15 @@ func cleanUpPortForward() {
 func createNGFInstallConfig(cfg setupConfig, extraInstallArgs ...string) framework.InstallationConfig {
 	GinkgoWriter.Printf("Creating NGF installation config\n")
 	installCfg := framework.InstallationConfig{
-		ReleaseName:       cfg.releaseName,
-		Namespace:         ngfNamespace,
-		ChartPath:         cfg.chartPath,
-		ServiceType:       *serviceType,
-		Plus:              *plusEnabled,
-		PlusUsageEndpoint: *plusUsageEndpoint,
-		Telemetry:         cfg.telemetry,
-		GatewayClassName:  gatewayClassName,
+		ReleaseName:          cfg.releaseName,
+		Namespace:            ngfNamespace,
+		ChartPath:            cfg.chartPath,
+		ServiceType:          *serviceType,
+		Plus:                 *plusEnabled,
+		PlusUsageEndpoint:    *plusUsageEndpoint,
+		Telemetry:            cfg.telemetry,
+		GatewayClassName:     gatewayClassName,
+		NginxImagePullSecret: *nginxImageJWTFileName,
 	}
 
 	switch {
@@ -278,6 +281,13 @@ func createNGFInstallConfig(cfg setupConfig, extraInstallArgs ...string) framewo
 
 	if *plusEnabled {
 		Expect(framework.CreateLicenseSecret(resourceManager, ngfNamespace, *plusLicenseFileName)).To(Succeed())
+		if nginxImageJWTFileName != nil {
+			Expect(framework.CreateImagePullSecret(resourceManager, ngfNamespace, *nginxImageJWTFileName)).To(Succeed())
+			extraInstallArgs = append(
+				extraInstallArgs,
+				"--set", "nginx.imagePullSecret="+framework.PlusImagePullSecretName,
+			)
+		}
 	}
 
 	output, err := framework.InstallNGF(installCfg, extraInstallArgs...)

--- a/tests/suite/waf_policy_test.go
+++ b/tests/suite/waf_policy_test.go
@@ -1,0 +1,630 @@
+// This package needs to be named main to get build info
+// because of https://github.com/golang/go/issues/33976
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	ngfAPI "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
+	"github.com/nginx/nginx-gateway-fabric/v2/tests/framework"
+)
+
+var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
+	// WAF requires amd64 and NGINX Plus with NAP WAF images (--waf-enabled=true).
+	BeforeAll(func() {
+		if runtime.GOARCH == "arm64" {
+			Skip("NAP WAF does not support ARM architecture")
+		}
+		if !*wafEnabled {
+			Skip("Skipping WAF tests: --waf-enabled is not set")
+		}
+	})
+
+	var (
+		files = []string{
+			"waf-policy/cafe.yaml",
+			"waf-policy/bundle-server.yaml",
+			"waf-policy/gateway.yaml",
+			"waf-policy/cafe-routes.yaml",
+		}
+
+		proxyFile = []string{
+			"waf-policy/nginx-proxy.yaml",
+		}
+
+		namespace    = "waf-policy"
+		nginxPodName string
+	)
+
+	BeforeAll(func() {
+		ns := &core.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(resourceManager.Apply([]client.Object{ns})).To(Succeed())
+		Expect(resourceManager.ApplyFromFiles(proxyFile, namespace)).To(Succeed())
+		Expect(resourceManager.ApplyFromFiles(files, namespace)).To(Succeed())
+		Expect(resourceManager.WaitForAppsToBeReady(namespace)).To(Succeed())
+
+		// bundleFiles maps pre-compiled .tgz paths (relative to the repo root, output by
+		// make compile-waf-bundles) to the filename each is served as by the bundle server.
+		bundleFiles := map[string]string{
+			"manifests/waf-policy/dataguard-blocking.tgz":         "dataguard-blocking.tgz",
+			"manifests/waf-policy/attack-signatures-blocking.tgz": "attack-signatures-blocking.tgz",
+			"manifests/waf-policy/logconf.tgz":                    "logconf.tgz",
+		}
+
+		// Copy pre-compiled WAF policy bundles into the bundle-server pod so that the
+		// WAFPolicy HTTP source can fetch them during the tests.
+		bundleServerPodNames, err := resourceManager.GetPodNames(
+			namespace, client.MatchingLabels{"app": "bundle-server"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(bundleServerPodNames).To(HaveLen(1), "expected exactly one bundle-server pod")
+
+		for localPath, remoteName := range bundleFiles {
+			cpCmd := exec.CommandContext(
+				context.Background(),
+				"kubectl", "cp",
+				localPath,
+				fmt.Sprintf("%s/%s:/usr/share/nginx/html/%s", namespace, bundleServerPodNames[0], remoteName),
+			)
+			cpOut, cpErr := cpCmd.CombinedOutput()
+			Expect(cpErr).ToNot(HaveOccurred(), "kubectl cp %s failed: %s", localPath, string(cpOut))
+		}
+
+		nginxPodNames, err := resourceManager.GetReadyNginxPodNames(
+			namespace,
+			timeoutConfig.GetStatusTimeout,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nginxPodNames).To(HaveLen(1))
+
+		nginxPodName = nginxPodNames[0]
+
+		setUpPortForward(nginxPodName, namespace)
+	})
+
+	AfterAll(func() {
+		framework.AddNginxLogsAndEventsToReport(resourceManager, namespace)
+		cleanUpPortForward()
+
+		Expect(resourceManager.DeleteNamespace(namespace)).To(Succeed())
+	})
+
+	Context("WAF sidecar containers", func() {
+		It("are injected into the NGINX pod when NginxProxy has waf enabled", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
+			defer cancel()
+
+			var pod core.Pod
+			Expect(resourceManager.Get(ctx, types.NamespacedName{Name: nginxPodName, Namespace: namespace}, &pod)).
+				To(Succeed())
+
+			containerNames := make([]string, 0, len(pod.Spec.Containers))
+			for _, c := range pod.Spec.Containers {
+				containerNames = append(containerNames, c.Name)
+			}
+
+			Expect(containerNames).To(ContainElements("waf-enforcer", "waf-config-mgr"),
+				"expected WAF sidecar containers to be present in the NGINX pod")
+		})
+	})
+
+	Context("when a valid WAFPolicy targeting an existing Gateway is created", func() {
+		policyFiles := []string{"waf-policy/wafpolicy.yaml"}
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		It("is accepted by the Gateway", func() {
+			nsname := types.NamespacedName{Name: "gateway-waf", Namespace: namespace}
+			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
+		})
+
+		It("produces the correct NGINX directives", func() {
+			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			// app_protect_enable is set at the server level for gateway-targeted policies
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_enable",
+				Value:     "on",
+				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
+			})).To(Succeed())
+
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_policy_file",
+				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
+				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
+			})).To(Succeed())
+
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_security_log_enable",
+				Value:     "on",
+				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
+			})).To(Succeed())
+
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_security_log",
+				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf_log_34f5fe1a8362f3e5.tgz stderr", namespace),
+				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
+			})).To(Succeed())
+		})
+
+		It("blocks requests containing attack signatures", func() {
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			// </script> is a classic XSS payload that the attack-signatures policy blocks.
+			attackURL := fmt.Sprintf("http://cafe.example.com:%d/coffee?x=%%3C%%2Fscript%%3E", port)
+
+			Eventually(func() (bool, error) {
+				resp, err := framework.Get(framework.Request{
+					URL:     attackURL,
+					Address: address,
+					Timeout: timeoutConfig.RequestTimeout,
+				})
+				if err != nil {
+					return false, err
+				}
+				return strings.Contains(resp.Body, "Request Rejected"), nil
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(BeTrue(), "expected WAF to block XSS attack signature")
+		})
+
+		It("allows responses containing sensitive data without a dataguard policy", func() {
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			coffeeURL := fmt.Sprintf("http://cafe.example.com:%d/coffee", port)
+
+			// The attack-signatures policy does not mask response data — SSN passes through.
+			Eventually(func() (bool, error) {
+				resp, err := framework.Get(framework.Request{
+					URL:     coffeeURL,
+					Address: address,
+					Timeout: timeoutConfig.RequestTimeout,
+				})
+				if err != nil {
+					return false, err
+				}
+				return strings.Contains(resp.Body, "123-45-6789"), nil
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(BeTrue(), "expected SSN to pass through without a dataguard policy")
+		})
+	})
+
+	Context("when a WAFPolicy targets an HTTPRoute", func() {
+		policyFiles := []string{"waf-policy/wafpolicy-route.yaml"}
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		It("is accepted", func() {
+			nsname := types.NamespacedName{Name: "coffee-route-waf", Namespace: namespace}
+			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
+		})
+
+		It("produces WAF directives in the location block for the targeted route", func() {
+			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			// For an HTTPRoute-targeted policy, directives are in the location block.
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_enable",
+				Value:     "on",
+				File:      fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace),
+				Location:  "/coffee",
+			})).To(Succeed())
+
+			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_policy_file",
+				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_coffee-route-waf.tgz", namespace),
+				File:      fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace),
+				Location:  "/coffee",
+			})).To(Succeed())
+		})
+
+		It("masks sensitive data in responses on the protected route", func() {
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			coffeeURL := fmt.Sprintf("http://cafe.example.com:%d/coffee", port)
+
+			// The dataguard policy on the coffee route masks SSN and credit card numbers.
+			Eventually(func() (bool, error) {
+				resp, err := framework.Get(framework.Request{
+					URL:     coffeeURL,
+					Address: address,
+					Timeout: timeoutConfig.RequestTimeout,
+				})
+				if err != nil {
+					return false, err
+				}
+				return !strings.Contains(resp.Body, "4111-1111-1111-1111") &&
+					!strings.Contains(resp.Body, "123-45-6789"), nil
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(BeTrue(), "expected WAF dataguard to mask sensitive data on the coffee route")
+		})
+
+		It("does not mask sensitive data on the unprotected tea route", func() {
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			teaURL := fmt.Sprintf("http://cafe.example.com:%d/tea", port)
+
+			Eventually(func() error {
+				return framework.ExpectRequestToSucceed(
+					timeoutConfig.RequestTimeout, teaURL, address, "URI: /tea",
+				)
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500 * time.Millisecond).
+				Should(Succeed())
+		})
+	})
+
+	Context("when a WAFPolicy references a nonexistent bundle", func() {
+		policyFiles := []string{"waf-policy/wafpolicy-missing-bundle.yaml"}
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		It("has a Programmed=False/Pending condition", func() {
+			nsname := types.NamespacedName{Name: "gateway-waf-missing-bundle", Namespace: namespace}
+			Expect(waitForWAFPolicyCondition(nsname, "Programmed", metav1.ConditionFalse, "Pending")).To(Succeed())
+		})
+
+		It("does not add app_protect directives to NGINX config", func() {
+			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+				Directive: "app_protect_policy_file",
+				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf-missing-bundle.tgz", namespace),
+				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf-missing-bundle.conf", namespace),
+			})
+			Expect(err).To(HaveOccurred(), "expected no WAF policy directive for missing bundle")
+		})
+	})
+
+	Context("when a WAFPolicy targets a nonexistent Gateway", func() {
+		policyFiles := []string{"waf-policy/invalid-wafpolicy.yaml"}
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		It("is created without error and has no ancestor status", func() {
+			// When the target Gateway does not exist, NGF does not process the policy and sets no
+			// ancestor status — the policy is silently ignored until its target appears.
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
+			defer cancel()
+
+			var pol ngfAPI.WAFPolicy
+			Expect(resourceManager.Get(
+				ctx,
+				types.NamespacedName{Name: "gateway-waf-invalid", Namespace: namespace},
+				&pol,
+			)).To(Succeed())
+
+			Expect(pol.Status.Ancestors).To(BeEmpty(),
+				"expected no ancestor status for a policy targeting a nonexistent Gateway")
+		})
+	})
+
+	Context("when a WAFPolicy with polling is applied and the bundle becomes unavailable", Ordered, func() {
+		// This context exercises the stale-bundle (fail-open) path:
+		// NGF keeps the last successfully fetched bundle active and sets
+		// Programmed=True/StaleBundleWarning instead of removing WAF protection.
+		policyFiles := []string{"waf-policy/wafpolicy-polling.yaml"}
+
+		var bundleServerPodName string
+
+		BeforeAll(func() {
+			bundleServerPodNames, err := resourceManager.GetPodNames(
+				namespace, client.MatchingLabels{"app": "bundle-server"},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bundleServerPodNames).To(HaveLen(1))
+			bundleServerPodName = bundleServerPodNames[0]
+
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			// Restore the bundle so other tests are not affected.
+			cpCmd := exec.CommandContext( //nolint:gosec // not a subprocess launched with tainted input
+				context.Background(),
+				"kubectl", "cp",
+				"manifests/waf-policy/attack-signatures-blocking.tgz",
+				fmt.Sprintf("%s/%s:/usr/share/nginx/html/attack-signatures-blocking.tgz", namespace, bundleServerPodName),
+			)
+			cpOut, cpErr := cpCmd.CombinedOutput()
+			Expect(cpErr).ToNot(HaveOccurred(), "kubectl cp to restore bundle failed: %s", string(cpOut))
+
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+		})
+
+		It("is accepted and enforces WAF while the bundle is available", func() {
+			nsname := types.NamespacedName{Name: "gateway-waf-polling", Namespace: namespace}
+			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
+
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			attackURL := fmt.Sprintf("http://cafe.example.com:%d/coffee?x=%%3C%%2Fscript%%3E", port)
+
+			Eventually(func() (bool, error) {
+				resp, err := framework.Get(framework.Request{
+					URL:     attackURL,
+					Address: address,
+					Timeout: timeoutConfig.RequestTimeout,
+				})
+				if err != nil {
+					return false, err
+				}
+				return strings.Contains(resp.Body, "Request Rejected"), nil
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(BeTrue(), "expected WAF to be active before bundle removal")
+		})
+
+		It("transitions to Programmed=True/StaleBundleWarning after the bundle is removed and keeps WAF active", func() {
+			// Remove the bundle from the server so the next poll fetch returns 404.
+			rmCmd := exec.CommandContext(
+				context.Background(),
+				"kubectl", "exec",
+				"-n", namespace,
+				bundleServerPodName,
+				"--",
+				"rm", "-f", "/usr/share/nginx/html/attack-signatures-blocking.tgz",
+			)
+			rmOut, rmErr := rmCmd.CombinedOutput()
+			Expect(rmErr).ToNot(HaveOccurred(), "kubectl exec rm failed: %s", string(rmOut))
+
+			// Wait for the poller to attempt re-fetch (interval is 30s) and set the stale warning.
+			// Allow up to 90s: one full interval plus generous processing time.
+			nsname := types.NamespacedName{Name: "gateway-waf-polling", Namespace: namespace}
+			Expect(waitForWAFPolicyCondition(
+				nsname, "Programmed", metav1.ConditionTrue, "StaleBundleWarning",
+				90*time.Second,
+			)).To(Succeed())
+
+			// Confirm WAF is still enforcing with the stale bundle — XSS should still be blocked.
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			attackURL := fmt.Sprintf("http://cafe.example.com:%d/coffee?x=%%3C%%2Fscript%%3E", port)
+
+			Eventually(func() (bool, error) {
+				resp, err := framework.Get(framework.Request{
+					URL:     attackURL,
+					Address: address,
+					Timeout: timeoutConfig.RequestTimeout,
+				})
+				if err != nil {
+					return false, err
+				}
+				return strings.Contains(resp.Body, "Request Rejected"), nil
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(BeTrue(), "expected WAF to remain active using stale bundle after fetch failure")
+		})
+	})
+
+	Context("when a WAFPolicy is deleted", Ordered, func() {
+		policyFiles := []string{"waf-policy/wafpolicy.yaml"}
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
+			nsname := types.NamespacedName{Name: "gateway-waf", Namespace: namespace}
+			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
+		})
+
+		It("removes WAF directives from the NGINX config after deletion", func() {
+			Expect(resourceManager.DeleteFromFiles(policyFiles, namespace)).To(Succeed())
+
+			Eventually(func() error {
+				conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+				if err != nil {
+					return err
+				}
+				err = framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+					Directive: "app_protect_policy_file",
+					Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
+					File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
+				})
+				if err == nil {
+					return fmt.Errorf("app_protect_policy_file directive still present after policy deletion")
+				}
+				return nil
+			}).
+				WithTimeout(timeoutConfig.GetStatusTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(Succeed(), "expected WAF directives to be removed after policy deletion")
+		})
+
+		It("continues to serve traffic after WAF policy removal", func() {
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			coffeeURL := fmt.Sprintf("http://cafe.example.com:%d/coffee", port)
+
+			Eventually(func() error {
+				return framework.ExpectRequestToSucceed(
+					timeoutConfig.RequestTimeout, coffeeURL, address, "Customer List",
+				)
+			}).
+				WithTimeout(timeoutConfig.RequestTimeout).
+				WithPolling(500*time.Millisecond).
+				Should(Succeed(), "expected traffic to continue after WAF policy removal")
+		})
+	})
+})
+
+// waitForWAFPolicyAccepted polls until the WAFPolicy has Accepted/True/Accepted.
+func waitForWAFPolicyAccepted(nsname types.NamespacedName) error {
+	return waitForWAFPolicyAncestorStatus(nsname, metav1.ConditionTrue, v1.PolicyReasonAccepted)
+}
+
+// waitForWAFPolicyCondition polls until the WAFPolicy ancestor has a condition of the given type,
+// status, and reason. Pass 0 for timeout to use the default GetStatusTimeout.
+func waitForWAFPolicyCondition(
+	nsname types.NamespacedName,
+	condType string,
+	condStatus metav1.ConditionStatus,
+	reason string,
+	timeout ...time.Duration,
+) error {
+	d := timeoutConfig.GetStatusTimeout
+	if len(timeout) > 0 && timeout[0] > 0 {
+		d = timeout[0]
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+
+	GinkgoWriter.Printf(
+		"Waiting for WAFPolicy %q to have condition %s/%s/%s\n",
+		nsname, condType, condStatus, reason,
+	)
+
+	return wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true,
+		func(ctx context.Context) (bool, error) {
+			var pol ngfAPI.WAFPolicy
+			if err := resourceManager.Get(ctx, nsname, &pol); err != nil {
+				return false, err
+			}
+
+			if len(pol.Status.Ancestors) == 0 {
+				GinkgoWriter.Printf("WAFPolicy %q has no ancestor status yet\n", nsname)
+				return false, nil
+			}
+
+			for _, cond := range pol.Status.Ancestors[0].Conditions {
+				if cond.Type != condType {
+					continue
+				}
+				if string(cond.Status) == string(condStatus) && cond.Reason == reason {
+					return true, nil
+				}
+				GinkgoWriter.Printf(
+					"WAFPolicy %q condition %s is %s/%s, waiting for %s/%s\n",
+					nsname, condType, cond.Status, cond.Reason, condStatus, reason,
+				)
+				return false, nil
+			}
+
+			GinkgoWriter.Printf("WAFPolicy %q has no %s condition yet\n", nsname, condType)
+			return false, nil
+		},
+	)
+}
+
+// waitForWAFPolicyAncestorStatus polls until the WAFPolicy ancestor status has the given condition.
+func waitForWAFPolicyAncestorStatus(
+	nsname types.NamespacedName,
+	condStatus metav1.ConditionStatus,
+	condReason v1.PolicyConditionReason,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
+	defer cancel()
+
+	GinkgoWriter.Printf(
+		"Waiting for WAFPolicy %q to have condition Accepted/%s/%s\n",
+		nsname, condStatus, condReason,
+	)
+
+	return wait.PollUntilContextCancel(
+		ctx,
+		500*time.Millisecond,
+		true, /* poll immediately */
+		func(ctx context.Context) (bool, error) {
+			var pol ngfAPI.WAFPolicy
+			if err := resourceManager.Get(ctx, nsname, &pol); err != nil {
+				return false, err
+			}
+
+			if len(pol.Status.Ancestors) == 0 {
+				GinkgoWriter.Printf("WAFPolicy %q has no ancestor status yet\n", nsname)
+				return false, nil
+			}
+
+			ancestor := pol.Status.Ancestors[0]
+
+			if ancestor.ControllerName != framework.NgfControllerName {
+				return false, fmt.Errorf(
+					"expected controller name %s, got %s",
+					framework.NgfControllerName,
+					ancestor.ControllerName,
+				)
+			}
+
+			for _, cond := range ancestor.Conditions {
+				if cond.Type != string(v1.PolicyConditionAccepted) {
+					continue
+				}
+				if cond.Status == condStatus && cond.Reason == string(condReason) {
+					return true, nil
+				}
+				return false, fmt.Errorf(
+					"Accepted condition is %s/%s, expected %s/%s",
+					cond.Status, cond.Reason, condStatus, condReason,
+				)
+			}
+
+			GinkgoWriter.Printf("WAFPolicy %q has no Accepted condition yet\n", nsname)
+			return false, nil
+		},
+	)
+}

--- a/tests/suite/waf_policy_test.go
+++ b/tests/suite/waf_policy_test.go
@@ -107,8 +107,8 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 		Expect(resourceManager.DeleteNamespace(namespace)).To(Succeed())
 	})
 
-	Context("WAF sidecar containers", func() {
-		It("are injected into the NGINX pod when NginxProxy has waf enabled", func() {
+	Context("when NginxProxy has WAF enabled", func() {
+		It("injects WAF sidecar containers into the NGINX pod", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
 			defer cancel()
 
@@ -146,30 +146,36 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			// app_protect_enable is set at the server level for gateway-targeted policies
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_enable",
-				Value:     "on",
-				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
-			})).To(Succeed())
-
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_policy_file",
-				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
-				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
-			})).To(Succeed())
-
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_security_log_enable",
-				Value:     "on",
-				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
-			})).To(Succeed())
-
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_security_log",
-				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf_log_34f5fe1a8362f3e5.tgz stderr", namespace),
-				File:      fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace),
-			})).To(Succeed())
+			// app_protect directives are set at the server level for gateway-targeted policies.
+			wafFile := fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace)
+			expectedFields := []framework.ExpectedNginxField{
+				{
+					Directive: "app_protect_enable",
+					Value:     "on",
+					File:      wafFile,
+				},
+				{
+					Directive: "app_protect_policy_file",
+					Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
+					File:      wafFile,
+				},
+				{
+					Directive: "app_protect_security_log_enable",
+					Value:     "on",
+					File:      wafFile,
+				},
+				{
+					// Use substring match: the log bundle filename contains a content-derived hash
+					// that may change across compiler versions.
+					Directive:             "app_protect_security_log",
+					Value:                 fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf_log_", namespace),
+					File:                  wafFile,
+					ValueSubstringAllowed: true,
+				},
+			}
+			for _, field := range expectedFields {
+				Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
+			}
 		})
 
 		It("blocks requests containing attack signatures", func() {
@@ -242,19 +248,24 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// For an HTTPRoute-targeted policy, directives are in the location block.
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_enable",
-				Value:     "on",
-				File:      fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace),
-				Location:  "/coffee",
-			})).To(Succeed())
-
-			Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-				Directive: "app_protect_policy_file",
-				Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_coffee-route-waf.tgz", namespace),
-				File:      fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace),
-				Location:  "/coffee",
-			})).To(Succeed())
+			wafFile := fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace)
+			expectedFields := []framework.ExpectedNginxField{
+				{
+					Directive: "app_protect_enable",
+					Value:     "on",
+					File:      wafFile,
+					Location:  "/coffee",
+				},
+				{
+					Directive: "app_protect_policy_file",
+					Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_coffee-route-waf.tgz", namespace),
+					File:      wafFile,
+					Location:  "/coffee",
+				},
+			}
+			for _, field := range expectedFields {
+				Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
+			}
 		})
 
 		It("masks sensitive data in responses on the protected route", func() {
@@ -282,7 +293,7 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 				Should(BeTrue(), "expected WAF dataguard to mask sensitive data on the coffee route")
 		})
 
-		It("does not mask sensitive data on the unprotected tea route", func() {
+		It("allows requests to the unprotected tea route", func() {
 			port := 80
 			if portFwdPort != 0 {
 				port = portFwdPort
@@ -419,23 +430,23 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 
 		It("transitions to Programmed=True/StaleBundleWarning after the bundle is removed and keeps WAF active", func() {
 			// Remove the bundle from the server so the next poll fetch returns 404.
-			rmCmd := exec.CommandContext(
-				context.Background(),
-				"kubectl", "exec",
-				"-n", namespace,
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.RequestTimeout)
+			defer cancel()
+			_, err := resourceManager.ExecInPod(
+				ctx,
+				namespace,
 				bundleServerPodName,
-				"--",
-				"rm", "-f", "/usr/share/nginx/html/attack-signatures-blocking.tgz",
+				"",
+				[]string{"rm", "-f", "/usr/share/nginx/html/attack-signatures-blocking.tgz"},
 			)
-			rmOut, rmErr := rmCmd.CombinedOutput()
-			Expect(rmErr).ToNot(HaveOccurred(), "kubectl exec rm failed: %s", string(rmOut))
+			Expect(err).ToNot(HaveOccurred(), "failed to remove bundle from server")
 
-			// Wait for the poller to attempt re-fetch (interval is 30s) and set the stale warning.
-			// Allow up to 90s: one full interval plus generous processing time.
+			// Wait for the poller to attempt re-fetch (interval is 15s) and set the stale warning.
+			// Allow up to 45s: one full interval plus generous processing time.
 			nsname := types.NamespacedName{Name: "gateway-waf-polling", Namespace: namespace}
 			Expect(waitForWAFPolicyCondition(
 				nsname, "Programmed", metav1.ConditionTrue, "StaleBundleWarning",
-				90*time.Second,
+				45*time.Second,
 			)).To(Succeed())
 
 			// Confirm WAF is still enforcing with the stale bundle — XSS should still be blocked.

--- a/tests/suite/waf_policy_test.go
+++ b/tests/suite/waf_policy_test.go
@@ -129,6 +129,8 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 	Context("when a valid WAFPolicy targeting an existing Gateway is created", func() {
 		policyFiles := []string{"waf-policy/wafpolicy.yaml"}
 
+		var conf *framework.Payload
+
 		BeforeAll(func() {
 			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
 		})
@@ -140,43 +142,40 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 		It("is accepted by the Gateway", func() {
 			nsname := types.NamespacedName{Name: "gateway-waf", Namespace: namespace}
 			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
-		})
 
-		It("produces the correct NGINX directives", func() {
-			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+			var err error
+			conf, err = resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
 			Expect(err).ToNot(HaveOccurred())
-
-			// app_protect directives are set at the server level for gateway-targeted policies.
-			wafFile := fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace)
-			expectedFields := []framework.ExpectedNginxField{
-				{
-					Directive: "app_protect_enable",
-					Value:     "on",
-					File:      wafFile,
-				},
-				{
-					Directive: "app_protect_policy_file",
-					Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
-					File:      wafFile,
-				},
-				{
-					Directive: "app_protect_security_log_enable",
-					Value:     "on",
-					File:      wafFile,
-				},
-				{
-					// Use substring match: the log bundle filename contains a content-derived hash
-					// that may change across compiler versions.
-					Directive:             "app_protect_security_log",
-					Value:                 fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf_log_", namespace),
-					File:                  wafFile,
-					ValueSubstringAllowed: true,
-				},
-			}
-			for _, field := range expectedFields {
-				Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
-			}
 		})
+
+		// app_protect directives are set at the server level for gateway-targeted policies.
+		// The log bundle filename contains a content-derived hash that may change across compiler
+		// versions, so ValueSubstringAllowed is used for that assertion.
+		DescribeTable("produces the correct NGINX directives",
+			func(expFields []framework.ExpectedNginxField) {
+				for _, field := range expFields {
+					Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
+				}
+			},
+			Entry("server-level WAF directives", func() []framework.ExpectedNginxField {
+				wafFile := fmt.Sprintf("WAFPolicy_%s_gateway-waf.conf", namespace)
+				return []framework.ExpectedNginxField{
+					{Directive: "app_protect_enable", Value: "on", File: wafFile},
+					{
+						Directive: "app_protect_policy_file",
+						Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf.tgz", namespace),
+						File:      wafFile,
+					},
+					{Directive: "app_protect_security_log_enable", Value: "on", File: wafFile},
+					{
+						Directive:             "app_protect_security_log",
+						Value:                 fmt.Sprintf("/etc/app_protect/bundles/%s_gateway-waf_log_", namespace),
+						File:                  wafFile,
+						ValueSubstringAllowed: true,
+					},
+				}
+			}()),
+		)
 
 		It("blocks requests containing attack signatures", func() {
 			port := 80
@@ -230,6 +229,8 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 	Context("when a WAFPolicy targets an HTTPRoute", func() {
 		policyFiles := []string{"waf-policy/wafpolicy-route.yaml"}
 
+		var conf *framework.Payload
+
 		BeforeAll(func() {
 			Expect(resourceManager.ApplyFromFiles(policyFiles, namespace)).To(Succeed())
 		})
@@ -241,32 +242,32 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 		It("is accepted", func() {
 			nsname := types.NamespacedName{Name: "coffee-route-waf", Namespace: namespace}
 			Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
-		})
 
-		It("produces WAF directives in the location block for the targeted route", func() {
-			conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
+			var err error
+			conf, err = resourceManager.GetNginxConfig(nginxPodName, namespace, nginxCrossplanePath)
 			Expect(err).ToNot(HaveOccurred())
-
-			// For an HTTPRoute-targeted policy, directives are in the location block.
-			wafFile := fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace)
-			expectedFields := []framework.ExpectedNginxField{
-				{
-					Directive: "app_protect_enable",
-					Value:     "on",
-					File:      wafFile,
-					Location:  "/coffee",
-				},
-				{
-					Directive: "app_protect_policy_file",
-					Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_coffee-route-waf.tgz", namespace),
-					File:      wafFile,
-					Location:  "/coffee",
-				},
-			}
-			for _, field := range expectedFields {
-				Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
-			}
 		})
+
+		// For an HTTPRoute-targeted policy, directives appear in the location block.
+		DescribeTable("produces WAF directives in the location block",
+			func(expFields []framework.ExpectedNginxField) {
+				for _, field := range expFields {
+					Expect(framework.ValidateNginxFieldExists(conf, field)).To(Succeed())
+				}
+			},
+			Entry("location-level WAF directives", func() []framework.ExpectedNginxField {
+				wafFile := fmt.Sprintf("WAFPolicy_%s_coffee-route-waf.conf", namespace)
+				return []framework.ExpectedNginxField{
+					{Directive: "app_protect_enable", Value: "on", File: wafFile, Location: "/coffee"},
+					{
+						Directive: "app_protect_policy_file",
+						Value:     fmt.Sprintf("/etc/app_protect/bundles/%s_coffee-route-waf.tgz", namespace),
+						File:      wafFile,
+						Location:  "/coffee",
+					},
+				}
+			}()),
+		)
 
 		It("masks sensitive data in responses on the protected route", func() {
 			port := 80


### PR DESCRIPTION
### Proposed changes

Problem: We don't have any functional tests asserting WAFPolicy behaviour

Solution: Add functional tests for WAFPolicy.

Test cases:

```
WAF sidecar containers

- WAF enforcer and config-mgr containers are injected into the NGINX pod when NginxProxy has WAF enabled

Valid WAFPolicy targeting a Gateway

- Policy is accepted by the Gateway
- Correct NGINX directives are produced (app_protect_enable, app_protect_policy_file, app_protect_security_log_enable, app_protect_security_log)
- XSS attack signatures are blocked
- Responses containing sensitive data pass through without a dataguard policy

WAFPolicy targeting an HTTPRoute

- Policy is accepted
- WAF directives appear in the location block for the targeted route
- Sensitive data (SSN, credit card) is masked on the protected route
- Sensitive data is not masked on the unprotected tea route

WAFPolicy referencing a nonexistent bundle

- Has a Programmed=False/Pending condition
- No app_protect directives are added to NGINX config

WAFPolicy targeting a nonexistent Gateway

- Created without error and has no ancestor status

WAFPolicy with polling — bundle becomes unavailable

- WAF is accepted and enforces (XSS blocked) while bundle is available
- Transitions to Programmed=True/StaleBundleWarning after bundle is removed, and WAF remains active using the stale bundle

WAFPolicy deletion

- WAF directives are removed from NGINX config after deletion
- Traffic continues to be served after policy removal
```

Testing: Ran the tests locally and in the pipeline.

Closes #3461 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
