### PR TITLE
update default upstream keepalive value to 32

### DIFF
--- a/apis/v1alpha1/upstreamsettingspolicy_types.go
+++ b/apis/v1alpha1/upstreamsettingspolicy_types.go
@@ -87,8 +87,8 @@ type UpstreamKeepAlive struct {
 	// Connections sets the maximum number of idle keep-alive connections to upstream servers that are preserved
 	// in the cache of each nginx worker process. When this number is exceeded, the least recently used
 	// connections are closed.
-	// The keepAlive directive for upstreams defaults to 16. To override this value, set the connections field.
-	// To disable the keepAlive directive, set connections to 0.
+	// The keepAlive directive for upstreams defaults to 32. To override this value,
+	// set the connections field. To disable the keepAlive directive, set connections to 0.
 	// Directive: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
 	//
 	// +optional

--- a/config/crd/bases/gateway.nginx.org_upstreamsettingspolicies.yaml
+++ b/config/crd/bases/gateway.nginx.org_upstreamsettingspolicies.yaml
@@ -65,7 +65,7 @@ spec:
                       Connections sets the maximum number of idle keep-alive connections to upstream servers that are preserved
                       in the cache of each nginx worker process. When this number is exceeded, the least recently used
                       connections are closed.
-                      The keepAlive directive for upstreams defaults to 16. To override this value, set the connections field.
+                      The keepAlive directive for upstreams defaults to 32. To override this value, set the connections field.
                       To disable the keepAlive directive, set connections to 0.
                       Directive: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
                     format: int32

--- a/config/crd/bases/gateway.nginx.org_upstreamsettingspolicies.yaml
+++ b/config/crd/bases/gateway.nginx.org_upstreamsettingspolicies.yaml
@@ -65,8 +65,8 @@ spec:
                       Connections sets the maximum number of idle keep-alive connections to upstream servers that are preserved
                       in the cache of each nginx worker process. When this number is exceeded, the least recently used
                       connections are closed.
-                      The keepAlive directive for upstreams defaults to 32. To override this value, set the connections field.
-                      To disable the keepAlive directive, set connections to 0.
+                      The keepAlive directive for upstreams defaults to 32. To override this value,
+                      set the connections field. To disable the keepAlive directive, set connections to 0.
                       Directive: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
                     format: int32
                     minimum: 0

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -12393,7 +12393,7 @@ spec:
                       Connections sets the maximum number of idle keep-alive connections to upstream servers that are preserved
                       in the cache of each nginx worker process. When this number is exceeded, the least recently used
                       connections are closed.
-                      The keepAlive directive for upstreams defaults to 16. To override this value, set the connections field.
+                      The keepAlive directive for upstreams defaults to 32. To override this value, set the connections field.
                       To disable the keepAlive directive, set connections to 0.
                       Directive: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
                     format: int32

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -12393,8 +12393,8 @@ spec:
                       Connections sets the maximum number of idle keep-alive connections to upstream servers that are preserved
                       in the cache of each nginx worker process. When this number is exceeded, the least recently used
                       connections are closed.
-                      The keepAlive directive for upstreams defaults to 32. To override this value, set the connections field.
-                      To disable the keepAlive directive, set connections to 0.
+                      The keepAlive directive for upstreams defaults to 32. To override this value,
+                      set the connections field. To disable the keepAlive directive, set connections to 0.
                       Directive: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
                     format: int32
                     minimum: 0

--- a/internal/controller/nginx/config/http/config.go
+++ b/internal/controller/nginx/config/http/config.go
@@ -9,7 +9,7 @@ const (
 	InternalRoutePathPrefix       = "/_ngf-internal"
 	InternalMirrorRoutePathPrefix = InternalRoutePathPrefix + "-mirror"
 	HTTPSScheme                   = "https"
-	KeepAliveConnectionDefault    = int32(16)
+	KeepAliveConnectionDefault    = int32(32)
 )
 
 // Server holds all configuration for an HTTP server.

--- a/internal/controller/nginx/config/upstreams.go
+++ b/internal/controller/nginx/config/upstreams.go
@@ -230,7 +230,7 @@ func (g GeneratorImpl) createUpstream(
 }
 
 // processKeepAliveSettings normalizes keepalive configuration from an upstream policy.
-// If Connections is nil, it's set to the default value of 16.
+// If Connections is nil, it's set to the default value (which matches the NGINX default).
 // If Connections is set to 0, it indicates that keepAlive is disabled.
 func processKeepAliveSettings(spec http.UpstreamKeepAlive) http.UpstreamKeepAlive {
 	if spec.Connections == nil {

--- a/internal/controller/nginx/config/upstreams_test.go
+++ b/internal/controller/nginx/config/upstreams_test.go
@@ -149,7 +149,6 @@ func TestExecuteUpstreams_NginxOSS(t *testing.T) {
 		"keepalive 32;":          4,
 	}
 
-
 	upstreams := gen.createUpstreams(stateUpstreams, upstreamsettings.NewProcessor())
 
 	upstreamResults := executeUpstreams(upstreams)

--- a/internal/controller/nginx/config/upstreams_test.go
+++ b/internal/controller/nginx/config/upstreams_test.go
@@ -146,8 +146,9 @@ func TestExecuteUpstreams_NginxOSS(t *testing.T) {
 		"zone up6-usp-keepAlive-connections-zero 2m;": 1,
 
 		"random two least_conn;": 5,
-		"keepalive 16;":          4,
+		"keepalive 32;":          4,
 	}
+
 
 	upstreams := gen.createUpstreams(stateUpstreams, upstreamsettings.NewProcessor())
 
@@ -341,7 +342,7 @@ func TestExecuteUpstreams_NginxPlus(t *testing.T) {
 
 		"random two least_conn;": 9,
 		"ip_hash;":               1,
-		"keepalive 16;":          8,
+		"keepalive 32;":          8,
 
 		"zone up1 1m;":                                1,
 		"zone up2 1m;":                                1,


### PR DESCRIPTION
### Proposed changes

Problem: The default upstream keepalive value was hardcoded to 16, but NGINX's current default is 32. This caused a mismatch between the documented and actual behavior.

Solution: Bumped `KeepAliveConnectionDefault` from 16 to 32 in `internal/controller/nginx/config/http/config.go`. Updated the API type doc comments in `apis/v1alpha1/upstreamsettingspolicy_types.go`, the CRD YAML descriptions in `config/crd/bases/` and `deploy/crds.yaml`, and the corresponding test expectations in `upstreams_test.go` to reflect the new default.

Testing: Ran go tests, all are passing. Also verified the full go test ./... suite; the only failure is a pre-existing TestGetBuildInfo in cmd/gateway which might be unrelated to this change.

Closes #5305 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Bump default upstream keepalive to 32, aligning with NGINX defaults - may increase default idle upstream connections and memory/connection usage.
```
