### PR TITLE
Fix Agent mTLS CA cert pool not refreshing after certificate rotation

### DIFF
--- a/internal/controller/nginx/agent/grpc/grpc.go
+++ b/internal/controller/nginx/agent/grpc/grpc.go
@@ -137,9 +137,62 @@ func (g *Server) createServer(tlsCredentials credentials.TransportCredentials) *
 }
 
 func getTLSConfig() (credentials.TransportCredentials, error) {
-	caPem, err := os.ReadFile(caCertPath)
-	if err != nil {
+	return buildTLSCredentials(caCertPath, tlsCertPath, tlsKeyPath)
+}
+
+// buildTLSCredentials creates mTLS transport credentials that dynamically reload TLS files on
+// each new connection. The CA cert pool and server certificate are read from disk for every
+// incoming TLS handshake via GetConfigForClient, so that certificate rotations (e.g., from the
+// cert-generator Helm pre-upgrade job) take effect without a control plane restart.
+//
+// caPath, certPath, and keyPath are validated on startup; if any file is missing or unparseable
+// the function returns an error before the server starts accepting connections.
+func buildTLSCredentials(caPath, certPath, keyPath string) (credentials.TransportCredentials, error) {
+	// Validate that the initial TLS files exist and are parseable.
+	if _, err := loadCACertPool(caPath); err != nil {
 		return nil, err
+	}
+	if _, err := tls.LoadX509KeyPair(certPath, keyPath); err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		GetConfigForClient: buildConfigForClient(caPath, certPath, keyPath),
+		MinVersion:         tls.VersionTLS13,
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// buildConfigForClient returns a GetConfigForClient callback that builds a fresh tls.Config
+// for each incoming connection by reading the CA cert pool and server certificate from disk.
+func buildConfigForClient(caPath, certPath, keyPath string) func(*tls.ClientHelloInfo) (*tls.Config, error) {
+	return func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+		certPool, err := loadCACertPool(caPath)
+		if err != nil {
+			return nil, err
+		}
+
+		return &tls.Config{
+			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				serverCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+				if err != nil {
+					return nil, err
+				}
+				return &serverCert, nil
+			},
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  certPool,
+			MinVersion: tls.VersionTLS13,
+		}, nil
+	}
+}
+
+// loadCACertPool reads the CA certificate from the given path and returns a new CertPool.
+func loadCACertPool(caPath string) (*x509.CertPool, error) {
+	caPem, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading CA cert: %w", err)
 	}
 
 	certPool := x509.NewCertPool()
@@ -147,19 +200,7 @@ func getTLSConfig() (credentials.TransportCredentials, error) {
 		return nil, errors.New("error parsing CA PEM")
 	}
 
-	getCertificateCallback := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-		serverCert, err := tls.LoadX509KeyPair(tlsCertPath, tlsKeyPath)
-		return &serverCert, err
-	}
-
-	tlsConfig := &tls.Config{
-		GetCertificate: getCertificateCallback,
-		ClientAuth:     tls.RequireAndVerifyClientCert,
-		ClientCAs:      certPool,
-		MinVersion:     tls.VersionTLS13,
-	}
-
-	return credentials.NewTLS(tlsConfig), nil
+	return certPool, nil
 }
 
 var _ manager.Runnable = &Server{}

