### PR TITLE
Fix NIM bundle fetch to select latest compilation when multiple versions exist

### DIFF
--- a/internal/framework/waf/fetch/fetch.go
+++ b/internal/framework/waf/fetch/fetch.go
@@ -285,7 +285,7 @@ func (f *HTTPFetcher) dispatchChecksum(
 		checksum, err := fetchN1CChecksum(ctx, client, req, f.n1cCompilePollDelay, f.logger)
 		return Result{Checksum: checksum}, err
 	case req.PolicyName != "" || req.NIM.PolicyUID != "":
-		checksum, err := fetchNIMChecksum(ctx, client, req)
+		checksum, err := fetchNIMChecksum(ctx, client, req, f.logger)
 		return Result{Checksum: checksum}, err
 	default:
 		return Result{}, &nonTransientError{
@@ -382,7 +382,7 @@ func (f *HTTPFetcher) dispatch(ctx context.Context, client *http.Client, req Req
 	case req.N1C.Namespace != "":
 		return fetchN1C(ctx, client, req, f.n1cCompilePollDelay, f.logger)
 	case req.PolicyName != "" || req.NIM.PolicyUID != "":
-		return fetchNIM(ctx, client, req)
+		return fetchNIM(ctx, client, req, f.logger)
 	default:
 		return fetchHTTP(ctx, client, req)
 	}
@@ -533,19 +533,119 @@ func fetchHTTP(ctx context.Context, client *http.Client, req Request) (Result, e
 	}, nil
 }
 
+// nimBundleItem is a single entry in the NIM bundles API response.
+type nimBundleItem struct {
+	Content  string `json:"content"`
+	Metadata struct {
+		Hash      string `json:"hash"`
+		Created   string `json:"created"`
+		PolicyUID string `json:"policyUID"`
+	} `json:"metadata"`
+}
+
 // nimResponse is the JSON envelope returned by the NIM bundles API.
 type nimResponse struct {
-	Items []struct {
-		Content  string `json:"content"`
-		Metadata struct {
-			Hash string `json:"hash"`
-		} `json:"metadata"`
-	} `json:"items"`
+	Items []nimBundleItem `json:"items"`
+}
+
+// latestNIMItem returns the item with the most recent metadata.created timestamp.
+// The NIM bundles API may return multiple compiled bundles for the same policy name
+// (one per compilation) in an undefined order. This function selects the most recently
+// compiled bundle by comparing RFC 3339 timestamps.
+// Falls back to the last item if no timestamps are parseable.
+func latestNIMItem(items []nimBundleItem) nimBundleItem {
+	best := len(items) - 1
+	var bestTime time.Time
+
+	for i, item := range items {
+		t, err := time.Parse(time.RFC3339Nano, item.Metadata.Created)
+		if err != nil {
+			continue
+		}
+		if t.After(bestTime) {
+			bestTime = t
+			best = i
+		}
+	}
+
+	return items[best]
 }
 
 // fetchNIM calls the NIM security policies bundles API and decodes the bundle from the response.
-func fetchNIM(ctx context.Context, client *http.Client, req Request) (Result, error) {
-	nimURL, err := buildNIMURL(req.URL, req.PolicyName, req.NIM.PolicyUID)
+//
+// When the request targets a specific compilation by policyUID, the bundle is fetched directly.
+// When the request targets a policy by name, NIM may return multiple compilations. To avoid
+// downloading the (potentially large) content of every historical compilation, a lightweight
+// metadata-only request is issued first to identify the most recently compiled bundle via its
+// created timestamp, then only that single bundle is fetched by its policyUID.
+func fetchNIM(ctx context.Context, client *http.Client, req Request, logger logr.Logger) (Result, error) {
+	policyUID := req.NIM.PolicyUID
+
+	// When fetching by policyName, resolve to the latest compilation's policyUID first.
+	if policyUID == "" {
+		var err error
+		policyUID, err = resolveLatestNIMPolicyUID(ctx, client, req, logger)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	logger.V(1).Info("Fetching NIM bundle by policyUID", "policyUID", policyUID)
+
+	return fetchNIMByUID(ctx, client, req, policyUID)
+}
+
+// resolveLatestNIMPolicyUID performs a metadata-only NIM request to find all compilations for the
+// given policy name, then returns the policyUID of the most recently compiled bundle.
+func resolveLatestNIMPolicyUID(
+	ctx context.Context,
+	client *http.Client,
+	req Request,
+	logger logr.Logger,
+) (string, error) {
+	metadataURL, err := buildNIMMetadataURL(req.URL, req.PolicyName, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to build NIM metadata URL: %w", err)
+	}
+
+	body, err := doGet(ctx, client, metadataURL, req.Auth)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch NIM bundle metadata: %w", err)
+	}
+
+	var resp nimResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse NIM metadata response: %w", err)
+	}
+
+	if len(resp.Items) == 0 {
+		return "", fmt.Errorf("NIM metadata response contains no items for policy %q", req.PolicyName)
+	}
+
+	logger.V(1).Info(
+		"Resolved NIM policy compilations",
+		"policyName", req.PolicyName,
+		"compilationCount", len(resp.Items),
+	)
+
+	latest := latestNIMItem(resp.Items)
+	if latest.Metadata.PolicyUID == "" {
+		return "", fmt.Errorf("NIM metadata response contains no policyUID for policy %q", req.PolicyName)
+	}
+
+	logger.V(1).Info(
+		"Selected latest NIM compilation",
+		"policyName", req.PolicyName,
+		"policyUID", latest.Metadata.PolicyUID,
+		"created", latest.Metadata.Created,
+	)
+
+	return latest.Metadata.PolicyUID, nil
+}
+
+// fetchNIMByUID fetches a single NIM bundle by its policyUID.
+func fetchNIMByUID(ctx context.Context, client *http.Client, req Request, policyUID string) (Result, error) {
+	nimURL, err := buildNIMURL(req.URL, "", policyUID)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to build NIM URL: %w", err)
 	}
@@ -560,25 +660,20 @@ func fetchNIM(ctx context.Context, client *http.Client, req Request) (Result, er
 		return Result{}, fmt.Errorf("failed to parse NIM response: %w", err)
 	}
 
-	policyRef := req.PolicyName
-	if policyRef == "" {
-		policyRef = req.NIM.PolicyUID
-	}
 	if len(resp.Items) == 0 {
-		return Result{}, fmt.Errorf("NIM response contains no items for policy %q", policyRef)
+		return Result{}, fmt.Errorf("NIM response contains no items for policy UID %q", policyUID)
 	}
 
-	// NIM returns items in chronological order (oldest first). When a policy is recompiled,
-	// multiple items exist for the same policy name. Use the last item to get the latest bundle.
-	latest := resp.Items[len(resp.Items)-1]
+	// A policyUID-targeted request returns exactly one item.
+	item := resp.Items[0]
 
-	data, err := base64.StdEncoding.DecodeString(latest.Content)
+	data, err := base64.StdEncoding.DecodeString(item.Content)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to base64-decode NIM bundle content: %w", err)
 	}
 
 	actualChecksum := ComputeChecksum(data)
