### PR TITLE
Readd AllowPrivilegeEscalation: false to containers

### DIFF
--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -1105,9 +1105,10 @@ func (p *NginxProvisioner) buildNginxContainer(
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
-			ReadOnlyRootFilesystem: helpers.GetPointer(true),
-			RunAsGroup:             helpers.GetPointer[int64](1001),
-			RunAsUser:              helpers.GetPointer[int64](101),
+			AllowPrivilegeEscalation: helpers.GetPointer(false),
+			ReadOnlyRootFilesystem:   helpers.GetPointer(true),
+			RunAsGroup:               helpers.GetPointer[int64](1001),
+			RunAsUser:                helpers.GetPointer[int64](101),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
@@ -1241,9 +1242,10 @@ func (p *NginxProvisioner) buildInitContainers(nProxyCfg *graph.EffectiveNginxPr
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
-				ReadOnlyRootFilesystem: helpers.GetPointer(true),
-				RunAsGroup:             helpers.GetPointer[int64](1001),
-				RunAsUser:              helpers.GetPointer[int64](101),
+				AllowPrivilegeEscalation: helpers.GetPointer(false),
+				ReadOnlyRootFilesystem:   helpers.GetPointer(true),
+				RunAsGroup:               helpers.GetPointer[int64](1001),
+				RunAsUser:                helpers.GetPointer[int64](101),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/dataplane"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph/shared/configmaps"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph/shared/secrets"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/controller"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/waf"
@@ -1392,8 +1393,8 @@ func (p *NginxProvisioner) configureNginxPlus(
 	if names.jwt != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "nginx-plus-license",
-			MountPath: "/etc/nginx/license.jwt",
-			SubPath:   "license.jwt",
+			MountPath: "/etc/nginx/" + secrets.LicenseJWTKey,
+			SubPath:   secrets.LicenseJWTKey,
 		})
 		spec.Spec.Volumes = append(spec.Spec.Volumes, corev1.Volume{
 			Name:         "nginx-plus-license",

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -2678,6 +2678,61 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 	}
 }
 
+func TestNginxContainerSecurityContext(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	provisioner := &NginxProvisioner{
+		cfg: Config{
+			GatewayPodConfig: &config.GatewayPodConfig{Version: "1.0.0"},
+		},
+	}
+
+	container := provisioner.buildNginxContainer(nil, nil)
+	g.Expect(container.SecurityContext).To(Equal(&corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		AllowPrivilegeEscalation: helpers.GetPointer(false),
+		ReadOnlyRootFilesystem:   helpers.GetPointer(true),
+		RunAsGroup:               helpers.GetPointer[int64](1001),
+		RunAsUser:                helpers.GetPointer[int64](101),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}))
+}
+
+func TestInitContainerSecurityContext(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	provisioner := &NginxProvisioner{
+		cfg: Config{
+			GatewayPodConfig: &config.GatewayPodConfig{
+				Version: "1.0.0",
+				Image:   "ngf-image",
+			},
+			AgentLabels: make(map[string]string),
+		},
+	}
+
+	initContainers := provisioner.buildInitContainers(nil)
+	g.Expect(initContainers).To(HaveLen(1))
+	g.Expect(initContainers[0].SecurityContext).To(Equal(&corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		AllowPrivilegeEscalation: helpers.GetPointer(false),
+		ReadOnlyRootFilesystem:   helpers.GetPointer(true),
+		RunAsGroup:               helpers.GetPointer[int64](1001),
+		RunAsUser:                helpers.GetPointer[int64](101),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}))
+}
+
 func TestDetermineNginxImageName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed changes

Problem: The WAF branch accidentally removed "AllowPrivilegeEscalation: false" from the NGINX and init containers' security context, breaking strict admission policies

Solution: Re-add this field to both security contexts.

Testing: Added unit tests to catch any future regressions

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5276 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes an issue where "AllowPrivilegeEscalation: false" was inadvertently removed from the NGINX and init containers' security contexts.
```
