### PR TITLE
Fix stale upstream IPs caused by agent reconnection race and missing config retry

### DIFF
--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -101,7 +101,16 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 		n.logger.Info("Sent nginx configuration to agent")
 	}
 
-	deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
+	err := deployment.GetConfigurationStatus()
+	deployment.SetLatestConfigError(err)
+
+	if err != nil {
+		// Invalidate the stored config version so that the next event triggers a resend,
+		// even if the file contents have not changed. This ensures that a transient config
+		// apply failure (e.g. a brief agent reconnection during a rolling deployment) does
+		// not permanently prevent NGINX from receiving updated upstream endpoints.
+		deployment.InvalidateConfigVersion()
+	}
 }
 
 // UpdateUpstreamServers sends an APIRequest to the agent to update upstream servers using the NGINX Plus API.

--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -115,6 +115,45 @@ func TestUpdateConfig_NoChange(t *testing.T) {
 	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(0))
 }
 
+func TestUpdateConfig_RetriesAfterFailure(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	fakeBroadcaster := &broadcastfakes.FakeBroadcaster{}
+	fakeBroadcaster.SendReturns(true)
+
+	updater := NewNginxUpdater(logr.Discard(), fake.NewFakeClient(), &status.Queue{}, nil, false)
+
+	deployment := &Deployment{
+		broadcaster: fakeBroadcaster,
+		podStatuses: make(map[string]error),
+	}
+
+	file := File{
+		Meta: &pb.FileMeta{
+			Name: "test.conf",
+			Hash: "12345",
+		},
+		Contents: []byte("test content"),
+	}
+
+	// Simulate a config apply failure: set an error on the pod status before sending.
+	deployment.SetPodErrorStatus("pod1", errors.New("connection not found"))
+
+	// First call: sends the config, but there is a pod error.
+	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
+	g.Expect(deployment.GetLatestConfigError()).To(HaveOccurred())
+
+	// The config version should have been invalidated because of the error,
+	// so calling UpdateConfig again with the SAME files should still trigger
+	// a resend (this is the retry path after a transient failure).
+	deployment.SetPodErrorStatus("pod1", nil) // clear the error for the retry
+	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(2))
+	g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
+}
+
 func TestUpdateUpstreamServers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -266,6 +266,15 @@ func (d *Deployment) RemoveWAFBundle(bundlePath string) *broadcast.NginxAgentMes
 	return nil
 }
 
+// InvalidateConfigVersion clears the stored config version so that the next call to
+// SetFiles will always trigger a resend to the agent, regardless of whether the file
+// contents changed. This must be called after a failed config apply to allow automatic
+// retry on the next event.
+// The deployment FileLock MUST already be locked before calling this function.
+func (d *Deployment) InvalidateConfigVersion() {
+	d.configVersion = ""
+}
+
 // rebuildFileOverviews regenerates the file overviews and config version from the current
 // file list. Returns a broadcast message if the config version changed.
 // The deployment FileLock MUST already be locked before calling this function.

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -69,6 +69,38 @@ func TestSetAndGetFiles(t *testing.T) {
 	g.Expect(newFileOverviews).To(Equal(fileOverviews))
 }
 
+func TestInvalidateConfigVersion(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	deployment := newDeployment(&broadcastfakes.FakeBroadcaster{}, "")
+
+	files := []File{
+		{
+			Meta: &pb.FileMeta{
+				Name: "test.conf",
+				Hash: "12345",
+			},
+			Contents: []byte("test content"),
+		},
+	}
+
+	// Initial SetFiles should produce a message (new config version).
+	msg := deployment.SetFiles(files, []v1.VolumeMount{})
+	g.Expect(msg).ToNot(BeNil())
+
+	// Setting the same files again should not produce a message (dedup).
+	msg = deployment.SetFiles(files, []v1.VolumeMount{})
+	g.Expect(msg).To(BeNil())
+
+	// After invalidating the config version, the same files should
+	// produce a new message (forces retry after a failed apply).
+	deployment.InvalidateConfigVersion()
+	msg = deployment.SetFiles(files, []v1.VolumeMount{})
+	g.Expect(msg).ToNot(BeNil())
+	g.Expect(msg.Type).To(Equal(broadcast.ConfigApplyRequest))
+}
+
 func TestSetAndGetFiles_VolumeIgnoreFiles(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)