-	bundleHash := latest.Metadata.Hash
+	bundleHash := item.Metadata.Hash
 
 	// Verify the downloaded bundle against the hash reported by the NIM API,
 	// unless the caller supplied their own ExpectedChecksum via BundleValidation
@@ -1097,7 +1192,9 @@ func buildN1CCompileBaseURL(baseURL, namespace, polObjID, polVersionID string, d
 
 // fetchNIMChecksum fetches only the metadata for a NIM policy bundle and returns the hash
 // without downloading the bundle content.
-func fetchNIMChecksum(ctx context.Context, client *http.Client, req Request) (string, error) {
+// When the response contains multiple compilations, the hash of the most recently compiled
+// bundle (by metadata.created timestamp) is returned.
+func fetchNIMChecksum(ctx context.Context, client *http.Client, req Request, logger logr.Logger) (string, error) {
 	nimURL, err := buildNIMMetadataURL(req.URL, req.PolicyName, req.NIM.PolicyUID)
 	if err != nil {
 		return "", fmt.Errorf("failed to build NIM metadata URL: %w", err)
@@ -1121,12 +1218,19 @@ func fetchNIMChecksum(ctx context.Context, client *http.Client, req Request) (st
 		return "", fmt.Errorf("NIM response contains no items for policy %q", policyRef)
 	}
 
-	// NIM returns items in chronological order (oldest first). When a policy is recompiled,
-	// multiple items exist for the same policy name. Use the last item to get the latest bundle.
-	hash := strings.ToLower(resp.Items[len(resp.Items)-1].Metadata.Hash)
+	latest := latestNIMItem(resp.Items)
+	hash := strings.ToLower(latest.Metadata.Hash)
 	if hash == "" {
 		return "", fmt.Errorf("NIM response contains no hash for policy %q", policyRef)
 	}
+
+	logger.V(1).Info(
+		"Fetched NIM policy checksum",
+		"policyRef", policyRef,
+		"policyUID", latest.Metadata.PolicyUID,
+		"created", latest.Metadata.Created,
+		"hash", hash,
+	)
 
 	return hash, nil
 }

--- a/internal/framework/waf/fetch/fetch.go
+++ b/internal/framework/waf/fetch/fetch.go
@@ -573,11 +573,11 @@ func latestNIMItem(items []nimBundleItem) nimBundleItem {
 
 // fetchNIM calls the NIM security policies bundles API and decodes the bundle from the response.
 //
-// When the request targets a specific compilation by policyUID, the bundle is fetched directly.
-// When the request targets a policy by name, NIM may return multiple compilations. To avoid
-// downloading the (potentially large) content of every historical compilation, a lightweight
-// metadata-only request is issued first to identify the most recently compiled bundle via its
-// created timestamp, then only that single bundle is fetched by its policyUID.
+// When a request targets a policy by name, and not by PolicyUID, NIM may return multiple compilations.
+// This results in downloading the content multiple past compilations.
+// To avoid this, a lightweight metadata-only request is issued first to identify the most recently
+// compiled bundle via its created timestamp.
+// This ensures a single bundle is fetched by its policyUID.
 func fetchNIM(ctx context.Context, client *http.Client, req Request, logger logr.Logger) (Result, error) {
 	policyUID := req.NIM.PolicyUID
 

--- a/internal/framework/waf/fetch/fetch.go
+++ b/internal/framework/waf/fetch/fetch.go
@@ -568,13 +568,17 @@ func fetchNIM(ctx context.Context, client *http.Client, req Request) (Result, er
 		return Result{}, fmt.Errorf("NIM response contains no items for policy %q", policyRef)
 	}
 
-	data, err := base64.StdEncoding.DecodeString(resp.Items[0].Content)
+	// NIM returns items in chronological order (oldest first). When a policy is recompiled,
+	// multiple items exist for the same policy name. Use the last item to get the latest bundle.
+	latest := resp.Items[len(resp.Items)-1]
+
+	data, err := base64.StdEncoding.DecodeString(latest.Content)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to base64-decode NIM bundle content: %w", err)
 	}
 
 	actualChecksum := ComputeChecksum(data)
-	bundleHash := resp.Items[0].Metadata.Hash
+	bundleHash := latest.Metadata.Hash
 
 	// Verify the downloaded bundle against the hash reported by the NIM API,
 	// unless the caller supplied their own ExpectedChecksum via BundleValidation
@@ -1117,7 +1121,9 @@ func fetchNIMChecksum(ctx context.Context, client *http.Client, req Request) (st
 		return "", fmt.Errorf("NIM response contains no items for policy %q", policyRef)
 	}
 
-	hash := strings.ToLower(resp.Items[0].Metadata.Hash)
+	// NIM returns items in chronological order (oldest first). When a policy is recompiled,
+	// multiple items exist for the same policy name. Use the last item to get the latest bundle.
+	hash := strings.ToLower(resp.Items[len(resp.Items)-1].Metadata.Hash)
 	if hash == "" {
 		return "", fmt.Errorf("NIM response contains no hash for policy %q", policyRef)
 	}

--- a/internal/framework/waf/fetch/fetch_test.go
+++ b/internal/framework/waf/fetch/fetch_test.go
@@ -1220,19 +1220,21 @@ func TestHTTPFetcherFetchNIM(t *testing.T) {
 		},
 		{
 			name: "NIM response with multiple items selects latest by created timestamp",
-			// Items deliberately NOT in chronological order to verify timestamp-based selection.
+			// The OLDER item is listed first so that if the content-fetch request
+			// accidentally omits the policyUID filter, resp.Items[0] returns the
+			// wrong (old) bundle and the test fails.
 			items: []nimBundleServerItem{
-				{
-					content:   newContent,
-					hash:      fetch.ComputeChecksum(newContent),
-					policyUID: "uid-v2",
-					created:   "2026-05-05T08:55:25.078Z",
-				},
 				{
 					content:   oldContent,
 					hash:      fetch.ComputeChecksum(oldContent),
 					policyUID: "uid-v1",
 					created:   "2026-05-05T08:40:31.213Z",
+				},
+				{
+					content:   newContent,
+					hash:      fetch.ComputeChecksum(newContent),
+					policyUID: "uid-v2",
+					created:   "2026-05-05T08:55:25.078Z",
 				},
 			},
 			policyName:       "updated-policy",

--- a/internal/framework/waf/fetch/fetch_test.go
+++ b/internal/framework/waf/fetch/fetch_test.go
@@ -1227,6 +1227,20 @@ func TestHTTPFetcherFetchNIM(t *testing.T) {
 			},
 			expectData: bundleContent,
 		},
+		{
+			// When a policy is recompiled in NIM, the API returns all compilations in
+			// chronological order (oldest first). The fetcher must select the last item to
+			// get the most recently compiled bundle, not the original version.
+			name:       "NIM response with multiple items returns latest (last) bundle",
+			policyName: "updated-policy",
+			serverBody: map[string]any{
+				"items": []map[string]any{
+					{"content": base64.StdEncoding.EncodeToString([]byte("old-bundle-v1"))},
+					{"content": encoded},
+				},
+			},
+			expectData: bundleContent,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1655,6 +1669,42 @@ func TestFetchPolicyBundleChecksumNIM(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(checksum).To(Equal(bundleHash))
 	g.Expect(includeBundleContent).To(Equal("false"))
+}
+
+func TestFetchPolicyBundleChecksumNIMMultipleItems(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	oldContent := []byte("old-bundle-v1")
+	oldHash := fetch.ComputeChecksum(oldContent)
+
+	newContent := []byte("new-bundle-v2")
+	newHash := fetch.ComputeChecksum(newContent)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// NIM returns items in chronological order: old first, latest last.
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items": []map[string]any{
+				{
+					"content":  base64.StdEncoding.EncodeToString(oldContent),
+					"metadata": map[string]any{"hash": oldHash},
+				},
+				{
+					"content":  base64.StdEncoding.EncodeToString(newContent),
+					"metadata": map[string]any{"hash": newHash},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	f := fetch.NewHTTPFetcher(logr.Discard())
+	req := fetch.Request{URL: srv.URL, PolicyName: "updated-policy"}
+	checksum, err := f.FetchPolicyBundleChecksum(context.Background(), req)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(checksum).To(Equal(newHash), "should return the hash of the latest (last) item, not the oldest")
 }
 
 func TestFetchBundleChecksumErrors(t *testing.T) {

--- a/internal/framework/waf/fetch/fetch_test.go
+++ b/internal/framework/waf/fetch/fetch_test.go
@@ -1177,101 +1177,98 @@ func TestHTTPFetcherFetchNIM(t *testing.T) {
 	t.Parallel()
 
 	bundleContent := []byte("nim-bundle-data")
+	oldContent := []byte("old-bundle-v1")
+	newContent := []byte("new-bundle-v2")
 
-	t.Run("successful NIM fetch", func(t *testing.T) {
-		t.Parallel()
-		g := NewWithT(t)
-
-		srv := newNIMBundleServer([]nimBundleServerItem{{
-			content:   bundleContent,
-			hash:      fetch.ComputeChecksum(bundleContent),
-			policyUID: "uid-1",
-			created:   "2026-01-01T00:00:00Z",
-		}}, nil)
-		defer srv.Close()
-
-		f := fetch.NewHTTPFetcher(logr.Discard())
-		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
-			URL:        srv.URL,
-			PolicyName: "my-policy",
-		})
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Data).To(Equal(bundleContent))
-		g.Expect(result.Checksum).To(Equal(fetch.ComputeChecksum(bundleContent)))
-	})
-
-	t.Run("NIM response with no items", func(t *testing.T) {
-		t.Parallel()
-		g := NewWithT(t)
-
-		srv := newNIMBundleServer(nil, nil)
-		defer srv.Close()
-
-		f := fetch.NewHTTPFetcher(logr.Discard())
-		_, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
-			URL:        srv.URL,
-			PolicyName: "missing-policy",
-		})
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("NIM metadata response contains no items"))
-	})
-
-	t.Run("NIM fetch with bearer auth", func(t *testing.T) {
-		t.Parallel()
-		g := NewWithT(t)
-
-		auth := &fetch.BundleAuth{BearerToken: "nimtoken"}
-		srv := newNIMBundleServer([]nimBundleServerItem{{
-			content:   bundleContent,
-			hash:      fetch.ComputeChecksum(bundleContent),
-			policyUID: "uid-auth",
-			created:   "2026-01-01T00:00:00Z",
-		}}, auth)
-		defer srv.Close()
-
-		f := fetch.NewHTTPFetcher(logr.Discard())
-		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
-			URL:        srv.URL,
-			PolicyName: "secured-policy",
-			Auth:       auth,
-		})
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Data).To(Equal(bundleContent))
-	})
-
-	t.Run("NIM response with multiple items selects latest by created timestamp", func(t *testing.T) {
-		t.Parallel()
-		g := NewWithT(t)
-
-		oldContent := []byte("old-bundle-v1")
-		newContent := []byte("new-bundle-v2")
-
-		// Items deliberately NOT in chronological order to verify timestamp-based selection.
-		srv := newNIMBundleServer([]nimBundleServerItem{
-			{
-				content:   newContent,
-				hash:      fetch.ComputeChecksum(newContent),
-				policyUID: "uid-v2",
-				created:   "2026-05-05T08:55:25.078Z",
+	tests := []struct {
+		auth             *fetch.BundleAuth
+		name             string
+		policyName       string
+		expectErr        string
+		expectedChecksum string
+		items            []nimBundleServerItem
+		expectedData     []byte
+	}{
+		{
+			name: "successful NIM fetch",
+			items: []nimBundleServerItem{{
+				content:   bundleContent,
+				hash:      fetch.ComputeChecksum(bundleContent),
+				policyUID: "uid-1",
+				created:   "2026-01-01T00:00:00Z",
+			}},
+			policyName:       "my-policy",
+			expectedData:     bundleContent,
+			expectedChecksum: fetch.ComputeChecksum(bundleContent),
+		},
+		{
+			name:       "NIM response with no items",
+			policyName: "missing-policy",
+			expectErr:  "NIM metadata response contains no items",
+		},
+		{
+			name: "NIM fetch with bearer auth",
+			items: []nimBundleServerItem{{
+				content:   bundleContent,
+				hash:      fetch.ComputeChecksum(bundleContent),
+				policyUID: "uid-auth",
+				created:   "2026-01-01T00:00:00Z",
+			}},
+			auth:         &fetch.BundleAuth{BearerToken: "nimtoken"},
+			policyName:   "secured-policy",
+			expectedData: bundleContent,
+		},
+		{
+			name: "NIM response with multiple items selects latest by created timestamp",
+			// Items deliberately NOT in chronological order to verify timestamp-based selection.
+			items: []nimBundleServerItem{
+				{
+					content:   newContent,
+					hash:      fetch.ComputeChecksum(newContent),
+					policyUID: "uid-v2",
+					created:   "2026-05-05T08:55:25.078Z",
+				},
+				{
+					content:   oldContent,
+					hash:      fetch.ComputeChecksum(oldContent),
+					policyUID: "uid-v1",
+					created:   "2026-05-05T08:40:31.213Z",
+				},
 			},
-			{
-				content:   oldContent,
-				hash:      fetch.ComputeChecksum(oldContent),
-				policyUID: "uid-v1",
-				created:   "2026-05-05T08:40:31.213Z",
-			},
-		}, nil)
-		defer srv.Close()
+			policyName:       "updated-policy",
+			expectedData:     newContent,
+			expectedChecksum: fetch.ComputeChecksum(newContent),
+		},
+	}
 
-		f := fetch.NewHTTPFetcher(logr.Discard())
-		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
-			URL:        srv.URL,
-			PolicyName: "updated-policy",
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			srv := newNIMBundleServer(tc.items, tc.auth)
+			defer srv.Close()
+
+			f := fetch.NewHTTPFetcher(logr.Discard())
+			result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
+				URL:        srv.URL,
+				PolicyName: tc.policyName,
+				Auth:       tc.auth,
+			})
+
+			if tc.expectErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectErr))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Data).To(Equal(tc.expectedData))
+			if tc.expectedChecksum != "" {
+				g.Expect(result.Checksum).To(Equal(tc.expectedChecksum))
+			}
 		})
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Data).To(Equal(newContent))
-		g.Expect(result.Checksum).To(Equal(fetch.ComputeChecksum(newContent)))
-	})
+	}
 }
 
 func TestHTTPFetcherFetchLogProfileBundleHTTP(t *testing.T) {

--- a/internal/framework/waf/fetch/fetch_test.go
+++ b/internal/framework/waf/fetch/fetch_test.go
@@ -47,6 +47,55 @@ func newHTTPBundleServer(body []byte, auth *fetch.BundleAuth) *httptest.Server {
 	}))
 }
 
