### PR TITLE
Set the default SSL verify depth to 4

### DIFF
--- a/internal/controller/nginx/config/servers_template.go
+++ b/internal/controller/nginx/config/servers_template.go
@@ -233,6 +233,7 @@ server {
             {{- if $l.ProxySSLVerify }}
         {{ $proxyOrGRPC }}_ssl_server_name on;
         {{ $proxyOrGRPC }}_ssl_verify on;
+        {{ $proxyOrGRPC }}_ssl_verify_depth 4;
                 {{- if $l.ProxySSLVerify.Name}}
         {{ $proxyOrGRPC }}_ssl_name {{ $l.ProxySSLVerify.Name }};
                 {{- end }}

--- a/internal/controller/nginx/config/servers_test.go
+++ b/internal/controller/nginx/config/servers_test.go
@@ -198,6 +198,8 @@ func TestExecuteServers(t *testing.T) {
 		"ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:HIGH:!aNULL:!MD5;": 1,
 		"ssl_prefer_server_ciphers on;":                     1,
 		"proxy_ssl_server_name on;":                         1,
+		"proxy_ssl_verify on;":                              1,
+		"proxy_ssl_verify_depth 4;":                         1,
 		"status_zone":                                       0,
 		"include /etc/nginx/includes/location-snippet.conf": 1,
 		"include /etc/nginx/includes/server-snippet.conf":   1,

--- a/tests/suite/authentication_filter_test.go
+++ b/tests/suite/authentication_filter_test.go
@@ -1418,6 +1418,13 @@ var _ = Describe("AuthenticationFilter", Ordered, Label("functional", "auth-filt
 							Location:  internalLocation,
 						},
 						{
+							Directive: "proxy_ssl_verify_depth",
+							Value:     "4",
+							File:      "http.conf",
+							Server:    "*.example.com",
+							Location:  internalLocation,
+						},
+						{
 							Directive: "proxy_ssl_server_name",
 							Value:     "on",
 							File:      "http.conf",


### PR DESCRIPTION
### Proposed changes

Problem: Currently `proxy_ssl_verify_depth` and `grpc_ssl_verify_depth` directives are not being set causing NGINX to default them to 1 which means only 1 intermediate certificate is allowed.

Solution: Set the default value to 4 to allow for more intermediate certificates to be allowed.

Testing: Unit tests updated and verified manually using secure-backend example

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5115 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
When using a BackendTLSPolicy, the proxy_ssl_verify_depth is now set to 4, enabling intermediate cert chain validation.
```