--- a/internal/controller/nginx/agent/grpc/grpc_test.go
+++ b/internal/controller/nginx/agent/grpc/grpc_test.go
@@ -2,7 +2,18 @@ package grpc
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // using sha1 for test SubjectKeyId only
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
@@ -46,4 +57,278 @@ func TestCreateServer(t *testing.T) {
 
 	// Verify
 	g.Expect(grpcServer).ToNot(BeNil())
+}
+
+// testCerts holds generated certificate data for testing.
+type testCerts struct {
+	caCert     *x509.Certificate
+	caKey      *rsa.PrivateKey
+	serverCert *x509.Certificate
+	caCertPEM  []byte
+	certPEM    []byte
+	keyPEM     []byte
+}
+
+// generateTestCerts generates a self-signed CA and a leaf certificate for testing.
+func generateTestCerts(t *testing.T) testCerts {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "test-ca",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		SubjectKeyId:          testSubjectKeyID(caKey),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	caCertBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
+
+	caCert, err := x509.ParseCertificate(caCertBytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+
+	// Generate leaf cert signed by the CA.
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+
+	leaf := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "test-server",
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		SubjectKeyId: testSubjectKeyID(leafKey),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		DNSNames:     []string{"localhost"},
+	}
+
+	leafCertBytes, err := x509.CreateCertificate(rand.Reader, leaf, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+
+	leafCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes})
+
+	leafKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(leafKey),
+	})
+
+	serverCert, err := x509.ParseCertificate(leafCertBytes)
+	if err != nil {
+		t.Fatalf("failed to parse leaf certificate: %v", err)
+	}
+
+	return testCerts{
+		caCertPEM:  caCertPEM,
+		certPEM:    leafCertPEM,
+		keyPEM:     leafKeyPEM,
+		caCert:     caCert,
+		caKey:      caKey,
+		serverCert: serverCert,
+	}
+}
+
+func testSubjectKeyID(key *rsa.PrivateKey) []byte {
+	h := sha1.New() //nolint:gosec // test-only
+	h.Write(key.N.Bytes())
+	return h.Sum(nil)
+}
+
+// writeCertsToDir writes PEM cert/key data to the given directory using standard filenames.
+func writeCertsToDir(t *testing.T, dir string, caCert, cert, key []byte) (caPath, certPath, keyPath string) {
+	t.Helper()
+	caPath = filepath.Join(dir, "ca.crt")
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+
+	if err := os.WriteFile(caPath, caCert, 0o600); err != nil {
+		t.Fatalf("failed to write CA cert: %v", err)
+	}
+	if err := os.WriteFile(certPath, cert, 0o600); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, key, 0o600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+
+	return caPath, certPath, keyPath
+}
+
+func TestLoadCACertPool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid CA cert", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		certs := generateTestCerts(t)
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		g.Expect(os.WriteFile(caFile, certs.caCertPEM, 0o600)).To(Succeed())
+
+		pool, err := loadCACertPool(caFile)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pool).ToNot(BeNil())
+
+		// Verify the pool can validate a cert signed by this CA.
+		_, err = certs.serverCert.Verify(x509.VerifyOptions{
+			DNSName: "localhost",
+			Roots:   pool,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		pool, err := loadCACertPool("/nonexistent/path/ca.crt")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("error reading CA cert"))
+		g.Expect(pool).To(BeNil())
+	})
+
+	t.Run("invalid PEM content", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		g.Expect(os.WriteFile(caFile, []byte("not-a-pem"), 0o600)).To(Succeed())
+
+		pool, err := loadCACertPool(caFile)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("error parsing CA PEM"))
+		g.Expect(pool).To(BeNil())
+	})
+}
+
+func TestBuildTLSCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid TLS files", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		certs := generateTestCerts(t)
+		caPath, certPath, keyPath := writeCertsToDir(t, t.TempDir(), certs.caCertPEM, certs.certPEM, certs.keyPEM)
+
+		creds, err := buildTLSCredentials(caPath, certPath, keyPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(creds).ToNot(BeNil())
+	})
+
+	t.Run("missing CA cert file", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		certs := generateTestCerts(t)
+		dir := t.TempDir()
+		certPath := filepath.Join(dir, "tls.crt")
+		keyPath := filepath.Join(dir, "tls.key")
+		g.Expect(os.WriteFile(certPath, certs.certPEM, 0o600)).To(Succeed())
+		g.Expect(os.WriteFile(keyPath, certs.keyPEM, 0o600)).To(Succeed())
+
+		creds, err := buildTLSCredentials(filepath.Join(dir, "ca.crt"), certPath, keyPath)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(creds).To(BeNil())
+	})
+
+	t.Run("missing server cert file", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		certs := generateTestCerts(t)
+		dir := t.TempDir()
+		caPath := filepath.Join(dir, "ca.crt")
+		g.Expect(os.WriteFile(caPath, certs.caCertPEM, 0o600)).To(Succeed())
+
+		creds, err := buildTLSCredentials(caPath, filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(creds).To(BeNil())
+	})
+}
+
+func TestBuildConfigForClient_DynamicReload(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+
+	// Generate initial certs and write them.
+	initialCerts := generateTestCerts(t)
+	caPath, certPath, keyPath := writeCertsToDir(t, dir, initialCerts.caCertPEM, initialCerts.certPEM, initialCerts.keyPEM)
+
+	getConfig := buildConfigForClient(caPath, certPath, keyPath)
+
+	// First call: should return config that trusts the initial CA.
+	cfg, err := getConfig(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg).ToNot(BeNil())
+	g.Expect(cfg.ClientAuth).To(Equal(tls.RequireAndVerifyClientCert))
+	g.Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+	g.Expect(cfg.ClientCAs).ToNot(BeNil())
+
+	// Verify the initial CA can validate the initial server cert.
+	_, err = initialCerts.serverCert.Verify(x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   cfg.ClientCAs,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Now rotate: generate a completely new CA and server cert.
+	rotatedCerts := generateTestCerts(t)
+	writeCertsToDir(t, dir, rotatedCerts.caCertPEM, rotatedCerts.certPEM, rotatedCerts.keyPEM)
+
+	// Second call: should return config that trusts the NEW CA.
+	cfg2, err := getConfig(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg2).ToNot(BeNil())
+
+	// The rotated CA should validate the rotated server cert.
+	_, err = rotatedCerts.serverCert.Verify(x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   cfg2.ClientCAs,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The rotated CA should NOT validate the initial server cert (different CA).
+	_, err = initialCerts.serverCert.Verify(x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   cfg2.ClientCAs,
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	// Also verify GetCertificate loads the rotated server cert.
+	g.Expect(cfg2.GetCertificate).ToNot(BeNil())
+	certFromCallback, err := cfg2.GetCertificate(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(certFromCallback).ToNot(BeNil())
+
+	parsed, err := x509.ParseCertificate(certFromCallback.Certificate[0])
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = parsed.Verify(x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   cfg2.ClientCAs,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/internal/controller/nginx/agent/grpc/grpc_test.go
+++ b/internal/controller/nginx/agent/grpc/grpc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1" //nolint:gosec // using sha1 for test SubjectKeyId only
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -43,133 +42,79 @@ func TestCreateServer(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	// Create a Server instance with a mock interceptor
 	server := &Server{
 		logger:      logr.Discard(),
 		interceptor: &mockInterceptor{},
 	}
 
-	// Mock TLS credentials - using insecure credentials for testing
-	mockTLSCredentials := insecure.NewCredentials()
-
-	// Call createServer
-	grpcServer := server.createServer(mockTLSCredentials)
-
-	// Verify
+	grpcServer := server.createServer(insecure.NewCredentials())
 	g.Expect(grpcServer).ToNot(BeNil())
 }
 
-// testCerts holds generated certificate data for testing.
+// testCerts holds PEM-encoded certificate data and the parsed leaf cert for test assertions.
 type testCerts struct {
-	caCert     *x509.Certificate
-	caKey      *rsa.PrivateKey
 	serverCert *x509.Certificate
 	caCertPEM  []byte
 	certPEM    []byte
 	keyPEM     []byte
 }
 
-// generateTestCerts generates a self-signed CA and a leaf certificate for testing.
-func generateTestCerts(t *testing.T) testCerts {
-	t.Helper()
-
+// generateTestCerts creates a self-signed CA and a leaf certificate signed by it.
+func generateTestCerts(g *WithT) testCerts {
 	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate CA key: %v", err)
-	}
+	g.Expect(err).ToNot(HaveOccurred())
 
 	ca := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName: "test-ca",
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(time.Hour),
-		SubjectKeyId:          testSubjectKeyID(caKey),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 
 	caCertBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("failed to create CA certificate: %v", err)
-	}
-
-	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
+	g.Expect(err).ToNot(HaveOccurred())
 
 	caCert, err := x509.ParseCertificate(caCertBytes)
-	if err != nil {
-		t.Fatalf("failed to parse CA certificate: %v", err)
-	}
+	g.Expect(err).ToNot(HaveOccurred())
 
-	// Generate leaf cert signed by the CA.
 	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate leaf key: %v", err)
-	}
+	g.Expect(err).ToNot(HaveOccurred())
 
 	leaf := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
-		Subject: pkix.Name{
-			CommonName: "test-server",
-		},
+		Subject:      pkix.Name{CommonName: "test-server"},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(time.Hour),
-		SubjectKeyId: testSubjectKeyID(leafKey),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		DNSNames:     []string{"localhost"},
 	}
 
 	leafCertBytes, err := x509.CreateCertificate(rand.Reader, leaf, caCert, &leafKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("failed to create leaf certificate: %v", err)
-	}
-
-	leafCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes})
-
-	leafKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(leafKey),
-	})
+	g.Expect(err).ToNot(HaveOccurred())
 
 	serverCert, err := x509.ParseCertificate(leafCertBytes)