+// nimBundleServerItem represents a single compiled NIM bundle served by the test helper.
+type nimBundleServerItem struct {
+	hash      string
+	policyUID string
+	created   string
+	content   []byte
+}
+
+// newNIMBundleServer creates a test server that simulates NIM's two-phase fetch pattern:
+//   - Requests with includeBundleContent=false return metadata only (hash, policyUID, created).
+//   - Requests with includeBundleContent=true return the full bundle content filtered by policyUID.
+//
+// When auth is non-nil, requests must carry matching credentials.
+func newNIMBundleServer(items []nimBundleServerItem, auth *fetch.BundleAuth) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth != nil && auth.BearerToken != "" {
+			if r.Header.Get("Authorization") != "Bearer "+auth.BearerToken {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		q := r.URL.Query()
+		includeContent := q.Get("includeBundleContent") == "true"
+		filterUID := q.Get("policyUID")
+
+		var respItems []map[string]any
+		for _, item := range items {
+			if filterUID != "" && item.policyUID != filterUID {
+				continue
+			}
+			entry := map[string]any{
+				"metadata": map[string]any{
+					"hash":      item.hash,
+					"policyUID": item.policyUID,
+					"created":   item.created,
+				},
+			}
+			if includeContent {
+				entry["content"] = base64.StdEncoding.EncodeToString(item.content)
+			}
+			respItems = append(respItems, entry)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"items": respItems}) //nolint:errcheck
+	}))
+}
+
 func TestHTTPFetcherFetchPolicyBundle(t *testing.T) {
 	t.Parallel()
 
@@ -318,33 +367,27 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 	t.Parallel()
 
 	bundleContent := []byte("nim-checksum-bundle")
-	encoded := base64.StdEncoding.EncodeToString(bundleContent)
+	bundleHash := fetch.ComputeChecksum(bundleContent)
 
-	type nimItem struct {
-		Content string `json:"content"`
+	nimItem := nimBundleServerItem{
+		content:   bundleContent,
+		hash:      bundleHash,
+		policyUID: "uid-checksum-test",
+		created:   "2026-01-01T00:00:00Z",
 	}
-	type nimResp struct {
-		Items []nimItem `json:"items"`
-	}
-	nimHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(nimResp{Items: []nimItem{{Content: encoded}}}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
 
 	t.Run("matching checksum succeeds", func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		srv := httptest.NewServer(nimHandler)
+		srv := newNIMBundleServer([]nimBundleServerItem{nimItem}, nil)
 		defer srv.Close()
 
 		f := fetch.NewHTTPFetcher(logr.Discard())
 		result, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
 			URL:              srv.URL,
 			PolicyName:       "my-policy",
-			ExpectedChecksum: fetch.ComputeChecksum(bundleContent),
+			ExpectedChecksum: bundleHash,
 		})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result.Data).To(Equal(bundleContent))
@@ -354,7 +397,7 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		srv := httptest.NewServer(nimHandler)
+		srv := newNIMBundleServer([]nimBundleServerItem{nimItem}, nil)
 		defer srv.Close()
 
 		f := fetch.NewHTTPFetcher(logr.Discard())
@@ -371,35 +414,23 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		originalBundleContent := []byte("original-bundle")
-		corruptBundleContent := []byte("corrupted-bundle")
-		encodedCorruptBundle := base64.StdEncoding.EncodeToString(corruptBundleContent)
-		originalBundleHash := fetch.ComputeChecksum(originalBundleContent)
+		corruptContent := []byte("corrupted-bundle")
+		originalHash := fetch.ComputeChecksum([]byte("original-bundle"))
 
 		// Serve a bundle whose content differs from what the metadata reports as the hash.
-		corruptHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			// Return the hash of the original bundle but serve the corrupted content.
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{{
-					"content": encodedCorruptBundle,
-					"metadata": map[string]any{
-						"hash": originalBundleHash,
-					},
-				}},
-			}); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		})
-
-		srv := httptest.NewServer(corruptHandler)
+		corruptItem := nimBundleServerItem{
+			content:   corruptContent,
+			hash:      originalHash,
+			policyUID: "uid-corrupt",
+			created:   "2026-01-01T00:00:00Z",
+		}
+		srv := newNIMBundleServer([]nimBundleServerItem{corruptItem}, nil)
 		defer srv.Close()
 
 		f := fetch.NewHTTPFetcher(logr.Discard())
 		_, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
 			URL:        srv.URL,
 			PolicyName: "my-policy",
