### PR TITLE
NGINX Plus: Add support for error_log in json format and structure access log in json format

### DIFF
--- a/apis/v1alpha2/nginxproxy_types.go
+++ b/apis/v1alpha2/nginxproxy_types.go
@@ -371,7 +371,7 @@ const (
 
 // NginxLogging defines logging related settings for NGINX.
 //
-// +kubebuilder:validation:XValidation:message="JSON-formatted error logs are not supported when errorLevel is debug",rule="!(has(self.json) && self.json && has(self.errorLevel) && self.errorLevel == 'debug')"
+// +kubebuilder:validation:XValidation:message="JSON-formatted error logs are not supported when errorLevel is debug",rule="!(has(self.errorLogFormat) && self.errorLogFormat == 'json' && has(self.errorLevel) && self.errorLevel == 'debug')"
 //
 //nolint:lll
 type NginxLogging struct {
@@ -384,13 +384,15 @@ type NginxLogging struct {
 	// +kubebuilder:default=info
 	ErrorLevel *NginxErrorLogLevel `json:"errorLevel,omitempty"`
 
-	// JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
-	// When enabled, it also emits a JSON-formatted access log if the user has not supplied
-	// a custom access log format.
+	// ErrorLogFormat controls the output format of the NGINX error_log directive.
+	// Set to 'json' to enable JSON-formatted error logs for NGINX Plus only and
+	// cannot be combined with errorLevel: debug.
+	// When set to 'json', NGINX Gateway Fabric also emits a JSON-formatted access log
+	// if the user has not supplied a custom access log format.
 	// See https://nginx.org/en/docs/ngx_core_module.html#error_log
 	//
 	// +optional
-	JSON *bool `json:"json,omitempty"`
+	ErrorLogFormat *NginxErrorLogFormat `json:"errorLogFormat,omitempty"`
 
 	// AgentLevel defines the log level of the NGINX agent process. Changing this value results in a
 	// re-roll of the NGINX deployment.
@@ -405,6 +407,19 @@ type NginxLogging struct {
 	// +optional
 	AccessLog *NginxAccessLog `json:"accessLog,omitempty"`
 }
+
+// NginxErrorLogFormat defines the output format for NGINX error logs.
+//
+// +kubebuilder:validation:Enum=default;json
+type NginxErrorLogFormat string
+
+const (
+	// NginxErrorLogFormatDefault uses NGINX's standard error log format.
+	NginxErrorLogFormatDefault NginxErrorLogFormat = "default"
+
+	// NginxErrorLogFormatJSON enables JSON-formatted error logs. Requires NGINX Plus.
+	NginxErrorLogFormatJSON NginxErrorLogFormat = "json"
+)
 
 // NginxErrorLogLevel type defines the log level of error logs for NGINX.
 //

--- a/apis/v1alpha2/nginxproxy_types.go
+++ b/apis/v1alpha2/nginxproxy_types.go
@@ -370,6 +370,10 @@ const (
 )
 
 // NginxLogging defines logging related settings for NGINX.
+//
+// +kubebuilder:validation:XValidation:message="JSON-formatted error logs are not supported when errorLevel is debug",rule="!(has(self.json) && self.json && has(self.errorLevel) && self.errorLevel == 'debug')"
+//
+//nolint:lll
 type NginxLogging struct {
 	// ErrorLevel defines the error log level. Possible log levels listed in order of increasing severity are
 	// debug, info, notice, warn, error, crit, alert, and emerg. Setting a certain log level will cause all messages
@@ -379,6 +383,14 @@ type NginxLogging struct {
 	// +optional
 	// +kubebuilder:default=info
 	ErrorLevel *NginxErrorLogLevel `json:"errorLevel,omitempty"`
+
+	// JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
+	// When enabled, it also emits a JSON-formatted access log if the user has not supplied
+	// a custom access log format.
+	// See https://nginx.org/en/docs/ngx_core_module.html#error_log
+	//
+	// +optional
+	JSON *bool `json:"json,omitempty"`
 
 	// AgentLevel defines the log level of the NGINX agent process. Changing this value results in a
 	// re-roll of the NGINX deployment.

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -453,9 +453,9 @@ func (in *NginxLogging) DeepCopyInto(out *NginxLogging) {
 		*out = new(NginxErrorLogLevel)
 		**out = **in
 	}
-	if in.JSON != nil {
-		in, out := &in.JSON, &out.JSON
-		*out = new(bool)
+	if in.ErrorLogFormat != nil {
+		in, out := &in.ErrorLogFormat, &out.ErrorLogFormat
+		*out = new(NginxErrorLogFormat)
 		**out = **in
 	}
 	if in.AgentLevel != nil {

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -453,6 +453,11 @@ func (in *NginxLogging) DeepCopyInto(out *NginxLogging) {
 		*out = new(NginxErrorLogLevel)
 		**out = **in
 	}
+	if in.JSON != nil {
+		in, out := &in.JSON, &out.JSON
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AgentLevel != nil {
 		in, out := &in.AgentLevel, &out.AgentLevel
 		*out = new(AgentLogLevel)

--- a/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
+++ b/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
@@ -8917,7 +8917,19 @@ spec:
                     - alert
                     - emerg
                     type: string
+                  json:
+                    description: |-
+                      JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
+                      When enabled, it also emits a JSON-formatted access log if the user has not supplied
+                      a custom access log format.
+                      See https://nginx.org/en/docs/ngx_core_module.html#error_log
+                    type: boolean
                 type: object
+                x-kubernetes-validations:
+                - message: JSON-formatted error logs are not supported when errorLevel
+                    is debug
+                  rule: '!(has(self.json) && self.json && has(self.errorLevel) &&
+                    self.errorLevel == ''debug'')'
               metrics:
                 description: |-
                   Metrics defines the configuration for Prometheus scraping metrics. Changing this value results in a

--- a/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
+++ b/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
@@ -8917,19 +8917,24 @@ spec:
                     - alert
                     - emerg
                     type: string
-                  json:
+                  errorLogFormat:
                     description: |-
-                      JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
-                      When enabled, it also emits a JSON-formatted access log if the user has not supplied
-                      a custom access log format.
+                      ErrorLogFormat controls the output format of the NGINX error_log directive.
+                      Set to 'json' to enable JSON-formatted error logs for NGINX Plus only and
+                      cannot be combined with errorLevel: debug.
+                      When set to 'json', NGINX Gateway Fabric also emits a JSON-formatted access log
+                      if the user has not supplied a custom access log format.
                       See https://nginx.org/en/docs/ngx_core_module.html#error_log
-                    type: boolean
+                    enum:
+                    - default
+                    - json
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: JSON-formatted error logs are not supported when errorLevel
                     is debug
-                  rule: '!(has(self.json) && self.json && has(self.errorLevel) &&
-                    self.errorLevel == ''debug'')'
+                  rule: '!(has(self.errorLogFormat) && self.errorLogFormat == ''json''
+                    && has(self.errorLevel) && self.errorLevel == ''debug'')'
               metrics:
                 description: |-
                   Metrics defines the configuration for Prometheus scraping metrics. Changing this value results in a

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -9966,19 +9966,24 @@ spec:
                     - alert
                     - emerg
                     type: string
-                  json:
+                  errorLogFormat:
                     description: |-
-                      JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
-                      When enabled, it also emits a JSON-formatted access log if the user has not supplied
-                      a custom access log format.
+                      ErrorLogFormat controls the output format of the NGINX error_log directive.
+                      Set to 'json' to enable JSON-formatted error logs for NGINX Plus only and
+                      cannot be combined with errorLevel: debug.
+                      When set to 'json', NGINX Gateway Fabric also emits a JSON-formatted access log
+                      if the user has not supplied a custom access log format.
                       See https://nginx.org/en/docs/ngx_core_module.html#error_log
-                    type: boolean
+                    enum:
+                    - default
+                    - json
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: JSON-formatted error logs are not supported when errorLevel
                     is debug
-                  rule: '!(has(self.json) && self.json && has(self.errorLevel) &&
-                    self.errorLevel == ''debug'')'
+                  rule: '!(has(self.errorLogFormat) && self.errorLogFormat == ''json''
+                    && has(self.errorLevel) && self.errorLevel == ''debug'')'
               metrics:
                 description: |-
                   Metrics defines the configuration for Prometheus scraping metrics. Changing this value results in a

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -9966,7 +9966,19 @@ spec:
                     - alert
                     - emerg
                     type: string
+                  json:
+                    description: |-
+                      JSON enables JSON-formatted error logs. Requires NGINX Plus and cannot be combined with errorLevel: debug.
+                      When enabled, it also emits a JSON-formatted access log if the user has not supplied
+                      a custom access log format.
+                      See https://nginx.org/en/docs/ngx_core_module.html#error_log
+                    type: boolean
                 type: object
+                x-kubernetes-validations:
+                - message: JSON-formatted error logs are not supported when errorLevel
+                    is debug
+                  rule: '!(has(self.json) && self.json && has(self.errorLevel) &&
+                    self.errorLevel == ''debug'')'
               metrics:
                 description: |-
                   Metrics defines the configuration for Prometheus scraping metrics. Changing this value results in a

--- a/internal/controller/nginx/config/main_config_template.go
+++ b/internal/controller/nginx/config/main_config_template.go
@@ -9,7 +9,7 @@ load_module modules/ngx_otel_module.so;
 load_module modules/ngx_http_app_protect_module.so;
 {{ end -}}
 
-error_log stderr {{ .Conf.Logging.ErrorLevel }};
+error_log stderr {{ .Conf.Logging.ErrorLevel }}{{ if .Conf.Logging.JSON }} json{{ end }};
 
 {{ range $i := .Includes -}}
 include {{ $i.Name }};

--- a/internal/controller/nginx/config/main_config_template.go
+++ b/internal/controller/nginx/config/main_config_template.go
@@ -9,7 +9,7 @@ load_module modules/ngx_otel_module.so;
 load_module modules/ngx_http_app_protect_module.so;
 {{ end -}}
 
-error_log stderr {{ .Conf.Logging.ErrorLevel }}{{ if .Conf.Logging.JSON }} json{{ end }};
+error_log stderr {{ .Conf.Logging.ErrorLevel }}{{ if eq .Conf.Logging.ErrorLogFormat "json" }} json{{ end }};
 
 {{ range $i := .Includes -}}
 include {{ $i.Name }};

--- a/internal/controller/nginx/config/main_config_test.go
+++ b/internal/controller/nginx/config/main_config_test.go
@@ -122,8 +122,8 @@ func TestExecuteMainConfig_Logging(t *testing.T) {
 			expectJSON:   false,
 		},
 		{
-			name:         "error log appends json keyword when JSON is true",
-			logging:      dataplane.Logging{ErrorLevel: "info", JSON: true},
+			name:         "error log appends json keyword when ErrorLogFormat is json",
+			logging:      dataplane.Logging{ErrorLevel: "info", ErrorLogFormat: "json"},
 			expDirective: "error_log stderr info json;",
 			expectJSON:   true,
 		},

--- a/internal/controller/nginx/config/main_config_test.go
+++ b/internal/controller/nginx/config/main_config_test.go
@@ -109,19 +109,40 @@ func TestExecuteMainConfig_Waf(t *testing.T) {
 func TestExecuteMainConfig_Logging(t *testing.T) {
 	t.Parallel()
 
-	conf := dataplane.Configuration{
-		Logging: dataplane.Logging{
-			ErrorLevel: "info",
+	tests := []struct {
+		name         string
+		expDirective string
+		logging      dataplane.Logging
+		expectJSON   bool
+	}{
+		{
+			name:         "error log uses default text format when JSON is false",
+			logging:      dataplane.Logging{ErrorLevel: "info"},
+			expDirective: "error_log stderr info;",
+			expectJSON:   false,
+		},
+		{
+			name:         "error log appends json keyword when JSON is true",
+			logging:      dataplane.Logging{ErrorLevel: "info", JSON: true},
+			expDirective: "error_log stderr info json;",
+			expectJSON:   true,
 		},
 	}
 
-	g := NewWithT(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
 
-	res := executeMainConfig(conf, &policiesfakes.FakeGenerator{})
-	g.Expect(res).To(HaveLen(1))
-	g.Expect(res[0].dest).To(Equal(mainIncludesConfigFile))
-
-	g.Expect(string(res[0].data)).To(ContainSubstring("error_log stderr info"))
+			res := executeMainConfig(dataplane.Configuration{Logging: test.logging}, &policiesfakes.FakeGenerator{})
+			g.Expect(res).To(HaveLen(1))
+			g.Expect(res[0].dest).To(Equal(mainIncludesConfigFile))
+			g.Expect(string(res[0].data)).To(ContainSubstring(test.expDirective))
+			if !test.expectJSON {
+				g.Expect(string(res[0].data)).ToNot(ContainSubstring("error_log stderr info json"))
+			}
+		})
+	}
 }
 
 func TestExecuteMainConfig_Snippets(t *testing.T) {

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -37,6 +37,19 @@ const (
 	DefaultLogFormatName = "ngf_user_defined_log_format"
 	// DefaultAccessLogPath is the default path for the access log.
 	DefaultAccessLogPath = "/dev/stdout"
+	// JSONAccessLogFormat is the JSON access log template emitted when JSON logging
+	// is enabled and the user has not supplied their own access log format. Fields mirror
+	// nginx's implicit 'combined' format.
+	JSONAccessLogFormat = `{` +
+		`"time_local":"$time_local",` +
+		`"remote_addr":"$remote_addr",` +
+		`"remote_user":"$remote_user",` +
+		`"request":"$request",` +
+		`"status":"$status",` +
+		`"body_bytes_sent":"$body_bytes_sent",` +
+		`"http_referer":"$http_referer",` +
+		`"http_user_agent":"$http_user_agent"` +
+		`}`
 	// InternalRLPAnnotationKey is the annotation key used to mark internally generated
 	// RateLimitPolicies. These policies are created when a RateLimitPolicy targets a route and not
 	// the Gateway itself; in this situation we need an additional policy to generate the http context
@@ -1956,6 +1969,10 @@ func buildLogging(gateway *graph.Gateway) Logging {
 			logSettings.ErrorLevel = string(*ngfProxy.Logging.ErrorLevel)
 		}
 
+		if ngfProxy.Logging.JSON != nil {
+			logSettings.JSON = *ngfProxy.Logging.JSON
+		}
+
 		srcLogSettings := ngfProxy.Logging
 
 		if accessLog := buildAccessLog(srcLogSettings); accessLog != nil {
@@ -1980,6 +1997,13 @@ func buildAccessLog(srcLogSettings *ngfAPIv1alpha2.NginxLogging) *AccessLog {
 				accessLog.Escape = string(*srcLogSettings.AccessLog.Escape)
 			}
 			return accessLog
+		}
+	}
+
+	if srcLogSettings.JSON != nil && *srcLogSettings.JSON {
+		return &AccessLog{
+			Format: JSONAccessLogFormat,
+			Escape: string(ngfAPIv1alpha2.NginxAccessLogEscapeJSON),
 		}
 	}
 

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -1969,8 +1969,8 @@ func buildLogging(gateway *graph.Gateway) Logging {
 			logSettings.ErrorLevel = string(*ngfProxy.Logging.ErrorLevel)
 		}
 
-		if ngfProxy.Logging.JSON != nil {
-			logSettings.JSON = *ngfProxy.Logging.JSON
+		if ngfProxy.Logging.ErrorLogFormat != nil {
+			logSettings.ErrorLogFormat = string(*ngfProxy.Logging.ErrorLogFormat)
 		}
 
 		srcLogSettings := ngfProxy.Logging
@@ -2000,7 +2000,7 @@ func buildAccessLog(srcLogSettings *ngfAPIv1alpha2.NginxLogging) *AccessLog {
 		}
 	}
 
-	if srcLogSettings.JSON != nil && *srcLogSettings.JSON {
+	if srcLogSettings.ErrorLogFormat != nil && *srcLogSettings.ErrorLogFormat == ngfAPIv1alpha2.NginxErrorLogFormatJSON {
 		return &AccessLog{
 			Format: JSONAccessLogFormat,
 			Escape: string(ngfAPIv1alpha2.NginxAccessLogEscapeJSON),

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -6576,18 +6576,18 @@ func TestBuildLogging(t *testing.T) {
 			expLoggingSettings: Logging{ErrorLevel: "emerg"},
 		},
 		{
-			msg: "JSON true emits JSON access log template when user has not supplied a custom format",
+			msg: "errorLogFormat json emits JSON access log template when user has not supplied a custom format",
 			gw: &graph.Gateway{
 				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
-						JSON:       helpers.GetPointer(true),
+						ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 					},
 				},
 			},
 			expLoggingSettings: Logging{
-				ErrorLevel: "info",
-				JSON:       true,
+				ErrorLevel:     "info",
+				ErrorLogFormat: "json",
 				AccessLog: &AccessLog{
 					Format: JSONAccessLogFormat,
 					Escape: "json",
@@ -6595,12 +6595,13 @@ func TestBuildLogging(t *testing.T) {
 			},
 		},
 		{
-			msg: "JSON true preserves user-supplied access log format and does not override with JSON access log template",
+			msg: "errorLogFormat json preserves user-supplied access log format and " +
+				"does not override with JSON access log template",
 			gw: &graph.Gateway{
 				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
-						JSON:       helpers.GetPointer(true),
+						ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 						AccessLog: &ngfAPIv1alpha2.NginxAccessLog{
 							Format: helpers.GetPointer(logFormat),
 						},
@@ -6608,20 +6609,20 @@ func TestBuildLogging(t *testing.T) {
 				},
 			},
 			expLoggingSettings: Logging{
-				ErrorLevel: "info",
-				JSON:       true,
+				ErrorLevel:     "info",
+				ErrorLogFormat: "json",
 				AccessLog: &AccessLog{
 					Format: logFormat,
 				},
 			},
 		},
 		{
-			msg: "JSON true with access log explicitly disabled leaves access log off",
+			msg: "errorLogFormat json with access log explicitly disabled leaves access log off",
 			gw: &graph.Gateway{
 				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
-						JSON:       helpers.GetPointer(true),
+						ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 						AccessLog: &ngfAPIv1alpha2.NginxAccessLog{
 							Disable: helpers.GetPointer(true),
 						},
@@ -6629,30 +6630,30 @@ func TestBuildLogging(t *testing.T) {
 				},
 			},
 			expLoggingSettings: Logging{
-				ErrorLevel: "info",
-				JSON:       true,
+				ErrorLevel:     "info",
+				ErrorLogFormat: "json",
 				AccessLog: &AccessLog{
 					Disable: true,
 				},
 			},
 		},
 		{
-			msg: "JSON false is propagated to dataplane logging",
+			msg: "errorLogFormat default is propagated to dataplane logging",
 			gw: &graph.Gateway{
 				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
-						JSON:       helpers.GetPointer(false),
+						ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatDefault),
 					},
 				},
 			},
 			expLoggingSettings: Logging{
-				ErrorLevel: "info",
-				JSON:       false,
+				ErrorLevel:     "info",
+				ErrorLogFormat: "default",
 			},
 		},
 		{
-			msg: "JSON unset leaves dataplane Logging.JSON at zero value",
+			msg: "errorLogFormat unset leaves dataplane Logging.ErrorLogFormat at zero value",
 			gw: &graph.Gateway{
 				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
 					Logging: &ngfAPIv1alpha2.NginxLogging{

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -6462,9 +6462,9 @@ func TestBuildLogging(t *testing.T) {
 
 	t.Parallel()
 	tests := []struct {
-		expLoggingSettings Logging
 		gw                 *graph.Gateway
 		msg                string
+		expLoggingSettings Logging
 	}{
 		{
 			msg:                "Gateway is nil",
@@ -6574,6 +6574,93 @@ func TestBuildLogging(t *testing.T) {
 				},
 			},
 			expLoggingSettings: Logging{ErrorLevel: "emerg"},
+		},
+		{
+			msg: "JSON true emits JSON access log template when user has not supplied a custom format",
+			gw: &graph.Gateway{
+				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						JSON:       helpers.GetPointer(true),
+					},
+				},
+			},
+			expLoggingSettings: Logging{
+				ErrorLevel: "info",
+				JSON:       true,
+				AccessLog: &AccessLog{
+					Format: JSONAccessLogFormat,
+					Escape: "json",
+				},
+			},
+		},
+		{
+			msg: "JSON true preserves user-supplied access log format and does not override with JSON access log template",
+			gw: &graph.Gateway{
+				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						JSON:       helpers.GetPointer(true),
+						AccessLog: &ngfAPIv1alpha2.NginxAccessLog{
+							Format: helpers.GetPointer(logFormat),
+						},
+					},
+				},
+			},
+			expLoggingSettings: Logging{
+				ErrorLevel: "info",
+				JSON:       true,
+				AccessLog: &AccessLog{
+					Format: logFormat,
+				},
+			},
+		},
+		{
+			msg: "JSON true with access log explicitly disabled leaves access log off",
+			gw: &graph.Gateway{
+				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						JSON:       helpers.GetPointer(true),
+						AccessLog: &ngfAPIv1alpha2.NginxAccessLog{
+							Disable: helpers.GetPointer(true),
+						},
+					},
+				},
+			},
+			expLoggingSettings: Logging{
+				ErrorLevel: "info",
+				JSON:       true,
+				AccessLog: &AccessLog{
+					Disable: true,
+				},
+			},
+		},
+		{
+			msg: "JSON false is propagated to dataplane logging",
+			gw: &graph.Gateway{
+				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+						JSON:       helpers.GetPointer(false),
+					},
+				},
+			},
+			expLoggingSettings: Logging{
+				ErrorLevel: "info",
+				JSON:       false,
+			},
+		},
+		{
+			msg: "JSON unset leaves dataplane Logging.JSON at zero value",
+			gw: &graph.Gateway{
+				EffectiveNginxProxy: &graph.EffectiveNginxProxy{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+					},
+				},
+			},
+			expLoggingSettings: Logging{ErrorLevel: "info"},
 		},
 		{
 			msg: "AccessLog configured",

--- a/internal/controller/state/dataplane/types.go
+++ b/internal/controller/state/dataplane/types.go
@@ -754,6 +754,8 @@ type Logging struct {
 	AccessLog *AccessLog
 	// ErrorLevel defines the error log level.
 	ErrorLevel string
+	// JSON enables JSON-formatted error logs. Requires NGINX Plus.
+	JSON bool
 }
 
 // NginxPlus specifies NGINX Plus additional settings.

--- a/internal/controller/state/dataplane/types.go
+++ b/internal/controller/state/dataplane/types.go
@@ -754,8 +754,9 @@ type Logging struct {
 	AccessLog *AccessLog
 	// ErrorLevel defines the error log level.
 	ErrorLevel string
-	// JSON enables JSON-formatted error logs. Requires NGINX Plus.
-	JSON bool
+	// ErrorLogFormat defines the error log format.
+	// If not specified, the default NGINX error log format is used.
+	ErrorLogFormat string
 }
 
 // NginxPlus specifies NGINX Plus additional settings.

--- a/internal/controller/state/graph/nginxproxy.go
+++ b/internal/controller/state/graph/nginxproxy.go
@@ -419,12 +419,12 @@ func validateLogging(npCfg *ngfAPIv1alpha2.NginxProxy, plus bool) field.ErrorLis
 			}
 		}
 
