### PR TITLE
Fix false-positive TargetConflict on policies when unrelated routes overlap each other

### DIFF
--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -624,8 +624,10 @@ func checkTargetRoutesForOverlap(
 	return conds
 }
 
-// checkForRouteOverlap checks if any route references the same namespace/gateway-name:hostname:port/path combination
-// as a route referenced in a policy.
+// checkForRouteOverlap checks if a non-targeted route references the same
+// namespace/gateway-name:hostname:port/path combination as a targeted route in the policy.
+// It only reads from the gatewayHostPortPaths map — it does not mutate it.
+// This prevents two unrelated non-targeted routes from triggering a false-positive conflict.
 func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string) *conditions.Condition {
 	currentRouteName := fmt.Sprintf("%s/%s", route.Source.GetNamespace(), route.Source.GetName())
 
@@ -648,10 +650,7 @@ func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string
 								port,
 								*match.Path.Value,
 							)
-							if val, ok := gatewayHostPortPaths[key]; !ok {
-								gatewayHostPortPaths[key] = currentRouteName
-							} else if val != currentRouteName {
-								// Only report conflict if it's a different route
+							if val, ok := gatewayHostPortPaths[key]; ok && val != currentRouteName {
 								msg := fmt.Sprintf(
 									"Policy cannot be applied to target %q since another "+
 										"Route %q shares a namespace/gateway-name:hostname:port/path combination with this target",
@@ -671,13 +670,33 @@ func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string
 	return nil
 }
 
-// buildGatewayHostPortPaths uses the same logic as checkForRouteOverlap, except it's
-// simply initializing the gatewayHostPortPaths map with the route that's referenced in the Policy,
-// so it doesn't care about the return value.
+// buildGatewayHostPortPaths builds a map of namespace/gateway-name:hostname:port/path keys
+// for a route that is targeted by the policy.
 func buildGatewayHostPortPaths(route *L7Route) map[string]string {
 	gatewayHostPortPaths := make(map[string]string)
+	routeName := fmt.Sprintf("%s/%s", route.Source.GetNamespace(), route.Source.GetName())
 
-	checkForRouteOverlap(route, gatewayHostPortPaths)
+	for _, parentRef := range route.ParentRefs {
+		if parentRef.Attachment != nil {
+			port := parentRef.Attachment.ListenerPort
+			for _, hostname := range parentRef.Attachment.AcceptedHostnames {
+				for _, rule := range route.Spec.Rules {
+					for _, match := range rule.Matches {
+						if match.Path != nil && match.Path.Value != nil {
+							key := fmt.Sprintf(
+								"%s:%s:%d%s",
+								parentRef.GatewayNsName.String(),
+								hostname,
+								port,
+								*match.Path.Value,
+							)
+							gatewayHostPortPaths[key] = routeName
+						}
+					}
+				}
+			}
+		}
+	}
 
 	return gatewayHostPortPaths
 }

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -1465,7 +1465,6 @@ func TestProcessPolicies_RouteOverlap(t *testing.T) {
 				}: createTestRouteWithPaths("hr-coffee", "/coffee"),
 				// Two non-targeted routes on a *different* gateway sharing the same path.
 				// These two routes overlap with each other, but neither overlaps with hr-coffee.
-				// Before the fix, the mutation of the shared map caused a false-positive conflict.
 				{
 					RouteType:      RouteTypeHTTP,
 					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "foreign-route-1"},

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -1448,6 +1448,35 @@ func TestProcessPolicies_RouteOverlap(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			// Regression test for: two non-targeted routes that overlap with EACH OTHER
+			// (same gateway:hostname:port/path) must not produce a false-positive TargetConflict
+			// on an unrelated policy whose target route is on a completely different gateway.
+			name:      "two non-targeted routes overlap each other but not the policy target; no conflict",
+			validator: &policiesfakes.FakeValidator{},
+			policies: map[PolicyKey]policies.Policy{
+				pol1Key: pol1,
+			},
+			routes: map[RouteKey]*L7Route{
+				// Targeted route: hr-coffee on gw (the policy target).
+				{
+					RouteType:      RouteTypeHTTP,
+					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "hr-coffee"},
+				}: createTestRouteWithPaths("hr-coffee", "/coffee"),
+				// Two non-targeted routes on a *different* gateway sharing the same path.
+				// These two routes overlap with each other, but neither overlaps with hr-coffee.
+				// Before the fix, the mutation of the shared map caused a false-positive conflict.
+				{
+					RouteType:      RouteTypeHTTP,
+					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "foreign-route-1"},
+				}: createTestRouteWithGateway("foreign-route-1", "other-gw", "/"),
+				{
+					RouteType:      RouteTypeHTTP,
+					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "foreign-route-2"},
+				}: createTestRouteWithGateway("foreign-route-2", "other-gw", "/"),
+			},
+			valid: true,
+		},
 	}
 
 	gateways := map[types.NamespacedName]*Gateway{
@@ -1455,6 +1484,15 @@ func TestProcessPolicies_RouteOverlap(t *testing.T) {
 			Source: &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gw",
+					Namespace: testNs,
+				},
+			},
+			Valid: true,
+		},
+		{Namespace: testNs, Name: "other-gw"}: {
+			Source: &v1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-gw",
 					Namespace: testNs,
 				},
 			},