-			// No ExpectedChecksum set — NIM API hash should be used automatically.
 		})
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("NIM bundle integrity check failed"))
@@ -409,32 +440,13 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		bundleContent := []byte("valid-nim-bundle")
-		encodedBundle := base64.StdEncoding.EncodeToString(bundleContent)
-		bundleHash := fetch.ComputeChecksum(bundleContent)
-
-		nimHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{{
-					"content": encodedBundle,
-					"metadata": map[string]any{
-						"hash": bundleHash,
-					},
-				}},
-			}); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		})
-
-		srv := httptest.NewServer(nimHandler)
+		srv := newNIMBundleServer([]nimBundleServerItem{nimItem}, nil)
 		defer srv.Close()
 
 		f := fetch.NewHTTPFetcher(logr.Discard())
 		result, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
 			URL:        srv.URL,
 			PolicyName: "my-policy",
-			// No ExpectedChecksum set — NIM API hash should be used automatically.
 		})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result.Data).To(Equal(bundleContent))
@@ -445,36 +457,26 @@ func TestNIMFetchExpectedChecksumEnforced(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		bundleContent := []byte("user-verified-bundle")
-		encodedBundle := base64.StdEncoding.EncodeToString(bundleContent)
+		content := []byte("user-verified-bundle")
 		wrongHash := strings.Repeat("a", 64)
 
-		nimHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			// NIM returns a wrong hash, but user supplies correct one.
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{{
-					"content": encodedBundle,
-					"metadata": map[string]any{
-						"hash": wrongHash,
-					},
-				}},
-			}); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		})
-
-		srv := httptest.NewServer(nimHandler)
+		item := nimBundleServerItem{
+			content:   content,
+			hash:      wrongHash,
+			policyUID: "uid-user-checksum",
+			created:   "2026-01-01T00:00:00Z",
+		}
+		srv := newNIMBundleServer([]nimBundleServerItem{item}, nil)
 		defer srv.Close()
 
 		f := fetch.NewHTTPFetcher(logr.Discard())
 		result, err := f.FetchPolicyBundle(t.Context(), fetch.Request{
 			URL:              srv.URL,
 			PolicyName:       "my-policy",
-			ExpectedChecksum: fetch.ComputeChecksum(bundleContent),
+			ExpectedChecksum: fetch.ComputeChecksum(content),
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Data).To(Equal(bundleContent))
+		g.Expect(result.Data).To(Equal(content))
 	})
 }
 