-		if logging.JSON != nil && *logging.JSON && !plus {
+		if logging.ErrorLogFormat != nil && *logging.ErrorLogFormat == ngfAPIv1alpha2.NginxErrorLogFormatJSON && !plus {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					loggingPath.Child("json"),
-					*logging.JSON,
+					loggingPath.Child("errorLogFormat"),
+					*logging.ErrorLogFormat,
 					"JSON-formatted error logs are only supported with NGINX Plus",
 				),
 			)

--- a/internal/controller/state/graph/nginxproxy.go
+++ b/internal/controller/state/graph/nginxproxy.go
@@ -371,7 +371,7 @@ func validateNginxProxy(
 		}
 	}
 
-	allErrs = append(allErrs, validateLogging(npCfg)...)
+	allErrs = append(allErrs, validateLogging(npCfg, plus)...)
 
 	allErrs = append(allErrs, validateDNSResolver(validator, npCfg)...)
 
@@ -386,7 +386,7 @@ func validateNginxProxy(
 	return allErrs
 }
 
-func validateLogging(npCfg *ngfAPIv1alpha2.NginxProxy) field.ErrorList {
+func validateLogging(npCfg *ngfAPIv1alpha2.NginxProxy, plus bool) field.ErrorList {
 	var allErrs field.ErrorList
 	spec := field.NewPath("spec")
 
@@ -417,6 +417,17 @@ func validateLogging(npCfg *ngfAPIv1alpha2.NginxProxy) field.ErrorList {
 						validLogLevels,
 					))
 			}