-	if err != nil {
-		t.Fatalf("failed to parse leaf certificate: %v", err)
-	}
+	g.Expect(err).ToNot(HaveOccurred())
 
 	return testCerts{
-		caCertPEM:  caCertPEM,
-		certPEM:    leafCertPEM,
-		keyPEM:     leafKeyPEM,
-		caCert:     caCert,
-		caKey:      caKey,
+		caCertPEM:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes}),
+		certPEM:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes}),
+		keyPEM:     pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(leafKey)}),
 		serverCert: serverCert,
 	}
 }
 
-func testSubjectKeyID(key *rsa.PrivateKey) []byte {
-	h := sha1.New() //nolint:gosec // test-only
-	h.Write(key.N.Bytes())
-	return h.Sum(nil)
-}
-
 // writeCertsToDir writes PEM cert/key data to the given directory using standard filenames.
-func writeCertsToDir(t *testing.T, dir string, caCert, cert, key []byte) (caPath, certPath, keyPath string) {
-	t.Helper()
+func writeCertsToDir(g *WithT, dir string, certs testCerts) (caPath, certPath, keyPath string) {
 	caPath = filepath.Join(dir, "ca.crt")
 	certPath = filepath.Join(dir, "tls.crt")
 	keyPath = filepath.Join(dir, "tls.key")
 
-	if err := os.WriteFile(caPath, caCert, 0o600); err != nil {
-		t.Fatalf("failed to write CA cert: %v", err)
-	}
-	if err := os.WriteFile(certPath, cert, 0o600); err != nil {
-		t.Fatalf("failed to write cert: %v", err)
-	}
-	if err := os.WriteFile(keyPath, key, 0o600); err != nil {
-		t.Fatalf("failed to write key: %v", err)
-	}
+	g.Expect(os.WriteFile(caPath, certs.caCertPEM, 0o600)).To(Succeed())
+	g.Expect(os.WriteFile(certPath, certs.certPEM, 0o600)).To(Succeed())
+	g.Expect(os.WriteFile(keyPath, certs.keyPEM, 0o600)).To(Succeed())
 
 	return caPath, certPath, keyPath
 }
@@ -181,7 +126,7 @@ func TestLoadCACertPool(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		certs := generateTestCerts(t)
+		certs := generateTestCerts(g)
 		caFile := filepath.Join(t.TempDir(), "ca.crt")
 		g.Expect(os.WriteFile(caFile, certs.caCertPEM, 0o600)).To(Succeed())
 
@@ -189,11 +134,7 @@ func TestLoadCACertPool(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(pool).ToNot(BeNil())
 
-		// Verify the pool can validate a cert signed by this CA.
-		_, err = certs.serverCert.Verify(x509.VerifyOptions{
-			DNSName: "localhost",
-			Roots:   pool,
-		})
+		_, err = certs.serverCert.Verify(x509.VerifyOptions{DNSName: "localhost", Roots: pool})
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -202,8 +143,7 @@ func TestLoadCACertPool(t *testing.T) {
 		g := NewWithT(t)
 
 		pool, err := loadCACertPool("/nonexistent/path/ca.crt")
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("error reading CA cert"))
+		g.Expect(err).To(MatchError(ContainSubstring("error reading CA cert")))
 		g.Expect(pool).To(BeNil())
 	})
 
@@ -215,8 +155,7 @@ func TestLoadCACertPool(t *testing.T) {
 		g.Expect(os.WriteFile(caFile, []byte("not-a-pem"), 0o600)).To(Succeed())
 
 		pool, err := loadCACertPool(caFile)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("error parsing CA PEM"))
+		g.Expect(err).To(MatchError(ContainSubstring("error parsing CA PEM")))
 		g.Expect(pool).To(BeNil())
 	})
 }