@@ -623,22 +625,13 @@ func TestBuildNIMURLStripsBaseQueryAndFragment(t *testing.T) {
 	g := NewWithT(t)
 
 	bundleContent := []byte("nim-bundle-data")
-	encoded := base64.StdEncoding.EncodeToString(bundleContent)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Should not have any leftover query params from the base URL
-		g.Expect(r.URL.Query().Get("extra")).To(BeEmpty())
-		// Should not carry the fragment (fragments are client-side only, but ensure path is clean)
-		g.Expect(r.URL.Path).To(Equal("/api/platform/v1/security/policies/bundles"))
-		g.Expect(r.URL.Query().Get("policyName")).To(Equal("my-policy"))
-		g.Expect(r.URL.Query().Get("includeBundleContent")).To(Equal("true"))
-		g.Expect(r.URL.Query().Get("startTime")).To(Equal("1970-01-01T00:00:00Z"))
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
-			"items": []map[string]any{{"content": encoded}},
-		})
-	}))
+	srv := newNIMBundleServer([]nimBundleServerItem{{
+		content:   bundleContent,
+		hash:      fetch.ComputeChecksum(bundleContent),
+		policyUID: "uid-strip-test",
+		created:   "2026-01-01T00:00:00Z",
+	}}, nil)
 	defer srv.Close()
 
 	f := fetch.NewHTTPFetcher(logr.Discard())
