### PR TITLE
Bumps version for NGINX OSS, NGINX Plus, NGINX Agent and WAF compiler…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following table lists the software versions NGINX Gateway Fabric supports. O
 
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent | F5 WAF for NGINX |
 |----------------------|-------------|------------|-----------|------------|-------------|------------------|
-| Edge                 | 1.5.1       | 1.31+      | 1.30.0    | R36        | v3.9.1      | 5.12.1           |
+| Edge                 | 1.5.1       | 1.31+      | 1.31.0    | R37.0      | v3.10.1     | 5.13.0           |
 | 2.6.0                | 1.5.1       | 1.31+      | 1.30.0    | R36        | v3.9.1      | 5.12.1           |
 | 2.5.1                | 1.5.1       | 1.31+      | 1.29.7    | R36        | v3.8.0      | ---              |
 | 2.4.2                | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.1      | ---              |

--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -4,10 +4,10 @@ FROM scratch AS nginx-files
 # the following links can be replaced with local files if needed, i.e. ADD --chown=101:1001 <local_file> <container_file>
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
 
-FROM nginx:1.30.0-alpine-otel
+FROM nginx:1.31.0-alpine-otel
 
 # renovate: datasource=github-tags depName=nginx/agent
-ARG NGINX_AGENT_VERSION=v3.9.1
+ARG NGINX_AGENT_VERSION=v3.10.1
 ARG NJS_DIR
 ARG NGINX_CONF_DIR
 ARG BUILD_AGENT
@@ -16,7 +16,7 @@ RUN --mount=type=bind,from=nginx-files,src=nginx_signing.rsa.pub,target=/etc/apk
     printf "%s\n" "https://packages.nginx.org/nginx-agent/alpine/v$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
     && apk add --no-cache nginx-agent=${NGINX_AGENT_VERSION#v}
 
-RUN apk update && apk upgrade --no-cache nghttp2-libs xz-libs libcap
+RUN apk update && apk upgrade --no-cache curl grpc-cpp protobuf
 
 RUN apk add --no-cache bash \
     && mkdir -p /usr/lib/nginx/modules \

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -6,12 +6,12 @@ ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.p
 
 FROM alpine:3.22
 
-RUN apk update && apk upgrade --no-cache musl musl-utils zlib libcap
+RUN apk update && apk upgrade --no-cache grpc-cpp protobuf
 
-ARG NGINX_PLUS_VERSION=R36
+ARG NGINX_PLUS_VERSION=R37.0
 # renovate: datasource=github-tags depName=nginx/agent
-ARG NGINX_AGENT_VERSION=v3.9.1
-ARG APP_PROTECT_VERSION=36.5.607
+ARG NGINX_AGENT_VERSION=v3.10.1
+ARG APP_PROTECT_VERSION=37.0.5.635
 ARG INCLUDE_NAP_WAF=false
 ARG NJS_DIR
 ARG NGINX_CONF_DIR

--- a/build/ubi/Dockerfile.nginx
+++ b/build/ubi/Dockerfile.nginx
@@ -12,8 +12,11 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS ubi-nginx
 
 RUN microdnf -y update glib2 && microdnf clean all
 
+# renovate: datasource=github-tags depName=nginx/nginx
+ARG NGINX_VERSION=1.31.0
+
 # renovate: datasource=github-tags depName=nginx/agent
-ARG NGINX_AGENT_VERSION=v3.9.1
+ARG NGINX_AGENT_VERSION=v3.10.1
 ARG NJS_DIR
 ARG NGINX_CONF_DIR
 ARG BUILD_AGENT
@@ -42,7 +45,7 @@ RUN --mount=type=bind,from=nginx-files,src=nginx_signing.key,target=/tmp/nginx_s
     && groupadd -g 1001 nginx \
     && useradd -r -u 101 -g nginx -s /sbin/nologin -d /var/cache/nginx nginx \
     # Install NGINX and modules including OTEL
-    && microdnf --nodocs install -y nginx nginx-module-njs nginx-module-otel \
+    && microdnf --nodocs install -y nginx-${NGINX_VERSION} nginx-module-njs-${NGINX_VERSION}* nginx-module-otel-${NGINX_VERSION}* \
     # Install nginx-agent
     && microdnf --nodocs install -y nginx-agent-${NGINX_AGENT_VERSION#v}* \
     # Clean up

--- a/build/ubi/Dockerfile.nginxplus
+++ b/build/ubi/Dockerfile.nginxplus
@@ -13,12 +13,12 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS ubi-nginx-plus
 
 RUN microdnf -y update glib2 && microdnf clean all
 
-ARG NGINX_PLUS_VERSION=R36
-ARG APP_PROTECT_VERSION=36+5.607
+ARG NGINX_PLUS_VERSION=R37.0
+ARG APP_PROTECT_VERSION=37.0+5.635
 ARG INCLUDE_NAP_WAF=false
 
 # renovate: datasource=github-tags depName=nginx/agent
-ARG NGINX_AGENT_VERSION=v3.9.1
+ARG NGINX_AGENT_VERSION=v3.10.1
 ARG NJS_DIR
 ARG NGINX_CONF_DIR
 ARG BUILD_AGENT

--- a/examples/waf-policy/bundle-server.yaml
+++ b/examples/waf-policy/bundle-server.yaml
@@ -57,7 +57,7 @@ spec:
       - name: gateway-nginx-nginx-registry-secret
       initContainers:
       - name: compile-attack-signatures
-        image: private-registry.nginx.com/nap/waf-compiler:5.12.1
+        image: private-registry.nginx.com/nap/waf-compiler:5.13.0
         args:
         - -p
         - /policies/attack-signatures-blocking.json
@@ -69,7 +69,7 @@ spec:
         - name: bundles
           mountPath: /bundles
       - name: compile-dataguard
-        image: private-registry.nginx.com/nap/waf-compiler:5.12.1
+        image: private-registry.nginx.com/nap/waf-compiler:5.13.0
         args:
         - -p
         - /policies/dataguard-blocking.json

--- a/internal/framework/waf/waf.go
+++ b/internal/framework/waf/waf.go
@@ -6,4 +6,4 @@ package waf
 // It is used both as the default image tag for the waf-enforcer and waf-config-mgr
 // sidecar containers and as the nap_release query parameter when compiling
 // policy bundles via the F5 NGINX One Console API.
-const Release = "5.12.1"
+const Release = "5.13.0"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -261,7 +261,7 @@ test-cel-validation:
 		go test -v ./cel -run "$(CEL_TEST_TARGET)"; \
 	fi
 
-NAP_VERSION = $(shell sed -n 's/.*Release[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' $(SELF_DIR)internal/framework/waf/waf.go)
+NAP_VERSION = $(shell sed -n 's/^const Release[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' $(SELF_DIR)internal/framework/waf/waf.go)
 NAP_COMPILER_IMAGE = private-registry.nginx.com/nap/waf-compiler:$(NAP_VERSION)
 WAF_POLICY_DIR = $(SELF_DIR)tests/suite/manifests/waf-policy
 


### PR DESCRIPTION
… (#5289)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Updates the NGINX Agent version to v3.10.1, NGINX to v1.31.0, NGINX Plus to R37.0 and F5 WAF to 5.13.0.
```