@@ -228,8 +167,7 @@ func TestBuildTLSCredentials(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		certs := generateTestCerts(t)
-		caPath, certPath, keyPath := writeCertsToDir(t, t.TempDir(), certs.caCertPEM, certs.certPEM, certs.keyPEM)
+		caPath, certPath, keyPath := writeCertsToDir(g, t.TempDir(), generateTestCerts(g))
 
 		creds, err := buildTLSCredentials(caPath, certPath, keyPath)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -240,8 +178,8 @@ func TestBuildTLSCredentials(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		certs := generateTestCerts(t)
 		dir := t.TempDir()
+		certs := generateTestCerts(g)
 		certPath := filepath.Join(dir, "tls.crt")
 		keyPath := filepath.Join(dir, "tls.key")
 		g.Expect(os.WriteFile(certPath, certs.certPEM, 0o600)).To(Succeed())
@@ -256,8 +194,8 @@ func TestBuildTLSCredentials(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
-		certs := generateTestCerts(t)
 		dir := t.TempDir()
+		certs := generateTestCerts(g)
 		caPath := filepath.Join(dir, "ca.crt")
 		g.Expect(os.WriteFile(caPath, certs.caCertPEM, 0o600)).To(Succeed())
 
@@ -272,63 +210,37 @@ func TestBuildConfigForClient_DynamicReload(t *testing.T) {
 	g := NewWithT(t)
 
 	dir := t.TempDir()
-
-	// Generate initial certs and write them.
-	initialCerts := generateTestCerts(t)
-	caPath, certPath, keyPath := writeCertsToDir(t, dir, initialCerts.caCertPEM, initialCerts.certPEM, initialCerts.keyPEM)
+	initial := generateTestCerts(g)
+	caPath, certPath, keyPath := writeCertsToDir(g, dir, initial)
 
 	getConfig := buildConfigForClient(caPath, certPath, keyPath)
 
-	// First call: should return config that trusts the initial CA.
 	cfg, err := getConfig(nil)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg).ToNot(BeNil())
 	g.Expect(cfg.ClientAuth).To(Equal(tls.RequireAndVerifyClientCert))
 	g.Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
-	g.Expect(cfg.ClientCAs).ToNot(BeNil())
 
-	// Verify the initial CA can validate the initial server cert.
-	_, err = initialCerts.serverCert.Verify(x509.VerifyOptions{
-		DNSName: "localhost",
-		Roots:   cfg.ClientCAs,
-	})
+	_, err = initial.serverCert.Verify(x509.VerifyOptions{DNSName: "localhost", Roots: cfg.ClientCAs})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Now rotate: generate a completely new CA and server cert.
-	rotatedCerts := generateTestCerts(t)
-	writeCertsToDir(t, dir, rotatedCerts.caCertPEM, rotatedCerts.certPEM, rotatedCerts.keyPEM)
+	// Rotate to a completely new CA and leaf cert.
+	rotated := generateTestCerts(g)
+	writeCertsToDir(g, dir, rotated)
 
-	// Second call: should return config that trusts the NEW CA.
-	cfg2, err := getConfig(nil)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg2).ToNot(BeNil())
-
-	// The rotated CA should validate the rotated server cert.
-	_, err = rotatedCerts.serverCert.Verify(x509.VerifyOptions{
-		DNSName: "localhost",
-		Roots:   cfg2.ClientCAs,
-	})
+	cfgAfterRotation, err := getConfig(nil)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// The rotated CA should NOT validate the initial server cert (different CA).
-	_, err = initialCerts.serverCert.Verify(x509.VerifyOptions{
-		DNSName: "localhost",
-		Roots:   cfg2.ClientCAs,
-	})
-	g.Expect(err).To(HaveOccurred())
-
-	// Also verify GetCertificate loads the rotated server cert.
-	g.Expect(cfg2.GetCertificate).ToNot(BeNil())
-	certFromCallback, err := cfg2.GetCertificate(nil)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(certFromCallback).ToNot(BeNil())
-
-	parsed, err := x509.ParseCertificate(certFromCallback.Certificate[0])
+	_, err = rotated.serverCert.Verify(x509.VerifyOptions{DNSName: "localhost", Roots: cfgAfterRotation.ClientCAs})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = parsed.Verify(x509.VerifyOptions{
-		DNSName: "localhost",
-		Roots:   cfg2.ClientCAs,
-	})
+	_, err = initial.serverCert.Verify(x509.VerifyOptions{DNSName: "localhost", Roots: cfgAfterRotation.ClientCAs})
+	g.Expect(err).To(HaveOccurred(), "initial cert should not be trusted by rotated CA")
+
+	rotatedCert, err := cfgAfterRotation.GetCertificate(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	parsed, err := x509.ParseCertificate(rotatedCert.Certificate[0])
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = parsed.Verify(x509.VerifyOptions{DNSName: "localhost", Roots: cfgAfterRotation.ClientCAs})
 	g.Expect(err).ToNot(HaveOccurred())
 }


### PR DESCRIPTION
### Proposed changes

Problem: When the cert-generator job regenerates certificates during a helm upgrade using the flag `--set certGenerator.overwrite=true`, the control plane gRPC server's CA cert pool is loaded once at startup and never refreshed. The file watcher correctly detects the rotated TLS files and forces agents to reconnect, but on reconnect the server attempts to verify the new client certificates against the stale CA pool, causing an x509: certificate signed by unknown authority error loop that requires manual Secret deletion and pod restarts to resolve.

Solution: Replace the static ClientCAs cert pool in `tls.Config` with a `GetConfigForClient` callback, which Go's TLS stack invokes for every new incoming connection. The callback reads the CA cert and server certificate from disk on each handshake, so certificate rotations take effect automatically for all subsequent connections without a control plane restart. The initial files are still validated at server startup to catch misconfiguration early.

Testing:
Before fix:
- Deploy NGF and a Gateway
- Upgrade NGF with the flag `--set certGenerator.overwrite=true`
- Observe the following error in the dataplane logs which does not recover

```
time=2026-05-26T11:19:52.998Z level=ERROR msg="Failed to create connection" error="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: remote error: tls: unknown certificate authority\"" correlation_id=ffaae778-58f3-11f1-bb93-fa2155fe4f1c server_type=command
```
After fix:
- Upgrade NGF again with the flag `--set certGenerator.overwrite=true`
- Observe the following different error in the dataplane logs:
```
time=2026-05-26T13:17:33.907Z level=ERROR msg="Failed to create connection" error="rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \\\"crypto/rsa: verification error\\\" while trying to verify candidate authority certificate \\\"nginx-gateway\\\")\"" correlation_id=3f23eb97-5905-11f1-b112-361ea35a91de server_type=command
2026-05-26T13:17:34.061Z        warn    grpc@v1.80.0/clientconn.go:1525 [core] [Channel #4 SubChannel #5] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.45.247:443", ServerName: "nginx-gateway-nginx-gateway-fabric.nginx-gateway.svc", }. Err: connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"nginx-gateway\")"   {"resource": {"service.instance.id": "12d79db2-bafa-47b7-99c9-82ea487029a3", "service.name": "otel-nginx-agent", "service.version": "v3.10.1"}, "grpc_log": true}
```
- Observe it eventually (within ~60s or so) recovers, and the Agent can reconnect 
```
time=2026-05-26T13:17:41.439Z level=INFO msg="Connection created" response=response:{status:COMMAND_STATUS_OK} correlation_id=3f23eb97-5905-11f1-b112-361ea35a91de server_type=command
time=2026-05-26T13:17:41.439Z level=INFO msg="Agent connected" correlation_id=3f23eb97-5905-11f1-b112-361ea35a91de server_type=command
time=2026-05-26T13:17:41.439Z level=INFO msg="Finished updating command service client and re-establishing connection" correlation_id=3f23eb97-5905-11f1-b112-361ea35a91de server_type=command
```

Closes #5327 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes an issue where the NGINX Agent loses its mTLS connection to the control plane after the certificates are overwritten with a new CA and cannot reconnect.
```