@@ -656,22 +649,14 @@ func TestHTTPFetcherFetchNIMByUID(t *testing.T) {
 	g := NewWithT(t)
 
 	bundleContent := []byte("nim-uid-bundle-data")
-	encoded := base64.StdEncoding.EncodeToString(bundleContent)
 	policyUID := "2bc1e3ac-7990-4ca4-910a-8634c444c804"
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		g.Expect(r.URL.Path).To(Equal("/api/platform/v1/security/policies/bundles"))
-		g.Expect(r.URL.Query().Get("policyUID")).To(Equal(policyUID))
-		g.Expect(r.URL.Query().Get("includeBundleContent")).To(Equal("true"))
-		g.Expect(r.URL.Query().Get("startTime")).To(Equal("1970-01-01T00:00:00Z"))
-		// policyName must not be sent when fetching by UID
-		g.Expect(r.URL.Query().Get("policyName")).To(BeEmpty())
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
-			"items": []map[string]any{{"content": encoded}},
-		})
-	}))
+	srv := newNIMBundleServer([]nimBundleServerItem{{
+		content:   bundleContent,
+		hash:      fetch.ComputeChecksum(bundleContent),
+		policyUID: policyUID,
+		created:   "2026-01-01T00:00:00Z",
+	}}, nil)
 	defer srv.Close()
 
 	f := fetch.NewHTTPFetcher(logr.Discard())
