### PR TITLE
Fix InferencePool tracking

### DIFF
--- a/internal/controller/state/graph/inferencepools.go
+++ b/internal/controller/state/graph/inferencepools.go
@@ -99,8 +99,13 @@ func processInferencePoolsForGateway(
 					namespace = string(*ref.Namespace)
 				}
 
+				name := ref.InferencePoolName
+				if name == "" {
+					name = string(ref.Name)
+				}
+
 				poolName := types.NamespacedName{
-					Name:      ref.InferencePoolName,
+					Name:      name,
 					Namespace: namespace,
 				}
 

--- a/internal/controller/state/graph/inferencepools_test.go
+++ b/internal/controller/state/graph/inferencepools_test.go
@@ -133,6 +133,27 @@ func TestBuildReferencedInferencePools(t *testing.T) {
 		return route
 	})
 
+	// Simulates a route after the InferencePool was deleted and re-created:
+	// IsInferencePool is false and InferencePoolName is empty because the pool didn't exist
+	// when the route was last processed, but the original Kind and Name from the HTTPRoute
+	// spec are preserved.
+	routeWithDeletedPoolBackend := getModifiedRoute(func(route *L7Route) *L7Route {
+		route.Spec.Rules[0].RouteBackendRefs = []RouteBackendRef{
+			{
+				IsInferencePool:   false,
+				InferencePoolName: "",
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Kind:      helpers.GetPointer[gatewayv1.Kind](kinds.InferencePool),
+						Name:      "pool",
+						Namespace: helpers.GetPointer[gatewayv1.Namespace]("test"),
+					},
+				},
+			},
+		}
+		return route
+	})
+
 	invalidRoute := getModifiedRoute(func(route *L7Route) *L7Route {
 		route.Valid = false
 		return route
@@ -334,6 +355,23 @@ func TestBuildReferencedInferencePools(t *testing.T) {
 					Conditions: []conditions.Condition{},
 					// validity of InferencePool depends on condition counts only
 					Valid: true,
+				},
+			},
+		},
+		{
+			name: "deleted inferencepool backend ref still uses original name from route spec",
+			gws:  gws,
+			routes: map[RouteKey]*L7Route{
+				CreateRouteKey(validRoute.Source): routeWithDeletedPoolBackend,
+			},
+			inferencePools: map[types.NamespacedName]*inference.InferencePool{},
+			expPools: map[types.NamespacedName]*ReferencedInferencePool{
+				{Name: "pool", Namespace: "test"}: {
+					Source:     nil,
+					Gateways:   []*gatewayv1.Gateway{},
+					HTTPRoutes: []*L7Route{},
+					Conditions: []conditions.Condition{},
+					Valid:      true,
 				},
 			},
 		},

--- a/internal/controller/state/graph/inferencepools_test.go
+++ b/internal/controller/state/graph/inferencepools_test.go
@@ -359,7 +359,7 @@ func TestBuildReferencedInferencePools(t *testing.T) {
 			},
 		},
 		{
-			name: "deleted inferencepool backend ref still uses original name from route spec",
+			name: "non-existent inference pool backend ref referenced in route is still tracked",
 			gws:  gws,
 			routes: map[RouteKey]*L7Route{
 				CreateRouteKey(validRoute.Source): routeWithDeletedPoolBackend,


### PR DESCRIPTION
Problem: If an InferencePool didn't exist and an HTTPRoute referenced it, once the InferencePool was created, it still wasn't seen and config wouldn't be generated.

Solution: Use the correct name to handle the case where the InferencePool didn't exist yet.

Testing: Manually verified that adding InferencePool after Route works properly

Partially addresses: #5113 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue where an InferencePool would not be processed if added after the HTTPRoute that referenced it.
```
