### PR TITLE
Collect ListenerSetCount in telemetry

### DIFF
--- a/internal/controller/telemetry/collector.go
+++ b/internal/controller/telemetry/collector.go
@@ -145,6 +145,8 @@ type NGFResourceCounts struct {
 	RouteAttachedWAFPolicyCount int64
 	// WAFEnabledGatewayCount is the number of Gateways with WAF enabled on their effective NginxProxy.
 	WAFEnabledGatewayCount int64
+	// ListenerSetCount is the number of relevant ListenerSets.
+	ListenerSetCount int64
 }
 
 func (rc *NGFResourceCounts) CountPolicies(g *graph.Graph) {
@@ -354,6 +356,7 @@ func collectGraphResourceCount(
 	}
 
 	ngfResourceCounts.GatewayAttachedNpCount = gatewayAttachedNPCount
+	ngfResourceCounts.ListenerSetCount = int64(len(g.ListenerSets))
 
 	ngfResourceCounts.InferencePoolCount = int64(len(g.ReferencedInferencePools))
 

--- a/internal/controller/telemetry/collector_test.go
+++ b/internal/controller/telemetry/collector_test.go
@@ -604,6 +604,11 @@ var _ = Describe("Collector", Ordered, func() {
 						{Namespace: "test", Name: "inferencePool-2"}: {},
 						{Namespace: "test", Name: "inferencePool-3"}: {},
 					},
+					ListenerSets: map[types.NamespacedName]*graph.ListenerSet{
+						{Namespace: "test", Name: "listenerSet-1"}: {},
+						{Namespace: "test", Name: "listenerSet-2"}: {},
+						{Namespace: "test", Name: "listenerSet-3"}: {},
+					},
 				}
 
 				configs := []*dataplane.Configuration{
@@ -686,6 +691,7 @@ var _ = Describe("Collector", Ordered, func() {
 					GatewayAttachedWAFPolicyCount:            1,
 					RouteAttachedWAFPolicyCount:              2,
 					WAFEnabledGatewayCount:                   1,
+					ListenerSetCount:                         3,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -959,6 +965,9 @@ var _ = Describe("Collector", Ordered, func() {
 				ReferencedInferencePools: map[types.NamespacedName]*graph.ReferencedInferencePool{
 					{Namespace: "test", Name: "inferencePool-1"}: {},
 				},
+				ListenerSets: map[types.NamespacedName]*graph.ListenerSet{
+					{Namespace: "test", Name: "listenerSet-1"}: {},
+				},
 			}
 
 			config1 = []*dataplane.Configuration{
@@ -1053,6 +1062,7 @@ var _ = Describe("Collector", Ordered, func() {
 					GatewayAttachedWAFPolicyCount:            1,
 					RouteAttachedWAFPolicyCount:              2,
 					WAFEnabledGatewayCount:                   1,
+					ListenerSetCount:                         1,
 				}
 				expData.NginxPodCount = 1
 

--- a/internal/controller/telemetry/data.avdl
+++ b/internal/controller/telemetry/data.avdl
@@ -145,6 +145,9 @@ attached at the Route level. */
 		/** WAFEnabledGatewayCount is the number of Gateways with WAF enabled on their effective NginxProxy. */
 		long? WAFEnabledGatewayCount = null;
 		
+		/** ListenerSetCount is the number of relevant ListenerSets. */
+		long? ListenerSetCount = null;
+		
 		/** NginxPodCount is the total number of Nginx data plane Pods. */
 		long? NginxPodCount = null;
 		

--- a/internal/controller/telemetry/data_test.go
+++ b/internal/controller/telemetry/data_test.go
@@ -53,6 +53,7 @@ func TestDataAttributes(t *testing.T) {
 			GatewayAttachedWAFPolicyCount:            25,
 			RouteAttachedWAFPolicyCount:              26,
 			WAFEnabledGatewayCount:                   27,
+			ListenerSetCount:                         28,
 		},
 		SnippetsFiltersDirectives:       []string{"main-three-count", "http-two-count", "server-one-count"},
 		SnippetsFiltersDirectivesCount:  []int64{3, 2, 1},
@@ -114,6 +115,7 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("GatewayAttachedWAFPolicyCount", 25),
 		attribute.Int64("RouteAttachedWAFPolicyCount", 26),
 		attribute.Int64("WAFEnabledGatewayCount", 27),
+		attribute.Int64("ListenerSetCount", 28),
 
 		// Top level attributes
 		attribute.Int64("NginxPodCount", 3),
@@ -185,6 +187,7 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("GatewayAttachedWAFPolicyCount", 0),
 		attribute.Int64("RouteAttachedWAFPolicyCount", 0),
 		attribute.Int64("WAFEnabledGatewayCount", 0),
+		attribute.Int64("ListenerSetCount", 0),
 
 		// Top level attributes
 		attribute.Int64("NginxPodCount", 0),

--- a/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
@@ -40,6 +40,7 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("GatewayAttachedWAFPolicyCount", d.GatewayAttachedWAFPolicyCount))
 	attrs = append(attrs, attribute.Int64("RouteAttachedWAFPolicyCount", d.RouteAttachedWAFPolicyCount))
 	attrs = append(attrs, attribute.Int64("WAFEnabledGatewayCount", d.WAFEnabledGatewayCount))
+	attrs = append(attrs, attribute.Int64("ListenerSetCount", d.ListenerSetCount))
 
 	return attrs
 }

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"GatewayAttachedWAFPolicyCount: Int(0)",
 				"RouteAttachedWAFPolicyCount: Int(0)",
 				"WAFEnabledGatewayCount: Int(0)",
+				"ListenerSetCount: Int(0)",
 				"NginxPodCount: Int(0)",
 				"ControlPlanePodCount: Int(1)",
 				"NginxOneConnectionEnabled: Bool(false)",


### PR DESCRIPTION
### Proposed changes

Problem: We want to collect the number of ListenerSets in referencing Gateways watched by NGF.

Solution: Collect the count of ListenerSets. Also updates upstream naming for WAFGatewayPolicy

Testing: Unit tests and manually verified collection via debug logs.

Closes: #4613 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
