### PR TITLE
Pre-generate state files to avoid traffic disruption before plus API takes over

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -843,7 +843,8 @@ func (h *eventHandlerImpl) updateNginxConf(
 	volumeMounts []v1.VolumeMount,
 ) {
 	files := h.cfg.generator.Generate(conf)
-	h.cfg.nginxUpdater.UpdateConfig(deployment, files, volumeMounts)
+	stateFiles := h.cfg.generator.GenerateStateFiles(conf)
+	h.cfg.nginxUpdater.UpdateConfig(deployment, files, stateFiles, volumeMounts)
 
 	// If using NGINX Plus, update upstream servers using the API.
 	if h.cfg.plus {

--- a/internal/controller/handler_test.go
+++ b/internal/controller/handler_test.go
@@ -74,7 +74,7 @@ var _ = Describe("eventHandler", func() {
 		Expect(fakeGenerator.GenerateArgsForCall(0)).Should(Equal(expectedConf))
 
 		Expect(fakeNginxUpdater.UpdateConfigCallCount()).Should(Equal(1))
-		_, files, _ := fakeNginxUpdater.UpdateConfigArgsForCall(0)
+		_, files, _, _ := fakeNginxUpdater.UpdateConfigArgsForCall(0)
 		Expect(expectedFiles).To(Equal(files))
 
 		Eventually(
@@ -942,7 +942,7 @@ var _ = Describe("eventHandler", func() {
 
 		// Verify that UpdateConfig was called with the volume mounts
 		Expect(fakeNginxUpdater.UpdateConfigCallCount()).Should(Equal(1))
-		_, _, volumeMounts := fakeNginxUpdater.UpdateConfigArgsForCall(0)
+		_, _, _, volumeMounts := fakeNginxUpdater.UpdateConfigArgsForCall(0)
 		Expect(volumeMounts).To(HaveLen(1))
 		Expect(volumeMounts[0].Name).To(Equal("test-volume"))
 		Expect(volumeMounts[0].MountPath).To(Equal("/etc/test"))
@@ -994,7 +994,7 @@ var _ = Describe("eventHandler", func() {
 
 		// Verify that UpdateConfig was called with the volume mounts
 		Expect(fakeNginxUpdater.UpdateConfigCallCount()).Should(Equal(1))
-		_, _, volumeMounts := fakeNginxUpdater.UpdateConfigArgsForCall(0)
+		_, _, _, volumeMounts := fakeNginxUpdater.UpdateConfigArgsForCall(0)
 		Expect(volumeMounts).To(HaveLen(1))
 		Expect(volumeMounts[0].Name).To(Equal("daemon-volume"))
 		Expect(volumeMounts[0].MountPath).To(Equal("/var/daemon"))

--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -30,7 +30,7 @@ const retryUpstreamTimeout = 5 * time.Second
 
 // NginxUpdater is an interface for updating NGINX using the NGINX agent.
 type NginxUpdater interface {
-	UpdateConfig(deployment *Deployment, files []File, volumeMounts []v1.VolumeMount)
+	UpdateConfig(deployment *Deployment, files []File, stateFiles []File, volumeMounts []v1.VolumeMount)
 	UpdateUpstreamServers(deployment *Deployment, conf dataplane.Configuration)
 }
 
@@ -88,9 +88,10 @@ func NewNginxUpdater(
 func (n *NginxUpdaterImpl) UpdateConfig(
 	deployment *Deployment,
 	files []File,
+	stateFiles []File,
 	volumeMounts []v1.VolumeMount,
 ) {
-	msg := deployment.SetFiles(files, volumeMounts)
+	msg := deployment.SetFiles(files, stateFiles, volumeMounts)
 	if msg == nil {
 		n.logger.V(1).Info("No changes to nginx configuration files, not sending to agent")
 		return

--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -64,7 +64,7 @@ func TestUpdateConfig(t *testing.T) {
 				deployment.SetPodErrorStatus("pod1", testErr)
 			}
 
-			updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+			updater.UpdateConfig(deployment, []File{file}, nil, []v1.VolumeMount{})
 
 			g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
 			fileContents, _ := deployment.GetFile(file.Meta.Name, file.Meta.Hash)
@@ -75,11 +75,112 @@ func TestUpdateConfig(t *testing.T) {
 				// ensure that the error is cleared after the next config is applied
 				deployment.SetPodErrorStatus("pod1", nil)
 				file.Meta.Hash = "5678"
-				updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+				updater.UpdateConfig(deployment, []File{file}, nil, []v1.VolumeMount{})
 				g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
 			} else {
 				g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
 			}
+		})
+	}
+}
+
+func TestUpdateConfigWithStateFiles(t *testing.T) {
+	t.Parallel()
+
+	mainFile := File{
+		Meta:     &pb.FileMeta{Name: "/etc/nginx/conf.d/http.conf", Hash: "main-hash"},
+		Contents: []byte("http config"),
+	}
+
+	tests := []struct {
+		run func(
+			g Gomega,
+			updater *NginxUpdaterImpl,
+			deployment *Deployment,
+			fakeBroadcaster *broadcastfakes.FakeBroadcaster,
+		)
+		name string
+	}{
+		{
+			name: "UpdateConfig with state files stores them on the deployment as managed entries " +
+				"(real hash, Unmanaged=false) in the broadcast overview and serves them via GetFile, " +
+				"so a fresh subscriber's agent fetches and writes them on initial config",
+			run: func(
+				g Gomega,
+				updater *NginxUpdaterImpl,
+				deployment *Deployment,
+				fakeBroadcaster *broadcastfakes.FakeBroadcaster,
+			) {
+				stateFile := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "state-hash"},
+					Contents: []byte("server 10.0.0.1:8080;\n"),
+				}
+
+				updater.UpdateConfig(deployment, []File{mainFile}, []File{stateFile}, []v1.VolumeMount{})
+				g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
+
+				stateContents, _ := deployment.GetFile(stateFile.Meta.Name, stateFile.Meta.Hash)
+				g.Expect(stateContents).To(Equal(stateFile.Contents))
+
+				overviews, _ := deployment.GetFileOverviews()
+				var stateInOverview *pb.File
+				for _, fo := range overviews {
+					if fo.GetFileMeta().GetName() == stateFile.Meta.Name {
+						stateInOverview = fo
+					}
+				}
+				g.Expect(stateInOverview).ToNot(BeNil())
+				g.Expect(stateInOverview.GetUnmanaged()).To(BeFalse())
+				g.Expect(stateInOverview.GetFileMeta().GetHash()).To(Equal("state-hash"))
+			},
+		},
+		{
+			name: "UpdateConfig called twice with same main config but different state-file content " +
+				"sends only one broadcast endpoint-only changes must not trigger a reload on existing " +
+				"pods and GetFile still serves the latest state-file content for fresh subscribers",
+			run: func(
+				g Gomega,
+				updater *NginxUpdaterImpl,
+				deployment *Deployment,
+				fakeBroadcaster *broadcastfakes.FakeBroadcaster,
+			) {
+				stateV1 := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "v1"},
+					Contents: []byte("server 10.0.0.1:8080;\n"),
+				}
+				updater.UpdateConfig(deployment, []File{mainFile}, []File{stateV1}, []v1.VolumeMount{})
+				g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
+
+				stateV2 := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "v2"},
+					Contents: []byte("server 10.0.0.99:8080;\n"),
+				}
+				updater.UpdateConfig(deployment, []File{mainFile}, []File{stateV2}, []v1.VolumeMount{})
+
+				g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1),
+					"endpoint-only state-file change must not trigger an additional broadcast or reload")
+
+				contents, _ := deployment.GetFile(stateV2.Meta.Name, stateV2.Meta.Hash)
+				g.Expect(contents).To(Equal(stateV2.Contents))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			fakeBroadcaster := &broadcastfakes.FakeBroadcaster{}
+			fakeBroadcaster.SendReturns(true)
+
+			updater := NewNginxUpdater(logr.Discard(), fake.NewFakeClient(), &status.Queue{}, nil, true)
+			deployment := &Deployment{
+				broadcaster: fakeBroadcaster,
+				podStatuses: make(map[string]error),
+			}
+
+			tt.run(g, updater, deployment, fakeBroadcaster)
 		})
 	}
 }