+		}
+
+		if logging.JSON != nil && *logging.JSON && !plus {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					loggingPath.Child("json"),
+					*logging.JSON,
+					"JSON-formatted error logs are only supported with NGINX Plus",
+				),
+			)
 		}
 	}
 

--- a/internal/controller/state/graph/nginxproxy_test.go
+++ b/internal/controller/state/graph/nginxproxy_test.go
@@ -1628,6 +1628,7 @@ func TestValidateLogging(t *testing.T) {
 		name           string
 		errorString    string
 		expectErrCount int
+		plus           bool
 	}{
 		{
 			np: &ngfAPIv1alpha2.NginxProxy{
@@ -1748,6 +1749,46 @@ func TestValidateLogging(t *testing.T) {
 			errorString:    "",
 			expectErrCount: 0,
 		},
+		{
+			np: &ngfAPIv1alpha2.NginxProxy{
+				Spec: ngfAPIv1alpha2.NginxProxySpec{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						JSON: helpers.GetPointer(true),
+					},
+				},
+			},
+			name:           "json true is accepted on NGINX Plus",
+			plus:           true,
+			errorString:    "",
+			expectErrCount: 0,
+		},
+		{
+			np: &ngfAPIv1alpha2.NginxProxy{
+				Spec: ngfAPIv1alpha2.NginxProxySpec{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						JSON: helpers.GetPointer(false),
+					},
+				},
+			},
+			name:           "json false is accepted on OSS",
+			plus:           false,
+			errorString:    "",
+			expectErrCount: 0,
+		},
+		{
+			np: &ngfAPIv1alpha2.NginxProxy{
+				Spec: ngfAPIv1alpha2.NginxProxySpec{
+					Logging: &ngfAPIv1alpha2.NginxLogging{
+						JSON: helpers.GetPointer(true),
+					},
+				},
+			},
+			name: "json true is rejected on OSS because JSON logs require NGINX Plus",
+			plus: false,
+			errorString: "spec.logging.json: Invalid value: true:" +
+				" JSON-formatted error logs are only supported with NGINX Plus",
+			expectErrCount: 1,
+		},
 	}
 
 	for _, test := range tests {
@@ -1755,7 +1796,7 @@ func TestValidateLogging(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			allErrs := validateLogging(test.np)
+			allErrs := validateLogging(test.np, test.plus)
 			g.Expect(allErrs).To(HaveLen(test.expectErrCount))
 			if len(allErrs) > 0 {
 				g.Expect(allErrs.ToAggregate().Error()).To(Equal(test.errorString))

--- a/internal/controller/state/graph/nginxproxy_test.go
+++ b/internal/controller/state/graph/nginxproxy_test.go
@@ -1753,11 +1753,11 @@ func TestValidateLogging(t *testing.T) {
 			np: &ngfAPIv1alpha2.NginxProxy{
 				Spec: ngfAPIv1alpha2.NginxProxySpec{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						JSON: helpers.GetPointer(true),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 					},
 				},
 			},
-			name:           "json true is accepted on NGINX Plus",
+			name:           "errorLogFormat json is accepted on NGINX Plus",
 			plus:           true,
 			errorString:    "",
 			expectErrCount: 0,
@@ -1766,11 +1766,11 @@ func TestValidateLogging(t *testing.T) {
 			np: &ngfAPIv1alpha2.NginxProxy{
 				Spec: ngfAPIv1alpha2.NginxProxySpec{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						JSON: helpers.GetPointer(false),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatDefault),
 					},
 				},
 			},
-			name:           "json false is accepted on OSS",
+			name:           "errorLogFormat default is accepted on OSS",
 			plus:           false,
 			errorString:    "",
 			expectErrCount: 0,
@@ -1779,13 +1779,13 @@ func TestValidateLogging(t *testing.T) {
 			np: &ngfAPIv1alpha2.NginxProxy{
 				Spec: ngfAPIv1alpha2.NginxProxySpec{
 					Logging: &ngfAPIv1alpha2.NginxLogging{
-						JSON: helpers.GetPointer(true),
+						ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 					},
 				},
 			},
-			name: "json true is rejected on OSS because JSON logs require NGINX Plus",
+			name: "errorLogFormat json is rejected on OSS because JSON logs require NGINX Plus",
 			plus: false,
-			errorString: "spec.logging.json: Invalid value: true:" +
+			errorString: "spec.logging.errorLogFormat: Invalid value: \"json\":" +
 				" JSON-formatted error logs are only supported with NGINX Plus",
 			expectErrCount: 1,
 		},

--- a/tests/cel/common.go
+++ b/tests/cel/common.go
@@ -72,6 +72,9 @@ const (
 
 	expectedIfModeSetTrustedAddressesError = "if mode is set, trustedAddresses is a required field"
 
+	// Logging validation error.
+	expectedJSONNotSupportedWithDebugError = "JSON-formatted error logs are not supported when errorLevel is debug"
+
 	// Replicas validation error.
 	expectedMinReplicasLessThanOrEqualError = "minReplicas must be less than or equal to maxReplicas"
 

--- a/tests/cel/nginxproxy_test.go
+++ b/tests/cel/nginxproxy_test.go
@@ -248,3 +248,68 @@ func TestNginxProxyCompression(t *testing.T) {
 		})
 	}
 }
