### PR TITLE
When fetching WAF policy bundles from NIM, validate the checksum

### DIFF
--- a/internal/framework/waf/fetch/fetch.go
+++ b/internal/framework/waf/fetch/fetch.go
@@ -413,7 +413,10 @@ func fetchHTTP(ctx context.Context, client *http.Client, req Request) ([]byte, s
 // nimResponse is the JSON envelope returned by the NIM bundles API.
 type nimResponse struct {
 	Items []struct {
-		Content string `json:"content"`
+		Content  string `json:"content"`
+		Metadata struct {
+			Hash string `json:"hash"`
+		} `json:"metadata"`
 	} `json:"items"`
 }
 
@@ -447,7 +450,21 @@ func fetchNIM(ctx context.Context, client *http.Client, req Request) ([]byte, st
 		return nil, "", fmt.Errorf("failed to base64-decode NIM bundle content: %w", err)
 	}
 
-	return data, ComputeChecksum(data), nil
+	actualChecksum := ComputeChecksum(data)
+	bundleHash := resp.Items[0].Metadata.Hash
+
+	// Verify the downloaded bundle against the hash reported by the NIM API,
+	// unless the caller supplied their own ExpectedChecksum via BundleValidation
+	// (the outer Fetch loop will check that instead).
+	if bundleHash != "" && req.ExpectedChecksum == "" {
+		if actualChecksum != strings.ToLower(bundleHash) {
+			return nil, "", &nonTransientError{
+				err: fmt.Errorf("NIM bundle integrity check failed: expected %s, got %s", bundleHash, actualChecksum),
+			}
+		}
+	}
+
+	return data, actualChecksum, nil
 }
 
 func fetchNIMLogProfile(ctx context.Context, client *http.Client, req Request) ([]byte, string, error) {

--- a/internal/framework/waf/fetch/fetch_test.go
+++ b/internal/framework/waf/fetch/fetch_test.go
@@ -408,6 +408,116 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("checksum mismatch"))
 	})
+
+	t.Run("NIM api hash auto-verifies bundle without user-supplied checksum", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		originalBundleContent := []byte("original-bundle")
+		corruptBundleContent := []byte("corrupted-bundle")
+		encodedCorruptBundle := base64.StdEncoding.EncodeToString(corruptBundleContent)
+		originalBundleHash := fetch.ComputeChecksum(originalBundleContent)
+
+		// Serve a bundle whose content differs from what the metadata reports as the hash.
+		corruptHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// Return the hash of the original bundle but serve the corrupted content.
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{
+					"content": encodedCorruptBundle,
+					"metadata": map[string]any{
+						"hash": originalBundleHash,
+					},
+				}},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+
+		srv := httptest.NewServer(corruptHandler)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		_, _, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "my-policy",
+			// No ExpectedChecksum set — NIM API hash should be used automatically.
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("NIM bundle integrity check failed"))
+	})
+
+	t.Run("NIM api hash verification succeeds when hash matches", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		bundleContent := []byte("valid-nim-bundle")
+		encodedBundle := base64.StdEncoding.EncodeToString(bundleContent)
+		bundleHash := fetch.ComputeChecksum(bundleContent)
+
+		nimHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{
+					"content": encodedBundle,
+					"metadata": map[string]any{
+						"hash": bundleHash,
+					},
+				}},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+
+		srv := httptest.NewServer(nimHandler)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		data, checksum, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "my-policy",
+			// No ExpectedChecksum set — NIM API hash should be used automatically.
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(data).To(Equal(bundleContent))
+		g.Expect(checksum).To(Equal(bundleHash))
+	})
+
+	t.Run("user-supplied checksum takes precedence over NIM api hash", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		bundleContent := []byte("user-verified-bundle")
+		encodedBundle := base64.StdEncoding.EncodeToString(bundleContent)
+		wrongHash := strings.Repeat("a", 64)
+
+		nimHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// NIM returns a wrong hash, but user supplies correct one.
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{
+					"content": encodedBundle,
+					"metadata": map[string]any{
+						"hash": wrongHash,
+					},
+				}},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+
+		srv := httptest.NewServer(nimHandler)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		data, _, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
+			URL:              srv.URL,
+			PolicyName:       "my-policy",
+			ExpectedChecksum: fetch.ComputeChecksum(bundleContent),
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(data).To(Equal(bundleContent))
+	})
 }
 
 func TestN1CFetchExpectedChecksumEnforced(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

Problem: There is no validation to check if the contents of the NIM policy bundle that is downloaded is correct.

Solution: Check that the hash of the contents matches the hash returned in the response.

Testing: Added unit tests and manually verified in a test environment.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
