### PR TITLE
Assertion job should run on production runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # for compliance-rules action to sign assertion doc
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-amd64
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Proposed changes

Problem: The assertion jobs are failing with 403s trying to fetch the dependencies

Solution: Run these on the production runners instead

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