+
+func TestNginxProxyLoggingJSON(t *testing.T) {
+	t.Parallel()
+	k8sClient := getKubernetesClient(t)
+
+	tests := []struct {
+		spec       ngfAPIv1alpha2.NginxProxySpec
+		name       string
+		wantErrors []string
+	}{
+		{
+			name: "Validate NginxProxy is invalid when json is true and errorLevel is debug",
+			spec: ngfAPIv1alpha2.NginxProxySpec{
+				Logging: &ngfAPIv1alpha2.NginxLogging{
+					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
+					JSON:       helpers.GetPointer(true),
+				},
+			},
+			wantErrors: []string{expectedJSONNotSupportedWithDebugError},
+		},
+		{
+			name: "Validate NginxProxy is valid when json is true and errorLevel is info",
+			spec: ngfAPIv1alpha2.NginxProxySpec{
+				Logging: &ngfAPIv1alpha2.NginxLogging{
+					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+					JSON:       helpers.GetPointer(true),
+				},
+			},
+		},
+		{
+			name: "Validate NginxProxy is valid when json is false and errorLevel is debug",
+			spec: ngfAPIv1alpha2.NginxProxySpec{
+				Logging: &ngfAPIv1alpha2.NginxLogging{
+					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
+					JSON:       helpers.GetPointer(false),
+				},
+			},
+		},
+		{
+			name: "Validate NginxProxy is valid when errorLevel is debug and json is unset",
+			spec: ngfAPIv1alpha2.NginxProxySpec{
+				Logging: &ngfAPIv1alpha2.NginxLogging{
+					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			spec := tt.spec
+			resourceName := uniqueResourceName(testResourceName)
+
+			nginxProxy := &ngfAPIv1alpha2.NginxProxy{
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Name:      resourceName,
+					Namespace: defaultNamespace,
+				},
+				Spec: spec,
+			}
+			validateCrd(t, tt.wantErrors, nginxProxy, k8sClient)
+		})
+	}
+}

