### PR TITLE
Fix openshift and ubi issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,20 +505,15 @@ jobs:
 
   functional-tests:
     name: Functional tests
-    needs: [vars, build-oss, build-plus]
+    needs: [vars, build-oss, build-plus, build-plus-nap-waf]
     strategy:
       fail-fast: false
       matrix:
-        # On PRs: run nginx + plus with latest k8s only (2 jobs)
+        # On PRs: run nginx + plus + waf with latest k8s only (2 jobs)
         # On main/release: run full matrix (8 jobs)
-        image: [nginx, plus]
+        image: [nginx, plus, plus-waf]
         build-os: ${{ github.event_name == 'pull_request' && fromJSON('[""]') || fromJSON('["", "ubi"]') }}
         k8s-version: ${{ github.event_name == 'pull_request' && fromJSON(format('["{0}"]', needs.vars.outputs.k8s_latest)) || fromJSON(format('["{0}", "{1}"]', needs.vars.outputs.min_k8s_version, needs.vars.outputs.k8s_latest)) }}
-        include:
-          # plus-waf: always run once with latest k8s, no build-os suffix
-          - image: plus-waf
-            build-os: ''
-            k8s-version: ${{ needs.vars.outputs.k8s_latest }}
     uses: ./.github/workflows/functional.yml
     with:
       image: ${{ matrix.image }}

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -57,6 +57,7 @@ const (
 	appProtectBundlesVolumeName  = "app-protect-bundles"
 	appProtectConfigVolumeName   = "app-protect-config"
 	appProtectBdConfigVolumeName = "app-protect-bd-config"
+	appProtectLockVolumeName     = "app-protect-lock"
 )
 
 // portProtoEntry represents a unique port and protocol combination.
@@ -1102,7 +1103,6 @@ func (p *NginxProvisioner) buildNginxContainer(
 		ReadinessProbe:  p.buildReadinessProbe(nProxyCfg),
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 				Drop: []corev1.Capability{"ALL"},
 			},
 			ReadOnlyRootFilesystem: helpers.GetPointer(true),
@@ -1595,6 +1595,10 @@ func buildWAFSharedVolumes() []corev1.Volume {
 			Name:         appProtectBdConfigVolumeName,
 			VolumeSource: emptyDirVolumeSource,
 		},
+		{
+			Name:         appProtectLockVolumeName,
+			VolumeSource: emptyDirVolumeSource,
+		},
 	}
 }
 
@@ -1612,6 +1616,10 @@ func buildNginxWAFVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      appProtectBdConfigVolumeName,
 			MountPath: "/opt/app_protect/bd_config",
+		},
+		{
+			Name:      appProtectLockVolumeName,
+			MountPath: "/opt/app_protect/lock",
 		},
 	}
 }
@@ -1726,6 +1734,10 @@ func (p *NginxProvisioner) buildWAFConfigManagerContainer(
 			{
 				Name:      appProtectBundlesVolumeName,
 				MountPath: "/etc/app_protect/bundles",
+			},
+			{
+				Name:      appProtectLockVolumeName,
+				MountPath: "/opt/app_protect/lock",
 			},
 		},
 	}

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -2585,12 +2585,14 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 		"app-protect-bundles",
 		"app-protect-config",
 		"app-protect-bd-config",
+		"app-protect-lock",
 	}
 
 	expectedNginxWAFMounts := map[string]string{
 		"app-protect-bundles":   "/etc/app_protect/bundles",
 		"app-protect-config":    "/opt/app_protect/config",
 		"app-protect-bd-config": "/opt/app_protect/bd_config",
+		"app-protect-lock":      "/opt/app_protect/lock",
 	}
 
 	for _, expectedMount := range wafVolumeMountNames {
@@ -2649,13 +2651,14 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 	g.Expect(configMgrContainer.Resources.Limits).To(HaveKey(corev1.ResourceCPU))
 	g.Expect(configMgrContainer.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("300m")))
 
-	// Check config manager volume mounts (should have all 3 WAF volumes)
-	g.Expect(configMgrContainer.VolumeMounts).To(HaveLen(3))
+	// Check config manager volume mounts (should have all 4 WAF volumes)
+	g.Expect(configMgrContainer.VolumeMounts).To(HaveLen(4))
 
 	expectedConfigMgrMounts := map[string]string{
 		"app-protect-bd-config": "/opt/app_protect/bd_config",
 		"app-protect-config":    "/opt/app_protect/config",
 		"app-protect-bundles":   "/etc/app_protect/bundles",
+		"app-protect-lock":      "/opt/app_protect/lock",
 	}
 
 	for _, mount := range configMgrContainer.VolumeMounts {

--- a/operators/config/rbac/role.yaml
+++ b/operators/config/rbac/role.yaml
@@ -219,15 +219,5 @@ rules:
   - update
   - use
   - watch
-- apiGroups:
-  - appprotect.f5.com
-  resources:
-  - aplogconfs
-  - appolicies
-  verbs:
-  - get
-  - list
-  - update
-  - watch
 
 # +kubebuilder:scaffold:rules


### PR DESCRIPTION
### Proposed changes

Problem: A couple of bugs were discovered doing the OpenShift testing:
- The NET_BIND_SERVICE capability was accidentally reintroduced causing SCC issues
- Running WAF using the UBI images requires an additional volume mount for writing to `/opt/app_protect/lock/config_set_apply.lock` file

Solution: 
- Remove the NET_BIND_SERVICE capability
- Add the required additional volume mount `/opt/app_protect/lock/`
- Add WAF UBI functional tests to catch potential future regressions

Testing:
- Tested on OpenShift cluster. Conformance tests are passing and manual WAF tests are working
- Did one PR run of the WAF functional tests on UBI: https://github.com/nginx/nginx-gateway-fabric/actions/runs/25421246273/job/74564395805?pr=5246

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