--- a/internal/controller/nginx/agent/grpc/connections.go
+++ b/internal/controller/nginx/agent/grpc/connections.go
@@ -48,9 +48,18 @@ func NewConnectionsTracker() ConnectionsTracker {
 }
 
 // Track adds a connection to the tracking map.
+// If a connection already exists for the given key and has a valid InstanceID,
+// and the new connection does not, the existing InstanceID is preserved.
+// This prevents a reconnecting agent (which may not yet have rediscovered
+// its nginx instance) from temporarily invalidating in-flight config apply
+// operations on the existing Subscribe stream.
 func (c *AgentConnectionsTracker) Track(key string, conn Connection) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	if existing, ok := c.connections[key]; ok && conn.InstanceID == "" && existing.InstanceID != "" {
+		conn.InstanceID = existing.InstanceID
+	}
 
 	c.connections[key] = conn
 }

--- a/internal/controller/nginx/agent/grpc/connections_test.go
+++ b/internal/controller/nginx/agent/grpc/connections_test.go
@@ -71,6 +71,60 @@ func TestSetInstanceID(t *testing.T) {
 	g.Expect(trackedConn.InstanceID).To(Equal("instance1"))
 }
 
+func TestTrackPreservesInstanceID(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	tracker := agentgrpc.NewConnectionsTracker()
+
+	// Track a fully-ready connection.
+	original := agentgrpc.Connection{
+		InstanceID: "instance1",
+		ParentType: "Deployment",
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
+	}
+	tracker.Track("key1", original)
+
+	// Simulate the agent reconnecting with the same UUID but before it
+	// has rediscovered its nginx instance (InstanceID is empty).
+	reconnected := agentgrpc.Connection{
+		ParentType: "Deployment",
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
+	}
+	tracker.Track("key1", reconnected)
+
+	// The existing InstanceID must be preserved so that in-flight
+	// GetFile calls from the prior Subscribe stream succeed.
+	trackedConn := tracker.GetConnection("key1")
+	g.Expect(trackedConn.Ready()).To(BeTrue())
+	g.Expect(trackedConn.InstanceID).To(Equal("instance1"))
+	g.Expect(trackedConn.ParentName).To(Equal(reconnected.ParentName))
+}
+
+func TestTrackOverwritesInstanceID(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	tracker := agentgrpc.NewConnectionsTracker()
+
+	original := agentgrpc.Connection{
+		InstanceID: "instance1",
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
+	}
+	tracker.Track("key1", original)
+
+	// When the new connection supplies a non-empty InstanceID, the
+	// value must be updated (e.g. the agent restarted on a new nginx).
+	updated := agentgrpc.Connection{
+		InstanceID: "instance2",
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
+	}
+	tracker.Track("key1", updated)
+
+	trackedConn := tracker.GetConnection("key1")
+	g.Expect(trackedConn.InstanceID).To(Equal("instance2"))
+}
+
 func TestRemoveConnection(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)


### PR DESCRIPTION
### Proposed changes

Problem: During rolling deployments, the NGINX Agent briefly reconnects with the same UUID before rediscovering its nginx instance. CreateConnection unconditionally overwrites the tracked connection, clearing InstancelD to "". Any in-flight GetFile call on the still-active Subscribe stream then fails with "connection not found", causing the agent to roll back to the old config with stale upstream IPs. This compounds because configVersion is updated before the send succeeds - so when the same endpoints are seen on the next event, no diff is detected and the config is never retried, leaving all services on the gateway serving stale IPs until another unrelated endpoint change happens.

Solution: In Track(), preserve the existing InstancelD when the incoming connection has an empty one, preventing a mid-handshake reconnect from invalidating in-flight file fetches. In UpdateConfig(), invalidate the stored configVersion on any failed apply so the next Kubernetes event unconditionally retriggers a resend, regardless of whether file contents

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5330 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix stale upstream IPs caused by agent reconnection race and missing config retry.
```