@@ -1783,6 +1821,7 @@ func createTestRouteWithPaths(name string, paths ...string) *L7Route {
 		})
 	}
 
+	gwNsName := types.NamespacedName{Namespace: testNs, Name: "gw"}
 	route := &L7Route{
 		Source: &v1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1798,7 +1837,8 @@ func createTestRouteWithPaths(name string, paths ...string) *L7Route {
 		ParentRefs: []ParentRef{
 			{
 				Kind:           kinds.Gateway,
-				NamespacedName: types.NamespacedName{Namespace: testNs, Name: "gw"},
+				NamespacedName: gwNsName,
+				GatewayNsName:  gwNsName,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{"listener-1": {"foo.example.com"}},
 					ListenerPort:      80,
@@ -1808,6 +1848,43 @@ func createTestRouteWithPaths(name string, paths ...string) *L7Route {
 	}
 
 	return route
+}
+
+func createTestRouteWithGateway(name, gatewayName, path string) *L7Route {
+	routeMatches := []v1.HTTPRouteMatch{
+		{
+			Path: &v1.HTTPPathMatch{
+				Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
+				Value: helpers.GetPointer(path),
+			},
+		},
+	}
+
+	gwNsName := types.NamespacedName{Namespace: testNs, Name: gatewayName}
+	return &L7Route{
+		Source: &v1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNs,
+			},
+		},
+		Spec: L7RouteSpec{
+			Rules: []RouteRule{
+				{Matches: routeMatches},
+			},
+		},
+		ParentRefs: []ParentRef{
+			{
+				Kind:           kinds.Gateway,
+				NamespacedName: gwNsName,
+				GatewayNsName:  gwNsName,
+				Attachment: &ParentRefAttachmentStatus{
+					AcceptedHostnames: map[string][]string{"listener-1": {"bar.example.com"}},
+					ListenerPort:      80,
+				},
+			},
+		},
+	}
 }
 
 func createTestRouteWithMultipleGateways(name string, gatewayNames []string, path string) *L7Route {
@@ -1822,9 +1899,11 @@ func createTestRouteWithMultipleGateways(name string, gatewayNames []string, pat
 
 	parentRefs := make([]ParentRef, 0, len(gatewayNames))
 	for _, gwName := range gatewayNames {
+		gwNsName := types.NamespacedName{Namespace: testNs, Name: gwName}
 		parentRefs = append(parentRefs, ParentRef{
 			Kind:           kinds.Gateway,
-			NamespacedName: types.NamespacedName{Namespace: testNs, Name: gwName},
+			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 			Attachment: &ParentRefAttachmentStatus{
 				AcceptedHostnames: map[string][]string{"listener-1": {"foo.example.com"}},
 				ListenerPort:      80,

--- a/tests/suite/client_settings_test.go
+++ b/tests/suite/client_settings_test.go
@@ -348,6 +348,35 @@ var _ = Describe("ClientSettingsPolicy", Ordered, Label("functional", "cspolicy"
 			})
 		})
 	})
+
+	// Regression test: overlap-route-1 and overlap-route-2 share the same
+	// gateway:hostname:port/path ("overlap.example.com", PathPrefix "/") and
+	// therefore overlap with each other. The CSP targets the coffee route
+	// ("cafe.example.com", "/coffee"), which shares no path with either of
+	// them. The overlap between the two non-targeted routes must not produce
+	// a false-positive TargetConflict on the CSP.
+	Context("TargetConflict regression", func() {
+		When("two non-targeted routes overlap with each other but not with the policy target", func() {
+			targetConflictFiles := []string{
+				"clientsettings/target-conflict-overlapping-routes.yaml",
+				"clientsettings/target-conflict-csp.yaml",
+			}
+
+			BeforeAll(func() {
+				Expect(resourceManager.ApplyFromFiles(targetConflictFiles, namespace)).To(Succeed())
+				Expect(resourceManager.WaitForAppsToBeReady(namespace)).To(Succeed())
+			})
+
+			AfterAll(func() {
+				Expect(resourceManager.DeleteFromFiles(targetConflictFiles, namespace)).To(Succeed())
+			})
+
+			Specify("the policy is accepted without a false-positive TargetConflict", func() {
+				nsname := types.NamespacedName{Name: "target-conflict-csp", Namespace: namespace}
+				Expect(waitForCSPolicyToBeAccepted(nsname)).To(Succeed())
+			})
+		})
+	})
 })
 
 func waitForCSPolicyToBeAccepted(policyNsname types.NamespacedName) error {

--- a/tests/suite/manifests/clientsettings/target-conflict-csp.yaml
+++ b/tests/suite/manifests/clientsettings/target-conflict-csp.yaml
@@ -1,0 +1,15 @@
+# ClientSettingsPolicy targeting the coffee route (hostname "cafe.example.com", path "/coffee").
+# The coffee route does not share a gateway:hostname:port/path with overlap-route-1 or
+# overlap-route-2 ("overlap.example.com"). This policy must be Accepted even though
+# those two non-targeted routes overlap with each other.
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: target-conflict-csp
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: coffee
+  body:
+    maxSize: "5000"

--- a/tests/suite/manifests/clientsettings/target-conflict-overlapping-routes.yaml
+++ b/tests/suite/manifests/clientsettings/target-conflict-overlapping-routes.yaml
@@ -1,0 +1,45 @@
+# Two HTTPRoutes on hostname "overlap.example.com" with PathPrefix "/".
+# They share the same gateway:hostname:port/path, differentiated only by a header match,
+# so they overlap with each other. Neither route is targeted by the CSP under test
+# (which targets the coffee route on "cafe.example.com"). Before the fix, the mutual
+# overlap between these two routes would incorrectly produce a TargetConflict on the CSP.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overlap-route-1
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "overlap.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: coffee
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overlap-route-2
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "overlap.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: X-Version
+        value: v2
+    backendRefs:
+    - name: tea
+      port: 80


### PR DESCRIPTION

Problem: `checkForRouteOverlap` mutated the shared gatewayHostPortPaths map by adding entries for every non-targeted route it visited. When two non-targeted routes shared the same `gateway:hostname:port/path` key (e.g., two routes in ns-b on gateway-b with PathPrefix: /), the second route found the first's entry and reported a TargetConflict on the policy - even though the policy's target route was on a completely different gateway and hostname in ns-a.

Solution: Split `buildGatewayHostPortPaths` and `checkForRouteOverlap` into distinct responsibilities. `buildGatewayHostPortPaths` now populates the map directly from the targeted route's keys. `checkForRouteOverlap` is now read-only - it checks non-targeted routes against the map without adding entries. This prevents two unrelated non-targeted routes from triggering a false-positive conflict on each other.

Testing:
- Added a unit test reproducing the exact scenario: a policy targeting on one gateway while two non-targeted routes on a different gateway share the same hostname and path.
- Added a functional test in the ClientSettingsPolicy suite that deploys two overlapping routes and verifies the CSP on an unrelated route remains Accepted.
- All existing overlap detection tests continue to pass, including the legitimate-conflict cases.

Closes #5333 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix policies reporting a false TargetConflict when unrelated routes in other namespaces share a hostname and path with each other.
```