@@ -681,6 +666,8 @@ func TestHTTPFetcherFetchNIMByUID(t *testing.T) {
 			PolicyUID: policyUID,
 		},
 	}
+	// When fetching by policyUID, the fetcher should go directly to a content fetch
+	// without a metadata-only resolve step.
 	result, err := f.FetchPolicyBundle(context.Background(), req)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Data).To(Equal(bundleContent))
@@ -1190,100 +1177,101 @@ func TestHTTPFetcherFetchNIM(t *testing.T) {
 	t.Parallel()
 
 	bundleContent := []byte("nim-bundle-data")
-	encoded := base64.StdEncoding.EncodeToString(bundleContent)
 
-	tests := []struct {
-		name       string
-		policyName string
-		serverBody any
-		auth       *fetch.BundleAuth
-		expectErr  string
-		expectData []byte
-	}{
-		{
-			name:       "successful NIM fetch",
-			policyName: "my-policy",
-			serverBody: map[string]any{
-				"items": []map[string]any{
-					{"content": encoded},
-				},
-			},
-			expectData: bundleContent,
-		},
-		{
-			name:       "NIM response with no items",
-			policyName: "missing-policy",
-			serverBody: map[string]any{"items": []any{}},
-			expectErr:  "NIM response contains no items",
-		},
-		{
-			name:       "NIM fetch with bearer auth",
-			policyName: "secured-policy",
-			auth:       &fetch.BundleAuth{BearerToken: "nimtoken"},
-			serverBody: map[string]any{
-				"items": []map[string]any{
-					{"content": encoded},
-				},
-			},
-			expectData: bundleContent,
-		},
-		{
-			// When a policy is recompiled in NIM, the API returns all compilations in
-			// chronological order (oldest first). The fetcher must select the last item to
-			// get the most recently compiled bundle, not the original version.
-			name:       "NIM response with multiple items returns latest (last) bundle",
-			policyName: "updated-policy",
-			serverBody: map[string]any{
-				"items": []map[string]any{
-					{"content": base64.StdEncoding.EncodeToString([]byte("old-bundle-v1"))},
-					{"content": encoded},
-				},
-			},
-			expectData: bundleContent,
-		},
-	}
+	t.Run("successful NIM fetch", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewWithT(t)
+		srv := newNIMBundleServer([]nimBundleServerItem{{
+			content:   bundleContent,
+			hash:      fetch.ComputeChecksum(bundleContent),
+			policyUID: "uid-1",
+			created:   "2026-01-01T00:00:00Z",
+		}}, nil)
+		defer srv.Close()
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tc.auth != nil && tc.auth.BearerToken != "" {
-					if r.Header.Get("Authorization") != "Bearer "+tc.auth.BearerToken {
-						http.Error(w, "unauthorized", http.StatusUnauthorized)
-						return
-					}
-				}
-				// Verify NIM API path and query params
-				g.Expect(r.URL.Path).To(Equal("/api/platform/v1/security/policies/bundles"))
-				g.Expect(r.URL.Query().Get("policyName")).To(Equal(tc.policyName))
-				g.Expect(r.URL.Query().Get("includeBundleContent")).To(Equal("true"))
-				g.Expect(r.URL.Query().Get("startTime")).To(Equal("1970-01-01T00:00:00Z"))
-
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(tc.serverBody) //nolint:errcheck
-			}))
-			defer srv.Close()
-
-			f := fetch.NewHTTPFetcher(logr.Discard())
-			req := fetch.Request{
-				URL:        srv.URL,
-				PolicyName: tc.policyName,
-				Auth:       tc.auth,
-			}
-			result, err := f.FetchPolicyBundle(context.Background(), req)
-
-			if tc.expectErr != "" {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring(tc.expectErr))
-			} else {
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(result.Data).To(Equal(tc.expectData))
-				g.Expect(result.Checksum).To(Equal(fetch.ComputeChecksum(tc.expectData)))
-			}
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "my-policy",
 		})