@@ -106,10 +207,10 @@ func TestUpdateConfig_NoChange(t *testing.T) {
 	}
 
 	// Set the initial files on the deployment
-	deployment.SetFiles([]File{file}, []v1.VolumeMount{})
+	deployment.SetFiles([]File{file}, nil, []v1.VolumeMount{})
 
 	// Call UpdateConfig with the same files
-	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	updater.UpdateConfig(deployment, []File{file}, nil, []v1.VolumeMount{})
 
 	// Verify that no new configuration was sent
 	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(0))

--- a/internal/controller/nginx/agent/agentfakes/fake_nginx_updater.go
+++ b/internal/controller/nginx/agent/agentfakes/fake_nginx_updater.go
@@ -10,12 +10,13 @@ import (
 )
 
 type FakeNginxUpdater struct {
-	UpdateConfigStub        func(*agent.Deployment, []agent.File, []v1.VolumeMount)
+	UpdateConfigStub        func(*agent.Deployment, []agent.File, []agent.File, []v1.VolumeMount)
 	updateConfigMutex       sync.RWMutex
 	updateConfigArgsForCall []struct {
 		arg1 *agent.Deployment
 		arg2 []agent.File
-		arg3 []v1.VolumeMount
+		arg3 []agent.File
+		arg4 []v1.VolumeMount
 	}
 	UpdateUpstreamServersStub        func(*agent.Deployment, dataplane.Configuration)
 	updateUpstreamServersMutex       sync.RWMutex
@@ -27,28 +28,34 @@ type FakeNginxUpdater struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNginxUpdater) UpdateConfig(arg1 *agent.Deployment, arg2 []agent.File, arg3 []v1.VolumeMount) {
+func (fake *FakeNginxUpdater) UpdateConfig(arg1 *agent.Deployment, arg2 []agent.File, arg3 []agent.File, arg4 []v1.VolumeMount) {
 	var arg2Copy []agent.File
 	if arg2 != nil {
 		arg2Copy = make([]agent.File, len(arg2))
 		copy(arg2Copy, arg2)
 	}
-	var arg3Copy []v1.VolumeMount
+	var arg3Copy []agent.File
 	if arg3 != nil {
-		arg3Copy = make([]v1.VolumeMount, len(arg3))
+		arg3Copy = make([]agent.File, len(arg3))
 		copy(arg3Copy, arg3)
+	}
+	var arg4Copy []v1.VolumeMount
+	if arg4 != nil {
+		arg4Copy = make([]v1.VolumeMount, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.updateConfigMutex.Lock()
 	fake.updateConfigArgsForCall = append(fake.updateConfigArgsForCall, struct {
 		arg1 *agent.Deployment
 		arg2 []agent.File
-		arg3 []v1.VolumeMount
-	}{arg1, arg2Copy, arg3Copy})
+		arg3 []agent.File
+		arg4 []v1.VolumeMount
+	}{arg1, arg2Copy, arg3Copy, arg4Copy})
 	stub := fake.UpdateConfigStub
-	fake.recordInvocation("UpdateConfig", []interface{}{arg1, arg2Copy, arg3Copy})
+	fake.recordInvocation("UpdateConfig", []interface{}{arg1, arg2Copy, arg3Copy, arg4Copy})
 	fake.updateConfigMutex.Unlock()
 	if stub != nil {
-		fake.UpdateConfigStub(arg1, arg2, arg3)
+		fake.UpdateConfigStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -58,17 +65,17 @@ func (fake *FakeNginxUpdater) UpdateConfigCallCount() int {
 	return len(fake.updateConfigArgsForCall)
 }
 
-func (fake *FakeNginxUpdater) UpdateConfigCalls(stub func(*agent.Deployment, []agent.File, []v1.VolumeMount)) {
+func (fake *FakeNginxUpdater) UpdateConfigCalls(stub func(*agent.Deployment, []agent.File, []agent.File, []v1.VolumeMount)) {
 	fake.updateConfigMutex.Lock()
 	defer fake.updateConfigMutex.Unlock()
 	fake.UpdateConfigStub = stub
 }
 
-func (fake *FakeNginxUpdater) UpdateConfigArgsForCall(i int) (*agent.Deployment, []agent.File, []v1.VolumeMount) {
+func (fake *FakeNginxUpdater) UpdateConfigArgsForCall(i int) (*agent.Deployment, []agent.File, []agent.File, []v1.VolumeMount) {
 	fake.updateConfigMutex.RLock()
 	defer fake.updateConfigMutex.RUnlock()
 	argsForCall := fake.updateConfigArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeNginxUpdater) UpdateUpstreamServers(arg1 *agent.Deployment, arg2 dataplane.Configuration) {

--- a/internal/controller/nginx/agent/command_test.go
+++ b/internal/controller/nginx/agent/command_test.go
@@ -353,7 +353,7 @@ func TestSubscribe(t *testing.T) {
 			Contents: []byte("file contents"),
 		},
 	}
-	deployment.SetFiles(files, []v1.VolumeMount{})
+	deployment.SetFiles(files, nil, []v1.VolumeMount{})
 	deployment.SetImageVersion("nginx:v1.0.0")
 
 	initialAction := &pb.NGINXPlusAction{
@@ -499,7 +499,7 @@ func TestSubscribe_Reset(t *testing.T) {
 			Contents: []byte("file contents"),
 		},
 	}
-	deployment.SetFiles(files, []v1.VolumeMount{})
+	deployment.SetFiles(files, nil, []v1.VolumeMount{})
 	deployment.SetImageVersion("nginx:v1.0.0")
 
 	ctx, cancel := createGrpcContextWithCancel(t)

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -62,6 +63,8 @@ type Deployment struct {
 	nginxPlusActions []*pb.NGINXPlusAction
 	fileOverviews    []*pb.File
 	files            []File
+	// stateFiles holds NGINX Plus upstream state files.
+	stateFiles []File
 
 	latestFileNames []string
 	volumeMounts    []v1.VolumeMount
@@ -196,13 +199,32 @@ func (d *Deployment) GetFile(name, hash string) ([]byte, string) {
 		}
 	}
 
+	for _, file := range d.stateFiles {
+		if name == file.Meta.GetName() {
+			fileFoundHash = file.Meta.GetHash()
+			if hash == file.Meta.GetHash() {
+				return file.Contents, file.Meta.GetHash()
+			}
+		}
+	}
+
 	return nil, fileFoundHash
 }
 
 // SetFiles updates the nginx files and fileOverviews for the deployment and returns the message to send.
+// stateFiles are NGINX Plus upstream state files . They appear as managed entries in the
+// overview so a fresh subscriber's agent fetches and writes them on initial config closing the cold-start
+// gap where empty upstreams 502 incoming traffic. configVersion is computed from non-state-file overviews
+// only, so endpoint-only changes don't bump the version and therefore
+// don't trigger a broadcast or reload on existing pods; the Plus API call handles those updates instead.
 // The deployment FileLock MUST already be locked before calling this function.
-func (d *Deployment) SetFiles(files []File, volumeMounts []v1.VolumeMount) *broadcast.NginxAgentMessage {
+func (d *Deployment) SetFiles(
+	files []File,
+	stateFiles []File,
+	volumeMounts []v1.VolumeMount,
+) *broadcast.NginxAgentMessage {
 	d.files = files
+	d.stateFiles = stateFiles
 	d.volumeMounts = volumeMounts
 
 	return d.rebuildFileOverviews()
@@ -275,10 +297,18 @@ func (d *Deployment) rebuildFileOverviews() *broadcast.NginxAgentMessage {
 		fileOverviews = append(fileOverviews, &pb.File{FileMeta: f.Meta})
 	}
 
+	stateFilePaths := make(map[string]struct{}, len(d.stateFiles))
+	for _, sf := range d.stateFiles {
+		stateFilePaths[sf.Meta.GetName()] = struct{}{}
+	}
+
 	// Build the set of unmanaged files from volume mounts.
 	fileIgnoreSet := make(map[string]struct{})
 	for _, vm := range d.volumeMounts {
 		for _, f := range d.latestFileNames {
+			if _, isStateFile := stateFilePaths[f]; isStateFile {
+				continue
+			}
 			if strings.HasPrefix(f, vm.MountPath) {
 				fileIgnoreSet[f] = struct{}{}
 			}
@@ -290,7 +320,16 @@ func (d *Deployment) rebuildFileOverviews() *broadcast.NginxAgentMessage {
 		fileIgnoreSet[f] = struct{}{}
 	}
 
+	// Sort for deterministic overview order across rebuilds; map iteration is randomized in Go,
+	// which would otherwise produce a different fileOverviews slice each call even when the
+	// underlying content is unchanged.
+	sortedIgnoreFiles := make([]string, 0, len(fileIgnoreSet))
 	for f := range fileIgnoreSet {
+		sortedIgnoreFiles = append(sortedIgnoreFiles, f)
+	}
+	sort.Strings(sortedIgnoreFiles)
+
+	for _, f := range sortedIgnoreFiles {
 		fileOverviews = append(fileOverviews, &pb.File{
 			FileMeta: &pb.FileMeta{
 				Name:        f,
@@ -301,13 +340,18 @@ func (d *Deployment) rebuildFileOverviews() *broadcast.NginxAgentMessage {
 	}
 
 	newConfigVersion := filesHelper.GenerateConfigVersion(fileOverviews)
+
+	for _, sf := range d.stateFiles {
+		fileOverviews = append(fileOverviews, &pb.File{FileMeta: sf.Meta})
+	}
+
+	d.fileOverviews = fileOverviews
+
 	if d.configVersion == newConfigVersion {
-		// files have not changed, nothing to send
 		return nil
 	}
 
 	d.configVersion = newConfigVersion
-	d.fileOverviews = fileOverviews
 
 	return &broadcast.NginxAgentMessage{
 		Type:          broadcast.ConfigApplyRequest,

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -45,7 +45,7 @@ func TestSetAndGetFiles(t *testing.T) {
 		},
 	}
 
-	msg := deployment.SetFiles(files, []v1.VolumeMount{})
+	msg := deployment.SetFiles(files, nil, []v1.VolumeMount{})
 	fileOverviews, configVersion := deployment.GetFileOverviews()
 
 	g.Expect(msg.Type).To(Equal(broadcast.ConfigApplyRequest))
@@ -62,7 +62,7 @@ func TestSetAndGetFiles(t *testing.T) {
 	g.Expect(wrongHashFile).To(BeNil())
 
 	// Set the same files again
-	msg = deployment.SetFiles(files, []v1.VolumeMount{})
+	msg = deployment.SetFiles(files, nil, []v1.VolumeMount{})
 	g.Expect(msg).To(BeNil())
 
 	newFileOverviews, _ := deployment.GetFileOverviews()
@@ -106,7 +106,7 @@ func TestSetAndGetFiles_VolumeIgnoreFiles(t *testing.T) {
 		},
 	}
 
-	msg := deployment.SetFiles(files, volumeMounts)
+	msg := deployment.SetFiles(files, nil, volumeMounts)
 	fileOverviews, configVersion := deployment.GetFileOverviews()
 
 	g.Expect(msg.Type).To(Equal(broadcast.ConfigApplyRequest))
@@ -144,11 +144,121 @@ func TestSetAndGetFiles_VolumeIgnoreFiles(t *testing.T) {
 	g.Expect(wrongHashFile).To(BeNil())
 
 	// Set the same files again
-	msg = deployment.SetFiles(files, volumeMounts)
+	msg = deployment.SetFiles(files, nil, volumeMounts)
 	g.Expect(msg).To(BeNil())
 
 	newFileOverviews, _ := deployment.GetFileOverviews()
 	g.Expect(newFileOverviews).To(Equal(fileOverviews))
+}
+
+func TestStateFiles(t *testing.T) {
+	t.Parallel()
+
+	mainFile := File{
+		Meta:     &pb.FileMeta{Name: "/etc/nginx/conf.d/http.conf", Hash: "main"},
+		Contents: []byte("http config"),
+	}
+
+	tests := []struct {
+		run  func(g Gomega)
+		name string
+	}{
+		{
+			name: "state files are appended to the overview as managed entries (real hash, " +
+				"Unmanaged=false) so a fresh subscriber's agent fetches and writes them on initial config",
+			run: func(g Gomega) {
+				deployment := newDeployment(&broadcastfakes.FakeBroadcaster{}, "")
+
+				stateFile := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "state-hash"},
+					Contents: []byte("server 10.0.0.1:8080;\n"),
+				}
+
+				deployment.SetFiles([]File{mainFile}, []File{stateFile}, nil)
+
+				overviews, _ := deployment.GetFileOverviews()
+				var stateInOverview *pb.File
+				for _, fo := range overviews {
+					if fo.GetFileMeta().GetName() == stateFile.Meta.Name {
+						stateInOverview = fo
+					}
+				}
+				g.Expect(stateInOverview).ToNot(BeNil())
+				g.Expect(stateInOverview.GetUnmanaged()).To(BeFalse())
+				g.Expect(stateInOverview.GetFileMeta().GetHash()).To(Equal("state-hash"))
+
+				contents, _ := deployment.GetFile(stateFile.Meta.Name, stateFile.Meta.Hash)
+				g.Expect(contents).To(Equal(stateFile.Contents))
+			},
+		},
+		{
+			name: "endpoint-only state-file changes do not shift configVersion" +
+				", but d.fileOverviews still reflects the latest state-file content for " +
+				"fresh subscribers connecting after the change",
+			run: func(g Gomega) {
+				deployment := newDeployment(&broadcastfakes.FakeBroadcaster{}, "")
+
+				state1 := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "h1"},
+					Contents: []byte("server 10.0.0.1:8080;\n"),
+				}
+				g.Expect(deployment.SetFiles([]File{mainFile}, []File{state1}, nil)).ToNot(BeNil())
+
+				state2 := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "h2"},
+					Contents: []byte("server 10.0.0.99:8080;\n"),
+				}
+				g.Expect(deployment.SetFiles([]File{mainFile}, []File{state2}, nil)).To(BeNil(),
+					"endpoint-only change must not bump configVersion or trigger a broadcast")
+
+				overviews, _ := deployment.GetFileOverviews()
+				var stateInOverview *pb.File
+				for _, fo := range overviews {
+					if fo.GetFileMeta().GetName() == state2.Meta.Name {
+						stateInOverview = fo
+					}
+				}
+				g.Expect(stateInOverview).ToNot(BeNil())
+				g.Expect(stateInOverview.GetFileMeta().GetHash()).To(Equal("h2"))
+
+				contents, _ := deployment.GetFile(state2.Meta.Name, state2.Meta.Hash)
+				g.Expect(contents).To(Equal(state2.Contents))
+			},
+		},
+		{
+			name: "state-file paths reported by the agent via UpdateOverview are not duplicated as " +
+				"Unmanaged stubs alongside their managed entries; the path appears exactly once and as managed",
+			run: func(g Gomega) {
+				deployment := newDeployment(&broadcastfakes.FakeBroadcaster{}, "")
+
+				stateFile := File{
+					Meta:     &pb.FileMeta{Name: "/var/lib/nginx/state/coffee.conf", Hash: "state-hash"},
+					Contents: []byte("server 10.0.0.1:8080;\n"),
+				}
+				deployment.latestFileNames = []string{stateFile.Meta.Name}
+
+				volumeMounts := []v1.VolumeMount{{Name: "nginx-lib", MountPath: "/var/lib/nginx/state"}}
+				deployment.SetFiles([]File{mainFile}, []File{stateFile}, volumeMounts)
+
+				overviews, _ := deployment.GetFileOverviews()
+				var matches []*pb.File
+				for _, fo := range overviews {
+					if fo.GetFileMeta().GetName() == stateFile.Meta.Name {
+						matches = append(matches, fo)
+					}
+				}
+				g.Expect(matches).To(HaveLen(1), "state file path must appear exactly once in the overview")
+				g.Expect(matches[0].GetUnmanaged()).To(BeFalse())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.run(NewWithT(t))
+		})
+	}
 }
 
 func TestSetNGINXPlusActions(t *testing.T) {
@@ -232,7 +342,7 @@ func TestUpdateWAFBundle(t *testing.T) {
 			setup: func(d *Deployment) {
 				d.SetFiles([]File{
 					{Meta: &pb.FileMeta{Name: "test.conf", Hash: "abc"}, Contents: []byte("conf")},
-				}, nil)
+				}, nil, nil)
 			},
 			data:           []byte("bundle-v1"),
 			expectNumFiles: 2,
@@ -318,7 +428,7 @@ func TestRemoveWAFBundle(t *testing.T) {
 			setup: func(d *Deployment) {
 				d.SetFiles([]File{
 					{Meta: &pb.FileMeta{Name: "test.conf", Hash: "abc"}, Contents: []byte("conf")},
-				}, nil)
+				}, nil, nil)
 			},
 			expectNil: true,
 		},
@@ -334,7 +444,7 @@ func TestRemoveWAFBundle(t *testing.T) {
 			setup: func(d *Deployment) {
 				d.SetFiles([]File{
 					{Meta: &pb.FileMeta{Name: "test.conf", Hash: "abc"}, Contents: []byte("conf")},
-				}, nil)
+				}, nil, nil)
 				d.UpdateWAFBundle(bundlePath, []byte("bundle-data"))
 			},
 			expectNumFiles: 1,

--- a/internal/controller/nginx/config/configfakes/fake_generator.go
+++ b/internal/controller/nginx/config/configfakes/fake_generator.go
@@ -34,6 +34,17 @@ type FakeGenerator struct {
 		result1 agent.File
 		result2 error
 	}
+	GenerateStateFilesStub        func(dataplane.Configuration) []agent.File
+	generateStateFilesMutex       sync.RWMutex
+	generateStateFilesArgsForCall []struct {
+		arg1 dataplane.Configuration
+	}
+	generateStateFilesReturns struct {
+		result1 []agent.File
+	}
+	generateStateFilesReturnsOnCall map[int]struct {
+		result1 []agent.File
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -161,6 +172,67 @@ func (fake *FakeGenerator) GenerateDeploymentContextReturnsOnCall(i int, result1
 		result1 agent.File
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeGenerator) GenerateStateFiles(arg1 dataplane.Configuration) []agent.File {
+	fake.generateStateFilesMutex.Lock()
+	ret, specificReturn := fake.generateStateFilesReturnsOnCall[len(fake.generateStateFilesArgsForCall)]
+	fake.generateStateFilesArgsForCall = append(fake.generateStateFilesArgsForCall, struct {
+		arg1 dataplane.Configuration
+	}{arg1})
+	stub := fake.GenerateStateFilesStub
+	fakeReturns := fake.generateStateFilesReturns
+	fake.recordInvocation("GenerateStateFiles", []interface{}{arg1})
+	fake.generateStateFilesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeGenerator) GenerateStateFilesCallCount() int {
+	fake.generateStateFilesMutex.RLock()
+	defer fake.generateStateFilesMutex.RUnlock()
+	return len(fake.generateStateFilesArgsForCall)
+}
+
+func (fake *FakeGenerator) GenerateStateFilesCalls(stub func(dataplane.Configuration) []agent.File) {
+	fake.generateStateFilesMutex.Lock()
+	defer fake.generateStateFilesMutex.Unlock()
+	fake.GenerateStateFilesStub = stub
+}
+
+func (fake *FakeGenerator) GenerateStateFilesArgsForCall(i int) dataplane.Configuration {
+	fake.generateStateFilesMutex.RLock()
+	defer fake.generateStateFilesMutex.RUnlock()
+	argsForCall := fake.generateStateFilesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGenerator) GenerateStateFilesReturns(result1 []agent.File) {
+	fake.generateStateFilesMutex.Lock()
+	defer fake.generateStateFilesMutex.Unlock()
+	fake.GenerateStateFilesStub = nil
+	fake.generateStateFilesReturns = struct {
+		result1 []agent.File
+	}{result1}
+}
+
+func (fake *FakeGenerator) GenerateStateFilesReturnsOnCall(i int, result1 []agent.File) {
+	fake.generateStateFilesMutex.Lock()
+	defer fake.generateStateFilesMutex.Unlock()
+	fake.GenerateStateFilesStub = nil
+	if fake.generateStateFilesReturnsOnCall == nil {
+		fake.generateStateFilesReturnsOnCall = make(map[int]struct {
+			result1 []agent.File
+		})
+	}
+	fake.generateStateFilesReturnsOnCall[i] = struct {
+		result1 []agent.File
+	}{result1}
 }
 
 func (fake *FakeGenerator) Invocations() map[string][][]interface{} {

--- a/internal/controller/nginx/config/generator.go
+++ b/internal/controller/nginx/config/generator.go
@@ -81,6 +81,8 @@ const (
 type Generator interface {
 	// Generate generates NGINX configuration files from internal representation.
 	Generate(configuration dataplane.Configuration) []agent.File
+	// GenerateStateFiles generates NGINX Plus upstream state files. Returns nil for OSS.
+	GenerateStateFiles(configuration dataplane.Configuration) []agent.File
 	// GenerateDeploymentContext generates the deployment context used for N+ licensing.
 	GenerateDeploymentContext(depCtx dataplane.DeploymentContext) (agent.File, error)
 }
@@ -156,6 +158,12 @@ func (g GeneratorImpl) Generate(conf dataplane.Configuration) []agent.File {
 		files = append(files, generateAuthFile(id, data))
 	}
 	return files
+}
+
+// GenerateStateFiles generates NGINX Plus upstream state files for fresh pod cold-start.
+// Returns nil for OSS.
+func (g GeneratorImpl) GenerateStateFiles(conf dataplane.Configuration) []agent.File {
+	return g.generateStateFiles(conf)
 }
 
 // GenerateDeploymentContext generates the deployment_ctx.json file needed for N+ licensing.

--- a/internal/controller/nginx/config/state_files.go
+++ b/internal/controller/nginx/config/state_files.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	gotemplate "text/template"
+
+	pb "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	filesHelper "github.com/nginx/agent/v3/pkg/files"
+
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/agent"
+	nginxTypes "github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/types"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/dataplane"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/file"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
+)
+
+const stateFileTemplateText = `{{ range . -}}
+server {{ .Address }};
+{{ end -}}`
+
+var stateFileTemplate = gotemplate.Must(gotemplate.New("stateFile").Parse(stateFileTemplateText))
+
+// stateFileServer is one line in an NGINX Plus upstream state file.
+// Address already carries the bracketed form for IPv6 and the port suffix.
+type stateFileServer struct {
+	Address string
+}
+
+// generateStateFiles produces NGINX Plus upstream state files for the given configuration.
+// Each file contains `server <addr>:<port>;` lines so a freshly-started Plus pod loads its
+// upstreams populated, instead of empty until the first Plus API call lands.
+//
+// Upstreams with no endpoints get a state file containing the 503 placeholder server, mirroring
+// what the Plus API path emits in buildUpstreamServers.
+// Skips upstreams that have resolve servers (they cannot be managed via the Plus API and don't
+// use a state file). Returns nil for OSS.
+func (g GeneratorImpl) generateStateFiles(conf dataplane.Configuration) []agent.File {
+	if !g.plus {
+		return nil
+	}
+
+	stateFiles := make([]agent.File, 0, len(conf.Upstreams)+len(conf.StreamUpstreams))
+
+	for _, up := range conf.Upstreams {
+		if upstreamHasResolveServers(up) {
+			continue
+		}
+		base := up.StateFileKey
+		if base == "" {
+			base = up.Name
+		}
+		stateFiles = append(stateFiles, buildStateFile(base, up))
+	}
+
+	for _, up := range conf.StreamUpstreams {
+		if upstreamHasResolveServers(up) {
+			continue
+		}
+		stateFiles = append(stateFiles, buildStateFile(up.Name, up))
+	}
+
+	return stateFiles
+}
+
+func buildStateFile(baseName string, up dataplane.Upstream) agent.File {
+	var servers []stateFileServer
+	if len(up.Endpoints) == 0 {
+		servers = []stateFileServer{{Address: nginxTypes.Nginx503Server}}
+	} else {
+		servers = make([]stateFileServer, 0, len(up.Endpoints))
+		for _, ep := range up.Endpoints {
+			format := "%s:%d"
+			if ep.IPv6 {
+				format = "[%s]:%d"
+			}
+			servers = append(servers, stateFileServer{
+				Address: fmt.Sprintf(format, ep.Address, ep.Port),
+			})
+		}
+		// Sort so endpoint-slice ordering doesn't churn the state-file content/hash on
+		// every reconcile and force unnecessary file fetches by fresh subscribers.
+		sort.Slice(servers, func(i, j int) bool {
+			return servers[i].Address < servers[j].Address
+		})
+	}
+
+	contents := helpers.MustExecuteTemplate(stateFileTemplate, servers)
+
+	return agent.File{
+		Meta: &pb.FileMeta{
+			Name:        fmt.Sprintf("%s/%s.conf", stateDir, baseName),
+			Hash:        filesHelper.GenerateHash(contents),
+			Permissions: file.RegularFileMode,
+			Size:        int64(len(contents)),
+		},
+		Contents: contents,
+	}
+}

--- a/internal/controller/nginx/config/state_files_test.go
+++ b/internal/controller/nginx/config/state_files_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/dataplane"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/resolver"
+)
+
+func TestGenerateStateFiles_OSSReturnsNil(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	gen := GeneratorImpl{plus: false}
+	conf := dataplane.Configuration{
+		Upstreams: []dataplane.Upstream{
+			{
+				Name:      "up1",
+				Endpoints: []resolver.Endpoint{{Address: "10.0.0.1", Port: 80}},
+			},
+		},
+	}
+
+	g.Expect(gen.GenerateStateFiles(conf)).To(BeNil())
+}
+
+func TestGenerateStateFiles_Plus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expectedFiles map[string]string
+		name          string
+		conf          dataplane.Configuration
+	}{
+		{
+			name: "emits one state file per HTTP and stream upstream with server directives sorted " +
+				"alphabetically by address (so endpoint-slice ordering doesn't churn the file hash) " +
+				"and formats IPv6 addresses with brackets",
+			conf: dataplane.Configuration{
+				Upstreams: []dataplane.Upstream{
+					{
+						Name: "coffee",
+						// Out of order on purpose to verify deterministic sort.
+						Endpoints: []resolver.Endpoint{
+							{Address: "10.0.0.2", Port: 8080},
+							{Address: "fd00::1", Port: 8080, IPv6: true},
+							{Address: "10.0.0.1", Port: 8080},
+						},
+					},
+				},
+				StreamUpstreams: []dataplane.Upstream{
+					{
+						Name:      "tcp-svc",
+						Endpoints: []resolver.Endpoint{{Address: "10.0.0.5", Port: 9000}},
+					},
+				},
+			},
+			expectedFiles: map[string]string{
+				"/var/lib/nginx/state/coffee.conf":  "server 10.0.0.1:8080;\nserver 10.0.0.2:8080;\nserver [fd00::1]:8080;\n",
+				"/var/lib/nginx/state/tcp-svc.conf": "server 10.0.0.5:9000;\n",
+			},
+		},
+		{
+			name: "uses StateFileKey to name the file when set so the path stays " +
+				"in sync with the state directive emitted by the upstream config generator",
+			conf: dataplane.Configuration{
+				Upstreams: []dataplane.Upstream{
+					{
+						Name:         "long-generated-upstream-name",
+						StateFileKey: "shortkey",
+						Endpoints:    []resolver.Endpoint{{Address: "10.0.0.1", Port: 80}},
+					},
+				},
+			},
+			expectedFiles: map[string]string{
+				"/var/lib/nginx/state/shortkey.conf": "server 10.0.0.1:80;\n",
+			},
+		},
+		{
+			name: "skips upstreams with resolve servers because the Plus API cannot manage them, " +
+				"but emits the 503 placeholder for upstreams with no endpoints so requests get a 503 " +
+				"(not a 502 from an empty upstream) until real endpoints exist",
+			conf: dataplane.Configuration{
+				Upstreams: []dataplane.Upstream{
+					{
+						Name:      "with-resolve",
+						Endpoints: []resolver.Endpoint{{Address: "external.example.com", Port: 80, Resolve: true}},
+					},
+					{
+						Name:      "no-endpoints",
+						Endpoints: nil,
+					},
+					{
+						Name:      "ok",
+						Endpoints: []resolver.Endpoint{{Address: "10.0.0.1", Port: 80}},
+					},
+				},
+			},
+			expectedFiles: map[string]string{
+				"/var/lib/nginx/state/no-endpoints.conf": "server unix:/var/run/nginx/nginx-503-server.sock;\n",
+				"/var/lib/nginx/state/ok.conf":           "server 10.0.0.1:80;\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			gen := GeneratorImpl{plus: true}
+			files := gen.GenerateStateFiles(tt.conf)
+
+			g.Expect(files).To(HaveLen(len(tt.expectedFiles)))
+
+			for _, f := range files {
+				expected, ok := tt.expectedFiles[f.Meta.GetName()]
+				g.Expect(ok).To(BeTrue(), "unexpected state file: %s", f.Meta.GetName())
+				g.Expect(string(f.Contents)).To(Equal(expected))
+			}
+		})
+	}
+}

--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -49,6 +49,7 @@ allowed_directories:
 - /usr/share/nginx
 - /var/run/nginx
 - /etc/app_protect/bundles/
+- /var/lib/nginx/state
 features:
 - configuration
 - certificates


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: The NFR test zero downtime scale was failing with errors related to traffic drop for NGINX Plus.

Solution: A freshly-started NGINX Plus pod began with empty upstream state files and dropped traffic until the NGINX Plus API populated them at runtime. This PR closes that gap by having NGF pre-populate the state files and deliver them to the agent in the file overview, so a fresh pod starts with its upstreams already populated and serves traffic from the first request.

To preserve the existing no-reload-on-endpoint-change behavior on Plus, state-file hashes are excluded from the configVersion calculation. Endpoint changes still flow through the NGINX Plus API at runtime as they do today, they just no longer trigger a broadcast and reload on existing pods because configVersion doesn't change.

Testing: Ran all NFR tests once to ensure they pass, ran zero downtime scale 5-7 times to ensure we do not see the 502 errors for traffic drop

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #4683 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes an issue where empty state files during initial startup were empty leading to traffic drop for PLUS users by pre-populating state files from startup. The behavior for NGINX Plus API taking over state files at run time remains the same.
```