--- a/tests/cel/nginxproxy_test.go
+++ b/tests/cel/nginxproxy_test.go
@@ -259,35 +259,35 @@ func TestNginxProxyLoggingJSON(t *testing.T) {
 		wantErrors []string
 	}{
 		{
-			name: "Validate NginxProxy is invalid when json is true and errorLevel is debug",
+			name: "Validate NginxProxy is invalid when errorLogFormat is json and errorLevel is debug",
 			spec: ngfAPIv1alpha2.NginxProxySpec{
 				Logging: &ngfAPIv1alpha2.NginxLogging{
-					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
-					JSON:       helpers.GetPointer(true),
+					ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
+					ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 				},
 			},
 			wantErrors: []string{expectedJSONNotSupportedWithDebugError},
 		},
 		{
-			name: "Validate NginxProxy is valid when json is true and errorLevel is info",
+			name: "Validate NginxProxy is valid when errorLogFormat is json and errorLevel is info",
 			spec: ngfAPIv1alpha2.NginxProxySpec{
 				Logging: &ngfAPIv1alpha2.NginxLogging{
-					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
-					JSON:       helpers.GetPointer(true),
+					ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelInfo),
+					ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatJSON),
 				},
 			},
 		},
 		{
-			name: "Validate NginxProxy is valid when json is false and errorLevel is debug",
+			name: "Validate NginxProxy is valid when errorLogFormat is default and errorLevel is debug",
 			spec: ngfAPIv1alpha2.NginxProxySpec{
 				Logging: &ngfAPIv1alpha2.NginxLogging{
-					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
-					JSON:       helpers.GetPointer(false),
+					ErrorLevel:     helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),
+					ErrorLogFormat: helpers.GetPointer(ngfAPIv1alpha2.NginxErrorLogFormatDefault),
 				},
 			},
 		},
 		{
-			name: "Validate NginxProxy is valid when errorLevel is debug and json is unset",
+			name: "Validate NginxProxy is valid when errorLevel is debug and errorLogFormat is unset",
 			spec: ngfAPIv1alpha2.NginxProxySpec{
 				Logging: &ngfAPIv1alpha2.NginxLogging{
 					ErrorLevel: helpers.GetPointer(ngfAPIv1alpha2.NginxLogLevelDebug),


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users want to be able to view their error logs in JSON Format

Solution: Allow users to specify the format for their error_log. When `error_log` format is set to json, and no user specified access log is specified, the existing access log is structures in the  JSON format. This is only available for NGINX Plus users

Testing: Manual testing

- json format not allowed in OSS
- json format not allowed when error_log is debug
- when no access format specifies and error_log is json -- both logs are out in json format

```
{"time_local":"15/May/2026:18:26:16 +0000","remote_addr":"127.0.0.1","remote_user":"","request":"GET /coffee HTTP/1.1","status":"200","body_bytes_sent":"161","http_referer":"","http_user_agent":"curl/8.7.1"}

{"level":"error","timestamp":"2026-05-15T18:27:17.716+00:00","pid":48,"tid":48,"cnum":112,"msg":"open() \"/etc/nginx/html/coffee1\" failed","client":"127.0.0.1","server":"cafe.example.com","request":"GET /coffee1 HTTP/1.1","host":"cafe.example.com:8080","errno":2,"errtext":"No such file or directory"}
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #4477 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Adds support for configuring `error_log` output in JSON format for NGINX Plus. When no custom `access_log` is defined, the default `access_log` is converted to JSON automatically. Custom `access_log` configurations are left unchanged.
```