-	}
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.Data).To(Equal(bundleContent))
+		g.Expect(result.Checksum).To(Equal(fetch.ComputeChecksum(bundleContent)))
+	})
+
+	t.Run("NIM response with no items", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		srv := newNIMBundleServer(nil, nil)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		_, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "missing-policy",
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("NIM metadata response contains no items"))
+	})
+
+	t.Run("NIM fetch with bearer auth", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		auth := &fetch.BundleAuth{BearerToken: "nimtoken"}
+		srv := newNIMBundleServer([]nimBundleServerItem{{
+			content:   bundleContent,
+			hash:      fetch.ComputeChecksum(bundleContent),
+			policyUID: "uid-auth",
+			created:   "2026-01-01T00:00:00Z",
+		}}, auth)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "secured-policy",
+			Auth:       auth,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.Data).To(Equal(bundleContent))
+	})
+
+	t.Run("NIM response with multiple items selects latest by created timestamp", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		oldContent := []byte("old-bundle-v1")
+		newContent := []byte("new-bundle-v2")
+
+		// Items deliberately NOT in chronological order to verify timestamp-based selection.
+		srv := newNIMBundleServer([]nimBundleServerItem{
+			{
+				content:   newContent,
+				hash:      fetch.ComputeChecksum(newContent),
+				policyUID: "uid-v2",
+				created:   "2026-05-05T08:55:25.078Z",
+			},
+			{
+				content:   oldContent,
+				hash:      fetch.ComputeChecksum(oldContent),
+				policyUID: "uid-v1",
+				created:   "2026-05-05T08:40:31.213Z",
+			},
+		}, nil)
+		defer srv.Close()
+
+		f := fetch.NewHTTPFetcher(logr.Discard())
+		result, err := f.FetchPolicyBundle(context.Background(), fetch.Request{
+			URL:        srv.URL,
+			PolicyName: "updated-policy",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.Data).To(Equal(newContent))
+		g.Expect(result.Checksum).To(Equal(fetch.ComputeChecksum(newContent)))
+	})
 }
 
 func TestHTTPFetcherFetchLogProfileBundleHTTP(t *testing.T) {
@@ -1645,18 +1633,19 @@ func TestFetchPolicyBundleChecksumNIM(t *testing.T) {
 
 	bundleContent := []byte("nim-bundle-data")
 	bundleHash := fetch.ComputeChecksum(bundleContent)
-	encoded := base64.StdEncoding.EncodeToString(bundleContent)
 
 	var includeBundleContent string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		g.Expect(r.URL.Path).To(Equal("/api/platform/v1/security/policies/bundles"))
 		includeBundleContent = r.URL.Query().Get("includeBundleContent")
 		w.Header().Set("Content-Type", "application/json")
-		// Always return content so the handler is simple; the fetcher should not decode it for checksum-only.
 		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 			"items": []map[string]any{{
-				"content":  encoded,
-				"metadata": map[string]any{"hash": bundleHash},
+				"metadata": map[string]any{
+					"hash":      bundleHash,
+					"policyUID": "uid-checksum",
+					"created":   "2026-01-01T00:00:00Z",
+				},
 			}},
 		})
 	}))
@@ -1675,24 +1664,27 @@ func TestFetchPolicyBundleChecksumNIMMultipleItems(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	oldContent := []byte("old-bundle-v1")
-	oldHash := fetch.ComputeChecksum(oldContent)
-
-	newContent := []byte("new-bundle-v2")
-	newHash := fetch.ComputeChecksum(newContent)
+	oldHash := fetch.ComputeChecksum([]byte("old-bundle-v1"))
+	newHash := fetch.ComputeChecksum([]byte("new-bundle-v2"))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		// NIM returns items in chronological order: old first, latest last.
+		// Items deliberately NOT in chronological order to verify timestamp-based selection.
 		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 			"items": []map[string]any{
 				{
-					"content":  base64.StdEncoding.EncodeToString(oldContent),
-					"metadata": map[string]any{"hash": oldHash},
+					"metadata": map[string]any{
+						"hash":      newHash,
+						"policyUID": "uid-v2",
+						"created":   "2026-05-05T08:55:25.078Z",
+					},
 				},
 				{
-					"content":  base64.StdEncoding.EncodeToString(newContent),
-					"metadata": map[string]any{"hash": newHash},
+					"metadata": map[string]any{
+						"hash":      oldHash,
+						"policyUID": "uid-v1",
+						"created":   "2026-05-05T08:40:31.213Z",
+					},
 				},
 			},
 		})
@@ -1704,7 +1696,7 @@ func TestFetchPolicyBundleChecksumNIMMultipleItems(t *testing.T) {
 	checksum, err := f.FetchPolicyBundleChecksum(context.Background(), req)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(checksum).To(Equal(newHash), "should return the hash of the latest (last) item, not the oldest")
+	g.Expect(checksum).To(Equal(newHash), "should return the hash of the latest item by created timestamp")
 }
 
 func TestFetchBundleChecksumErrors(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

Problem: When a NIM policy is recompiled, the NIM bundles API returns multiple items (one per compilation). The fetcher unconditionally used Items[0], which was not guaranteed to be the latest compilation. This meant updated bundles could be missed even after deleting and recreating the WAFPolicy. Additionally, fetching with includeBundleContent=true downloaded with the (potentially large) content of every historical compilation unnecessarily.

Solution: Refactor the NIM fetch into a two-phase approach: 
- When fetching by policyName, a lightweight metadata-only request (includeBundleContent=false) is issued first to retrieve all compilations. The item with the most recent metadata.created timestamp is selected via a new latestNIMItem() helper, and then only that single bundle is fetched by its policyUID. 
- When fetching by policyUID (already pinned), the bundle is fetched directly with no metadata bundle phase. 
- The same timestamp-based selection is applied in fetchNIMChecksum so pollers also detect updates correctly. Added debug logs to confirm which policyUID and created timestamp are selected during fetch and checksum operations.

Testing: Tested locally using the latest version of NIM

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
