### PR TITLE
Address ListenerSet Attachment gaps (#5329)

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -416,7 +416,7 @@ func gatewayHasPendingWAFBundle(gr *graph.Graph, gw *graph.Gateway) bool {
 					continue
 				}
 				for _, parentRef := range route.ParentRefs {
-					if parentRef.Kind == kinds.Gateway && parentRef.NamespacedName == gwNsName {
+					if parentRef.GatewayNsName == gwNsName {
 						return true
 					}
 				}
@@ -467,9 +467,7 @@ func collectPolicyTargetDeployments(
 				continue
 			}
 			for _, parentRef := range route.ParentRefs {
-				if parentRef.Kind == kinds.Gateway {
-					addGateway(parentRef.NamespacedName)
-				}
+				addGateway(parentRef.GatewayNsName)
 			}
 		}
 	}

--- a/internal/controller/handler_test.go
+++ b/internal/controller/handler_test.go
@@ -2103,7 +2103,7 @@ func TestCollectPolicyTargetDeployments(t *testing.T) {
 				{NamespacedName: routeNsName, RouteType: graph.RouteTypeHTTP}: {
 					Valid: true,
 					ParentRefs: []graph.ParentRef{
-						{Kind: kinds.Gateway, NamespacedName: gwNsName},
+						{Kind: kinds.Gateway, NamespacedName: gwNsName, GatewayNsName: gwNsName},
 					},
 				},
 			},
@@ -2155,7 +2155,7 @@ func TestCollectPolicyTargetDeployments(t *testing.T) {
 				{NamespacedName: routeNsName, RouteType: graph.RouteTypeHTTP}: {
 					Valid: true,
 					ParentRefs: []graph.ParentRef{
-						{Kind: kinds.Gateway, NamespacedName: gwNsName},
+						{Kind: kinds.Gateway, NamespacedName: gwNsName, GatewayNsName: gwNsName},
 					},
 				},
 			},
@@ -2295,7 +2295,7 @@ func TestGatewayHasPendingWAFBundle(t *testing.T) {
 				{NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-route"}, RouteType: graph.RouteTypeHTTP}: {
 					Valid: true,
 					ParentRefs: []graph.ParentRef{
-						{Kind: kinds.Gateway, NamespacedName: gwNsName},
+						{Kind: kinds.Gateway, NamespacedName: gwNsName, GatewayNsName: gwNsName},
 					},
 				},
 			},
@@ -2335,7 +2335,7 @@ func TestGatewayHasPendingWAFBundle(t *testing.T) {
 				}: {
 					Valid: true,
 					ParentRefs: []graph.ParentRef{
-						{Kind: kinds.Gateway, NamespacedName: gwNsName},
+						{Kind: kinds.Gateway, NamespacedName: gwNsName, GatewayNsName: gwNsName},
 					},
 				},
 			},

--- a/internal/controller/state/change_processor_test.go
+++ b/internal/controller/state/change_processor_test.go
@@ -746,6 +746,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw1),
+							GatewayNsName:  client.ObjectKeyFromObject(gw1),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -761,6 +762,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw1),
+							GatewayNsName:  client.ObjectKeyFromObject(gw1),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -812,6 +814,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw2),
+							GatewayNsName:  client.ObjectKeyFromObject(gw2),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -827,6 +830,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw2),
+							GatewayNsName:  client.ObjectKeyFromObject(gw2),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -878,6 +882,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw1),
+							GatewayNsName:  client.ObjectKeyFromObject(gw1),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -893,6 +898,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw1),
+							GatewayNsName:  client.ObjectKeyFromObject(gw1),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -944,6 +950,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw2),
+							GatewayNsName:  client.ObjectKeyFromObject(gw2),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -959,6 +966,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw2),
+							GatewayNsName:  client.ObjectKeyFromObject(gw2),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -1010,6 +1018,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw1),
+							GatewayNsName:  client.ObjectKeyFromObject(gw1),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(
@@ -1046,6 +1055,7 @@ var _ = Describe("ChangeProcessor", func() {
 						{
 							Kind:           kinds.Gateway,
 							NamespacedName: client.ObjectKeyFromObject(gw2),
+							GatewayNsName:  client.ObjectKeyFromObject(gw2),
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									graph.CreateParentRefListenerKey(

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -360,6 +360,7 @@ func createInternalRoute(
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: gatewayNsName,
+				GatewayNsName:  gatewayNsName,
 				Attachment: &graph.ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{
 						graph.CreateParentRefListenerKey(gatewayNsName, listenerName): hostnames,
@@ -798,6 +799,7 @@ func TestBuildConfiguration(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: gatewayNsName,
+				GatewayNsName:  gatewayNsName,
 				Attachment: &graph.ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{
 						graph.CreateParentRefListenerKey(gatewayNsName, "listener-443-2"): {"app.example.com"},
@@ -807,6 +809,7 @@ func TestBuildConfiguration(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: gatewayNsName,
+				GatewayNsName:  gatewayNsName,
 				Attachment: &graph.ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{
 						graph.CreateParentRefListenerKey(gatewayNsName, "listener-444-3"): {"app.example.com"},
@@ -2849,6 +2852,7 @@ func TestBuildConfiguration(t *testing.T) {
 					{
 						Kind:           kinds.ListenerSet,
 						NamespacedName: listenerSetNsName,
+						GatewayNsName:  gatewayNsName,
 						Attachment: &graph.ParentRefAttachmentStatus{
 							AcceptedHostnames: map[string][]string{
 								// Key uses ListenerSet name instead of Gateway name
@@ -2950,6 +2954,7 @@ func TestBuildConfiguration(t *testing.T) {
 						{
 							Kind:           kinds.ListenerSet,
 							NamespacedName: listenerSetNsName,
+							GatewayNsName:  gatewayNsName,
 							Attachment: &graph.ParentRefAttachmentStatus{
 								AcceptedHostnames: map[string][]string{
 									// Key uses ListenerSet name instead of Gateway name
@@ -4865,6 +4870,7 @@ func TestCreatePassthroughServers(t *testing.T) {
 										{
 											Kind:           kinds.Gateway,
 											NamespacedName: gatewayNsName,
+											GatewayNsName:  gatewayNsName,
 											Attachment: &graph.ParentRefAttachmentStatus{
 												AcceptedHostnames: map[string][]string{
 													graph.CreateParentRefListenerKey(
@@ -4999,6 +5005,7 @@ func TestCreatePassthroughServers(t *testing.T) {
 										{
 											Kind:           kinds.ListenerSet,
 											NamespacedName: listenerSetNsName,
+											GatewayNsName:  types.NamespacedName{Namespace: "test", Name: "gateway"},
 											Attachment: &graph.ParentRefAttachmentStatus{
 												AcceptedHostnames: map[string][]string{
 													// Key uses ListenerSet name instead of Gateway name

--- a/internal/controller/state/graph/backend_refs.go
+++ b/internal/controller/state/graph/backend_refs.go
@@ -465,10 +465,9 @@ func checkExternalNameValidForGateways(
 	invalidForGateways map[types.NamespacedName]conditions.Condition,
 ) map[types.NamespacedName]conditions.Condition {
 	for _, parentRef := range parentRefs {
-		if parentRef.Kind == kinds.Gateway &&
-			(parentRef.EffectiveNginxProxy == nil ||
-				parentRef.EffectiveNginxProxy.DNSResolver == nil) {
-			invalidForGateways[parentRef.NamespacedName] = conditions.NewRouteBackendRefUnsupportedValue(
+		if parentRef.EffectiveNginxProxy == nil ||
+			parentRef.EffectiveNginxProxy.DNSResolver == nil {
+			invalidForGateways[parentRef.GatewayNsName] = conditions.NewRouteBackendRefUnsupportedValue(
 				"ExternalName service requires DNS resolver configuration in Gateway's NginxProxy",
 			)
 		}

--- a/internal/controller/state/graph/backend_refs_test.go
+++ b/internal/controller/state/graph/backend_refs_test.go
@@ -591,6 +591,7 @@ func TestAddBackendRefsToRules(t *testing.T) {
 		{
 			Kind:           kinds.Gateway,
 			NamespacedName: types.NamespacedName{Namespace: "test", Name: "gateway"},
+			GatewayNsName:  types.NamespacedName{Namespace: "test", Name: "gateway"},
 			Idx:            0,
 			Attachment: &ParentRefAttachmentStatus{
 				Attached: true,
@@ -1643,16 +1644,21 @@ func TestCreateBackend(t *testing.T) {
 			},
 			parentRefKind: kinds.ListenerSet, // Special case for ListenerSet
 			expectedBackend: BackendRef{
-				SvcNsName:          types.NamespacedName{Namespace: "test", Name: "external-service"},
-				ServicePort:        v1.ServicePort{Port: 80},
-				Weight:             5,
-				Valid:              true,
-				InvalidForGateways: map[types.NamespacedName]conditions.Condition{}, // No DNS resolver validation for ListenerSet
+				SvcNsName:   types.NamespacedName{Namespace: "test", Name: "external-service"},
+				ServicePort: v1.ServicePort{Port: 80},
+				Weight:      5,
+				Valid:       true,
+				InvalidForGateways: map[types.NamespacedName]conditions.Condition{
+					{Namespace: "test", Name: "gateway"}: conditions.NewRouteBackendRefUnsupportedValue(
+						"ExternalName service requires DNS resolver configuration in Gateway's NginxProxy",
+					),
+				},
 				SessionPersistence: &expectedSPConfig,
 			},
 			expectedServicePortReference: "test_external-service_80_test-persistence-idx",
 			expectedConditions:           nil,
-			name:                         "ExternalName service with ListenerSet parentRef - DNS resolver validation skipped",
+			name: "ExternalName service with ListenerSet parentRef" +
+				" - DNS resolver validation via parent Gateway",
 		},
 	}
 
@@ -1702,18 +1708,19 @@ func TestCreateBackend(t *testing.T) {
 					{
 						Kind:                kinds.Gateway,
 						NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway"},
+						GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway"},
 						EffectiveNginxProxy: test.nginxProxySpec,
 					},
 				},
 			}
 
-			// Handle ListenerSet parentRef case by not setting Gateway settings
-			// in ParentRef, which will cause createBackendRef to skip DNS resolver validation
+			// Handle ListenerSet parentRef case
 			if test.parentRefKind == kinds.ListenerSet {
 				route.ParentRefs = []ParentRef{
 					{
 						Kind:           kinds.ListenerSet,
 						NamespacedName: types.NamespacedName{Namespace: "test", Name: "listener-set"},
+						GatewayNsName:  types.NamespacedName{Namespace: "test", Name: "gateway"},
 					},
 				}
 			}
@@ -1723,6 +1730,7 @@ func TestCreateBackend(t *testing.T) {
 				route.ParentRefs = append(route.ParentRefs, ParentRef{
 					Kind:           kinds.Gateway,
 					NamespacedName: types.NamespacedName{Namespace: "test", Name: "gateway2"},
+					GatewayNsName:  types.NamespacedName{Namespace: "test", Name: "gateway2"},
 				})
 				// For this test, the first gateway should have DNS resolver
 				route.ParentRefs[0].EffectiveNginxProxy = &EffectiveNginxProxy{
@@ -1771,6 +1779,7 @@ func TestCreateBackend(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: types.NamespacedName{Namespace: "test", Name: "gateway"},
+				GatewayNsName:  types.NamespacedName{Namespace: "test", Name: "gateway"},
 			},
 		},
 	}

--- a/internal/controller/state/graph/gateway.go
+++ b/internal/controller/state/graph/gateway.go
@@ -411,10 +411,18 @@ func (g *Gateway) GetReferencedRateLimitPolicies(
 }
 
 // isRouteAttachedToGateway checks if the given route is attached to this gateway.
+// A route is considered attached if it references the gateway directly, or if it
+// references a ListenerSet that is attached to this gateway.
 func (g *Gateway) isRouteAttachedToGateway(route *L7Route, gatewayNsName types.NamespacedName) bool {
 	for _, parentRef := range route.ParentRefs {
 		if parentRef.Kind == kinds.Gateway && parentRef.NamespacedName == gatewayNsName {
 			return true
+		}
+
+		if parentRef.Kind == kinds.ListenerSet {
+			if _, exists := g.AttachedListenerSets[parentRef.NamespacedName]; exists {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/controller/state/graph/gateway_test.go
+++ b/internal/controller/state/graph/gateway_test.go
@@ -2114,11 +2114,24 @@ func TestValidateGatewayParametersRef(t *testing.T) {
 func TestGetReferencedSnippetsFilters(t *testing.T) {
 	t.Parallel()
 
+	listenerSetNsName := types.NamespacedName{Namespace: "gateway-ns", Name: "test-listenerset"}
+
 	gw := &Gateway{
 		Source: &v1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "gateway-ns",
 				Name:      "test-gateway",
+			},
+		},
+		AttachedListenerSets: map[types.NamespacedName]*ListenerSet{
+			listenerSetNsName: {
+				Source: &v1.ListenerSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-ns",
+						Name:      "test-listenerset",
+					},
+				},
+				Valid: true,
 			},
 		},
 	}
@@ -2151,6 +2164,16 @@ func TestGetReferencedSnippetsFilters(t *testing.T) {
 			},
 		},
 		Valid: false,
+	}
+
+	sf4 := &SnippetsFilter{
+		Source: &ngfAPIv1alpha1.SnippetsFilter{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "app4",
+				Name:      "listenerset-route-filter",
+			},
+		},
+		Valid: true,
 	}
 
 	routeAttachedToGateway := &L7Route{
@@ -2255,6 +2278,41 @@ func TestGetReferencedSnippetsFilters(t *testing.T) {
 		},
 	}
 
+	// Route attached via ListenerSet (not directly to the Gateway).
+	routeAttachedViaListenerSet := &L7Route{
+		Source: &v1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "app4",
+				Name:      "listenerset-route",
+			},
+		},
+		Valid: true,
+		ParentRefs: []ParentRef{
+			{
+				Kind:           kinds.ListenerSet,
+				NamespacedName: listenerSetNsName,
+			},
+		},
+		Spec: L7RouteSpec{
+			Rules: []RouteRule{
+				{
+					Filters: RouteRuleFilters{
+						Valid: true,
+						Filters: []Filter{
+							{
+								FilterType: FilterExtensionRef,
+								ResolvedExtensionRef: &ExtensionRefFilter{
+									SnippetsFilter: sf4,
+									Valid:          true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	routes := map[RouteKey]*L7Route{
 		{
 			NamespacedName: types.NamespacedName{Namespace: "app1", Name: "attached-route"},
@@ -2268,21 +2326,30 @@ func TestGetReferencedSnippetsFilters(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "app3", Name: "route-with-invalid-filter"},
 			RouteType:      RouteTypeHTTP,
 		}: routeWithInvalidFilter,
+		{
+			NamespacedName: types.NamespacedName{Namespace: "app4", Name: "listenerset-route"},
+			RouteType:      RouteTypeHTTP,
+		}: routeAttachedViaListenerSet,
 	}
 
 	allSnippetsFilters := map[types.NamespacedName]*SnippetsFilter{
-		{Namespace: "app1", Name: "app1-logging"}:   sf1,
-		{Namespace: "app2", Name: "app2-logging"}:   sf2,
-		{Namespace: "app3", Name: "invalid-filter"}: sf3Invalid,
+		{Namespace: "app1", Name: "app1-logging"}:             sf1,
+		{Namespace: "app2", Name: "app2-logging"}:             sf2,
+		{Namespace: "app3", Name: "invalid-filter"}:           sf3Invalid,
+		{Namespace: "app4", Name: "listenerset-route-filter"}: sf4,
 	}
 
 	g := NewWithT(t)
 
 	result := gw.GetReferencedSnippetsFilters(routes, allSnippetsFilters)
 
-	// Should only include sf1 (valid filter from route attached to this gateway)
+	// Should include sf1 (valid filter from route attached directly to gateway)
+	// and sf4 (valid filter from route attached via ListenerSet).
+	// sf2 is excluded (route not attached to this gateway).
+	// sf3Invalid is excluded (invalid filter).
 	expectedResult := map[types.NamespacedName]*SnippetsFilter{
-		{Namespace: "app1", Name: "app1-logging"}: sf1,
+		{Namespace: "app1", Name: "app1-logging"}:             sf1,
+		{Namespace: "app4", Name: "listenerset-route-filter"}: sf4,
 	}
 
 	g.Expect(result).To(Equal(expectedResult))
@@ -2299,11 +2366,24 @@ func TestGetReferencedSnippetsFilters(t *testing.T) {
 func TestGetReferencedRateLimitPolicies(t *testing.T) {
 	t.Parallel()
 
+	listenerSetNsName := types.NamespacedName{Namespace: "gateway-ns", Name: "test-listenerset"}
+
 	gw := &Gateway{
 		Source: &v1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "gateway-ns",
 				Name:      "test-gateway",
+			},
+		},
+		AttachedListenerSets: map[types.NamespacedName]*ListenerSet{
+			listenerSetNsName: {
+				Source: &v1.ListenerSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-ns",
+						Name:      "test-listenerset",
+					},
+				},
+				Valid: true,
 			},
 		},
 	}
@@ -2428,6 +2508,23 @@ func TestGetReferencedRateLimitPolicies(t *testing.T) {
 		},
 	}
 
+	// Policy targeting a route that is attached via ListenerSet.
+	rlpListenerSetRoute := &Policy{
+		Source: &ngfAPIv1alpha1.RateLimitPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "app8",
+				Name:      "listenerset-route-rate-limit",
+			},
+		},
+		Valid: true,
+		TargetRefs: []PolicyTargetRef{
+			{
+				Kind:   kinds.HTTPRoute,
+				Nsname: types.NamespacedName{Namespace: "app8", Name: "listenerset-route"},
+			},
+		},
+	}
+
 	routeAttachedToGateway := &L7Route{
 		Source: &v1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2476,6 +2573,23 @@ func TestGetReferencedRateLimitPolicies(t *testing.T) {
 		},
 	}
 
+	// Route attached via ListenerSet (not directly to the Gateway).
+	routeAttachedViaListenerSet := &L7Route{
+		Source: &v1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "app8",
+				Name:      "listenerset-route",
+			},
+		},
+		Valid: true,
+		ParentRefs: []ParentRef{
+			{
+				Kind:           kinds.ListenerSet,
+				NamespacedName: listenerSetNsName,
+			},
+		},
+	}
+
 	routes := map[RouteKey]*L7Route{
 		{
 			NamespacedName: types.NamespacedName{Namespace: "app1", Name: "attached-route"},
@@ -2489,6 +2603,10 @@ func TestGetReferencedRateLimitPolicies(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "app2", Name: "not-attached-route"},
 			RouteType:      RouteTypeHTTP,
 		}: routeNotAttachedToGateway,
+		{
+			NamespacedName: types.NamespacedName{Namespace: "app8", Name: "listenerset-route"},
+			RouteType:      RouteTypeHTTP,
+		}: routeAttachedViaListenerSet,
 	}
 
 	allPolicies := map[PolicyKey]*Policy{
@@ -2533,14 +2651,19 @@ func TestGetReferencedRateLimitPolicies(t *testing.T) {
 				},
 			},
 		},
+		{
+			NsName: types.NamespacedName{Namespace: "app8", Name: "listenerset-route-rate-limit"},
+			GVK:    schema.GroupVersionKind{Kind: kinds.RateLimitPolicy},
+		}: rlpListenerSetRoute,
 	}
 
 	g := NewWithT(t)
 
 	result := gw.GetReferencedRateLimitPolicies(routes, allPolicies)
 
-	// Should only include rlp1 (valid RateLimitPolicy targeting attached route, not gateway)
-	// and rlpGRPC (valid RateLimitPolicy targeting attached GRPC route)
+	// Should include rlp1 (valid RateLimitPolicy targeting attached route, not gateway),
+	// rlpGRPC (valid RateLimitPolicy targeting attached GRPC route), and
+	// rlpListenerSetRoute (valid RateLimitPolicy targeting route attached via ListenerSet).
 	expectedResult := map[PolicyKey]*Policy{
 		{
 			NsName: types.NamespacedName{Namespace: "app1", Name: "app1-rate-limit"},
@@ -2550,6 +2673,10 @@ func TestGetReferencedRateLimitPolicies(t *testing.T) {
 			NsName: types.NamespacedName{Namespace: "app5", Name: "grpc-rate-limit"},
 			GVK:    schema.GroupVersionKind{Kind: kinds.RateLimitPolicy},
 		}: rlpGRPC,
+		{
+			NsName: types.NamespacedName{Namespace: "app8", Name: "listenerset-route-rate-limit"},
+			GVK:    schema.GroupVersionKind{Kind: kinds.RateLimitPolicy},
+		}: rlpListenerSetRoute,
 	}
 
 	g.Expect(result).To(Equal(expectedResult))

--- a/internal/controller/state/graph/graph_test.go
+++ b/internal/controller/state/graph/graph_test.go
@@ -1333,6 +1333,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				SectionName:         hr1.Spec.ParentRefs[0].SectionName,
@@ -1365,10 +1366,12 @@ func TestBuildGraph(t *testing.T) {
 		Source:     hrLS,
 		ParentRefs: []ParentRef{
 			{
-				Kind:           kinds.ListenerSet,
-				NamespacedName: types.NamespacedName{Namespace: testNs, Name: "valid-listenerset"},
-				Idx:            0,
-				SectionName:    hrLS.Spec.ParentRefs[0].SectionName,
+				Kind:                kinds.ListenerSet,
+				NamespacedName:      types.NamespacedName{Namespace: testNs, Name: "valid-listenerset"},
+				GatewayNsName:       types.NamespacedName{Namespace: testNs, Name: "gateway-1"},
+				EffectiveNginxProxy: np1Effective,
+				Idx:                 0,
+				SectionName:         hrLS.Spec.ParentRefs[0].SectionName,
 				Attachment: &ParentRefAttachmentStatus{
 					Attached: true,
 					AcceptedHostnames: map[string][]string{
@@ -1425,6 +1428,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1436,6 +1440,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1448,6 +1453,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1464,6 +1470,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1480,6 +1487,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1492,6 +1500,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1528,6 +1537,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					Attached:          false,
@@ -1540,6 +1550,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1552,6 +1563,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					Attached:          false,
@@ -1564,6 +1576,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					Attached:          false,
@@ -1575,6 +1588,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1587,6 +1601,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1623,6 +1638,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1635,6 +1651,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1647,6 +1664,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1659,6 +1677,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1670,6 +1689,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1682,6 +1702,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1720,6 +1741,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1732,6 +1754,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1744,6 +1767,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1756,6 +1780,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
 					AcceptedHostnames: map[string][]string{},
@@ -1767,6 +1792,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1779,6 +1805,7 @@ func TestBuildGraph(t *testing.T) {
 			{
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				Idx:                 0,
 				EffectiveNginxProxy: np1Effective,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1824,6 +1851,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				SectionName:         gr.Spec.ParentRefs[0].SectionName,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1856,6 +1884,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				SectionName:         hr3.Spec.ParentRefs[0].SectionName,
 				Attachment: &ParentRefAttachmentStatus{
@@ -1911,6 +1940,7 @@ func TestBuildGraph(t *testing.T) {
 				Idx:                 0,
 				Kind:                kinds.Gateway,
 				NamespacedName:      client.ObjectKeyFromObject(gw1.Source),
+				GatewayNsName:       client.ObjectKeyFromObject(gw1.Source),
 				EffectiveNginxProxy: np1Effective,
 				SectionName:         ir.Spec.ParentRefs[0].SectionName,
 				Attachment: &ParentRefAttachmentStatus{

--- a/internal/controller/state/graph/grpcroute_test.go
+++ b/internal/controller/state/graph/grpcroute_test.go
@@ -252,6 +252,7 @@ func TestBuildGRPCRoutes(t *testing.T) {
 							SectionName:         gr.Spec.ParentRefs[0].SectionName,
 							Kind:                v1.Kind(kinds.Gateway),
 							NamespacedName:      gwNsName,
+							GatewayNsName:       gwNsName,
 						},
 					},
 					Valid:      true,
@@ -1023,6 +1024,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grBoth.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1079,6 +1081,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grEmptyMatch.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1113,6 +1116,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grValidFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1158,6 +1162,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidMatchesEmptyMethodFields.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1204,6 +1209,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidMatchesInvalidMethodFields.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1254,6 +1260,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grOneInvalid.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1315,6 +1322,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidHeadersInvalidType.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1355,6 +1363,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidHeadersEmptyType.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1395,6 +1404,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidMatchesNilMethodType.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1434,6 +1444,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1481,6 +1492,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidHostname.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1506,6 +1518,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1546,6 +1559,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grUnresolvableSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1587,6 +1601,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidAndUnresolvableSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1632,6 +1647,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1672,6 +1688,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grUnresolvableAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1713,6 +1730,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidAndUnresolvableAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1757,6 +1775,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidAndValidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1801,6 +1820,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grUnresolvedAndValidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1847,6 +1867,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grTwoValidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1903,6 +1924,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grValidWithUnsupportedField.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1940,6 +1962,7 @@ func TestBuildGRPCRoute(t *testing.T) {
 						SectionName:         grInvalidWithUnsupportedField.Spec.ParentRefs[0].SectionName,
 						Kind:                v1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      false,
@@ -2161,6 +2184,7 @@ func TestBuildGRPCRouteWithMirrorRoutes(t *testing.T) {
 				SectionName:         gr.Spec.ParentRefs[0].SectionName,
 				Kind:                v1.Kind(kinds.Gateway),
 				NamespacedName:      gatewayNsName,
+				GatewayNsName:       gatewayNsName,
 			},
 		},
 		{

--- a/internal/controller/state/graph/httproute_test.go
+++ b/internal/controller/state/graph/httproute_test.go
@@ -308,6 +308,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 							SectionName:         hr.Spec.ParentRefs[0].SectionName,
 							Kind:                gatewayv1.Kind(kinds.Gateway),
 							NamespacedName:      gwNsName,
+							GatewayNsName:       gwNsName,
 						},
 					},
 					Valid:      true,
@@ -873,6 +874,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hr.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -920,6 +922,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidMatchesEmptyPathType.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -968,6 +971,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidMatchesEmptyPathValue.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1013,6 +1017,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidHostname.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1038,6 +1043,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidMatches.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1077,6 +1083,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidFilters.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1117,6 +1124,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrDroppedInvalidMatches.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1165,6 +1173,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrDroppedInvalidMatchesAndInvalidFilters.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1228,6 +1237,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrDroppedInvalidFilters.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1279,6 +1289,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrValidSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Spec: L7RouteSpec{
@@ -1325,6 +1336,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrValidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Spec: L7RouteSpec{
@@ -1369,6 +1381,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1409,6 +1422,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1449,6 +1463,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrUnresolvableSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1490,6 +1505,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrUnresolvableAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1531,6 +1547,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidAndUnresolvableSnippetsFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1578,6 +1595,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInvalidAndUnresolvableAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1624,6 +1642,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrValidAndUnresolvableAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1681,6 +1700,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrValidAndInvalidAuthenticationFilter.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1738,6 +1758,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrTwoValidAuthenticationFilters.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Conditions: []conditions.Condition{
@@ -1794,6 +1815,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrValidWithUnsupportedField.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1831,6 +1853,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInferencePool.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -1880,6 +1903,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 						SectionName:         hrInferencePoolDoesNotExist.Spec.ParentRefs[0].SectionName,
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName:      gatewayNsName,
+						GatewayNsName:       gatewayNsName,
 					},
 				},
 				Valid:      true,
@@ -2052,6 +2076,7 @@ func TestBuildHTTPRouteWithMirrorRoutes(t *testing.T) {
 				SectionName:         hr.Spec.ParentRefs[0].SectionName,
 				Kind:                gatewayv1.Kind(kinds.Gateway),
 				NamespacedName:      gatewayNsName,
+				GatewayNsName:       gatewayNsName,
 			},
 		},
 		{

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -370,18 +370,18 @@ func attachPolicyToRoute(
 	}
 
 	for _, parentRef := range route.ParentRefs {
-		if parentRef.Kind == kinds.Gateway && parentRef.EffectiveNginxProxy != nil {
+		if parentRef.EffectiveNginxProxy != nil {
 			globalSettings := &policies.GlobalSettings{
 				TelemetryEnabled: telemetryEnabledForNginxProxy(parentRef.EffectiveNginxProxy),
 				WAFEnabled:       WAFEnabledForNginxProxy(parentRef.EffectiveNginxProxy),
 			}
 
 			if conds := validator.ValidateGlobalSettings(policy.Source, globalSettings); len(conds) > 0 {
-				policy.InvalidForGateways[parentRef.NamespacedName] = struct{}{}
+				policy.InvalidForGateways[parentRef.GatewayNsName] = struct{}{}
 				ancestor.Conditions = append(ancestor.Conditions, conds...)
 			} else {
 				// Policy is effective for this gateway (not adding to InvalidForGateways)
-				effectiveGateways = append(effectiveGateways, parentRef.NamespacedName)
+				effectiveGateways = append(effectiveGateways, parentRef.GatewayNsName)
 			}
 		}
 	}
@@ -486,8 +486,9 @@ func propagateSnippetsPolicyToRoutes(
 
 	for _, route := range routes {
 		for _, parentRef := range route.ParentRefs {
-			// Check if the route is attached to this specific gateway
-			if parentRef.Kind == kinds.Gateway && parentRef.NamespacedName == gwNsName {
+			// Check if the route is attached to this specific gateway, either directly
+			// or via a ListenerSet (GatewayNsName resolves to the parent Gateway for both).
+			if parentRef.GatewayNsName == gwNsName {
 				// Avoid duplicate attachment if logic runs multiple times (though graph build is single pass)
 				// or if policy targets both.
 				alreadyAttached := slices.Contains(route.Policies, policy)
@@ -629,7 +630,7 @@ func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string
 	currentRouteName := fmt.Sprintf("%s/%s", route.Source.GetNamespace(), route.Source.GetName())
 
 	for _, parentRef := range route.ParentRefs {
-		if parentRef.Attachment != nil && parentRef.Kind == kinds.Gateway {
+		if parentRef.Attachment != nil {
 			port := parentRef.Attachment.ListenerPort
 			// FIXME(sarthyparty): https://github.com/nginx/nginx-gateway-fabric/issues/3811
 			// Need to merge listener hostnames with route hostnames so wildcards are handled correctly
@@ -638,7 +639,15 @@ func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string
 				for _, rule := range route.Spec.Rules {
 					for _, match := range rule.Matches {
 						if match.Path != nil && match.Path.Value != nil {
-							key := fmt.Sprintf("%s:%s:%d%s", parentRef.NamespacedName.String(), hostname, port, *match.Path.Value)
+							// Use GatewayNsName to ensure overlap detection works across routes
+							// attached directly to a Gateway and those attached via ListenerSet.
+							key := fmt.Sprintf(
+								"%s:%s:%d%s",
+								parentRef.GatewayNsName.String(),
+								hostname,
+								port,
+								*match.Path.Value,
+							)
 							if val, ok := gatewayHostPortPaths[key]; !ok {
 								gatewayHostPortPaths[key] = currentRouteName
 							} else if val != currentRouteName {

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -2726,6 +2726,7 @@ func TestSnippetsPolicyPropagation(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: gwNsName,
+				GatewayNsName:  gwNsName,
 			},
 		},
 	}
@@ -2741,6 +2742,7 @@ func TestSnippetsPolicyPropagation(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: otherGwNsName,
+				GatewayNsName:  otherGwNsName,
 			},
 		},
 	}
@@ -2756,10 +2758,12 @@ func TestSnippetsPolicyPropagation(t *testing.T) {
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: gwNsName,
+				GatewayNsName:  gwNsName,
 			},
 			{
 				Kind:           kinds.Gateway,
 				NamespacedName: otherGwNsName,
+				GatewayNsName:  otherGwNsName,
 			},
 		},
 	}

--- a/internal/controller/state/graph/route_common.go
+++ b/internal/controller/state/graph/route_common.go
@@ -38,10 +38,15 @@ type ParentRef struct {
 	// Port is the network port this Route targets.
 	Port *v1.PortNumber
 	// EffectiveNginxProxy is the effective NGINX Proxy configuration for this ParentRef.
-	// Will be nil if ParentRef is not of Kind Gateway.
+	// For Gateway parents, this is the Gateway's EffectiveNginxProxy.
+	// For ListenerSet parents, this is inherited from the parent Gateway's EffectiveNginxProxy.
 	EffectiveNginxProxy *EffectiveNginxProxy
 	// NamespacedName is the NamespacedName of the ParentRef
 	NamespacedName types.NamespacedName
+	// GatewayNsName is the NamespacedName of the Gateway this ParentRef is associated with.
+	// For Gateway parents, this equals NamespacedName. For ListenerSet parents, this is the
+	// NamespacedName of the ListenerSet's parent Gateway.
+	GatewayNsName types.NamespacedName
 	// Kind is the Kind of the ParentRef, it can be either Gateway or ListenerSet.
 	Kind v1.Kind
 	// Idx is the index of the corresponding ParentReference in the Route.
@@ -397,6 +402,47 @@ func buildRoutesForGateways(
 	return routes
 }
 
+// resolveParentRef finds the Gateway or ListenerSet for a parent reference and populates the ParentRef fields.
+// Returns the resolved Gateway and/or ListenerSet, or nil for both if the parent cannot be found.
+func resolveParentRef(
+	p v1.ParentReference,
+	kind string,
+	routeNamespace string,
+	gws map[types.NamespacedName]*Gateway,
+	listenerSets map[types.NamespacedName]*ListenerSet,
+	parentRef *ParentRef,
+) (*Gateway, *ListenerSet) {
+	switch kind {
+	case kinds.Gateway:
+		gw := findGatewayForParentRef(p, routeNamespace, gws)
+		if gw == nil {
+			return nil, nil
+		}
+		parentRef.EffectiveNginxProxy = gw.EffectiveNginxProxy
+		parentRef.NamespacedName = client.ObjectKeyFromObject(gw.Source)
+		parentRef.GatewayNsName = parentRef.NamespacedName
+
+		return gw, nil
+	case kinds.ListenerSet:
+		ls := findListenerSetForParentRef(p, routeNamespace, listenerSets)
+		if ls == nil {
+			return nil, nil
+		}
+		parentRef.NamespacedName = client.ObjectKeyFromObject(ls.Source)
+		if ls.Gateway != nil {
+			gwKey := client.ObjectKeyFromObject(ls.Gateway)
+			parentRef.GatewayNsName = gwKey
+			if parentGW, ok := gws[gwKey]; ok {
+				parentRef.EffectiveNginxProxy = parentGW.EffectiveNginxProxy
+			}
+		}
+
+		return nil, ls
+	}
+
+	return nil, nil
+}
+
 func buildSectionNameRefs(
 	parentRefs []v1.ParentReference,
 	routeNamespace string,
@@ -432,22 +478,9 @@ func buildSectionNameRefs(
 			Kind: v1.Kind(kind),
 		}
 
-		var gw *Gateway
-		var ls *ListenerSet
-		switch kind {
-		case kinds.Gateway:
-			gw = findGatewayForParentRef(p, routeNamespace, gws)
-			if gw == nil {
-				continue
-			}
-			parentRef.EffectiveNginxProxy = gw.EffectiveNginxProxy
-			parentRef.NamespacedName = client.ObjectKeyFromObject(gw.Source)
-		case kinds.ListenerSet:
-			ls = findListenerSetForParentRef(p, routeNamespace, listenerSets)
-			if ls == nil {
-				continue
-			}
-			parentRef.NamespacedName = client.ObjectKeyFromObject(ls.Source)
+		gw, ls := resolveParentRef(p, kind, routeNamespace, gws, listenerSets, &parentRef)
+		if gw == nil && ls == nil {
+			continue
 		}
 
 		k := key{

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -104,6 +104,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName1].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-1"},
 			SectionName:         parentRefs[0].SectionName,
 		},
 		{
@@ -111,6 +112,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName2].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-2"},
 			SectionName:         parentRefs[2].SectionName,
 		},
 		{
@@ -118,6 +120,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName1].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-1"},
 			SectionName:         parentRefs[3].SectionName,
 		},
 		{
@@ -125,6 +128,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName2].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-2"},
 			SectionName:         parentRefs[4].SectionName,
 		},
 		{
@@ -132,6 +136,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName3].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-3"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-3"},
 			SectionName:         helpers.GetPointer[gatewayv1.SectionName]("http"),
 		},
 		{
@@ -139,6 +144,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 			Kind:                kinds.Gateway,
 			EffectiveNginxProxy: gws[gwNsName3].EffectiveNginxProxy,
 			NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-3"},
+			GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-3"},
 			SectionName:         helpers.GetPointer[gatewayv1.SectionName]("https"),
 		},
 	}
@@ -275,6 +281,7 @@ func TestBuildSectionNameRefs(t *testing.T) {
 					Kind:                kinds.Gateway,
 					EffectiveNginxProxy: gws[gwNsName1].EffectiveNginxProxy,
 					NamespacedName:      types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+					GatewayNsName:       types.NamespacedName{Namespace: "test", Name: "gateway-1"},
 					SectionName:         helpers.GetPointer[gatewayv1.SectionName]("http"),
 				},
 				{

--- a/internal/controller/state/graph/tcproute_test.go
+++ b/internal/controller/state/graph/tcproute_test.go
@@ -62,6 +62,10 @@ func TestBuildTCPRoute(t *testing.T) {
 			Namespace: "test",
 			Name:      "gateway",
 		},
+		GatewayNsName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "gateway",
+		},
 	}
 
 	listenerSetParentRef := gatewayv1.ParentReference{

--- a/internal/controller/state/graph/tlsroute_test.go
+++ b/internal/controller/state/graph/tlsroute_test.go
@@ -84,6 +84,10 @@ func TestBuildTLSRoute(t *testing.T) {
 			Namespace: "test",
 			Name:      "gateway",
 		},
+		GatewayNsName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "gateway",
+		},
 	}
 
 	listenerSetParentRefGraph := ParentRef{
@@ -607,6 +611,10 @@ func TestBuildTLSRoute(t *testing.T) {
 						EffectiveNginxProxy: &EffectiveNginxProxy{IPFamily: helpers.GetPointer(ngfAPI.IPv6)},
 						Kind:                gatewayv1.Kind(kinds.Gateway),
 						NamespacedName: types.NamespacedName{
+							Namespace: "test",
+							Name:      "gateway",
+						},
+						GatewayNsName: types.NamespacedName{
 							Namespace: "test",
 							Name:      "gateway",
 						},

--- a/internal/controller/state/graph/udproute_test.go
+++ b/internal/controller/state/graph/udproute_test.go
@@ -81,6 +81,10 @@ func TestBuildUDPRoute(t *testing.T) {
 			Namespace: "test",
 			Name:      "gateway",
 		},
+		GatewayNsName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "gateway",
+		},
 	}
 
 	listenerSetParentRefGraph := ParentRef{

--- a/internal/controller/status/prepare_requests_test.go
+++ b/internal/controller/status/prepare_requests_test.go
@@ -119,6 +119,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         1,
@@ -129,6 +130,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         2,
@@ -139,6 +141,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         3,
@@ -149,6 +152,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         3,
@@ -158,6 +162,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         3,
@@ -168,6 +173,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         4,
@@ -178,6 +184,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         4,
@@ -188,6 +195,7 @@ var (
 			},
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         5,
@@ -198,6 +206,7 @@ var (
 			},
 			Kind:           kinds.ListenerSet,
 			NamespacedName: lsNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         6,
@@ -208,6 +217,7 @@ var (
 			},
 			Kind:           kinds.ListenerSet,
 			NamespacedName: lsNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         6,
@@ -218,6 +228,7 @@ var (
 			},
 			Kind:           kinds.ListenerSet,
 			NamespacedName: lsNsName,
+			GatewayNsName:  gwNsName,
 		},
 		{
 			Idx:         7,
@@ -228,6 +239,7 @@ var (
 			},
 			Kind:           kinds.ListenerSet,
 			NamespacedName: lsNsName,
+			GatewayNsName:  gwNsName,
 		},
 	}
 
@@ -238,6 +250,7 @@ var (
 			SectionName:    commonRouteSpecInvalid.ParentRefs[0].SectionName,
 			Kind:           kinds.Gateway,
 			NamespacedName: gwNsName,
+			GatewayNsName:  gwNsName,
 		},
 	}
 

--- a/tests/suite/manifests/rate-limit-policy/gateway.yaml
+++ b/tests/suite/manifests/rate-limit-policy/gateway.yaml
@@ -9,3 +9,6 @@ spec:
     port: 80
     protocol: HTTP
     hostname: "*.example.com"
+  allowedListeners:
+    namespaces:
+      from: Same

--- a/tests/suite/manifests/rate-limit-policy/listenerset-rlp.yaml
+++ b/tests/suite/manifests/rate-limit-policy/listenerset-rlp.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: RateLimitPolicy
+metadata:
+  name: ls-route-rate-limit
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ls-coffee
+  rateLimit:
+    local:
+      rules:
+      - zoneSize: 10m
+        burst: 3
+        key: "$binary_remote_addr"
+        rate: 1r/m
+    logLevel: "warn"
+    rejectCode: 466

--- a/tests/suite/manifests/rate-limit-policy/listenerset-route.yaml
+++ b/tests/suite/manifests/rate-limit-policy/listenerset-route.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ls-coffee
+spec:
+  parentRefs:
+  - name: extra-listeners
+    kind: ListenerSet
+    group: gateway.networking.k8s.io
+    sectionName: http-extra
+  hostnames:
+  - "ls.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /coffee
+    backendRefs:
+    - name: coffee
+      port: 80

--- a/tests/suite/manifests/rate-limit-policy/listenerset.yaml
+++ b/tests/suite/manifests/rate-limit-policy/listenerset.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: extra-listeners
+spec:
+  parentRef:
+    name: gateway
+  listeners:
+  - name: http-extra
+    port: 80
+    protocol: HTTP
+    hostname: "ls.example.com"

--- a/tests/suite/rate_limit_policy_test.go
+++ b/tests/suite/rate_limit_policy_test.go
@@ -459,10 +459,122 @@ var _ = Describe("RateLimitPolicy", Ordered, Label("functional", "rate-limit-pol
 			)
 		})
 	})
+
+	// Regression test: RateLimitPolicy targeting an HTTPRoute attached via a ListenerSet
+	// previously caused an NGINX crash ("zero size shared memory zone") because the
+	// limit_req_zone directive was not generated at the HTTP level, while the limit_req
+	// directive was still generated at the location level.
+	When("RateLimitPolicy is applied to an HTTPRoute attached via ListenerSet", func() {
+		lsFiles := []string{
+			"rate-limit-policy/listenerset.yaml",
+			"rate-limit-policy/listenerset-route.yaml",
+			"rate-limit-policy/listenerset-rlp.yaml",
+		}
+
+		var baseCoffeeURL string
+
+		BeforeAll(func() {
+			Expect(resourceManager.ApplyFromFiles(lsFiles, namespace)).To(Succeed())
+			Expect(resourceManager.WaitForAppsToBeReady(namespace)).To(Succeed())
+
+			port := 80
+			if portFwdPort != 0 {
+				port = portFwdPort
+			}
+			baseCoffeeURL = fmt.Sprintf("http://ls.example.com:%d%s", port, "/coffee")
+		})
+
+		AfterAll(func() {
+			Expect(resourceManager.DeleteFromFiles(lsFiles, namespace)).To(Succeed())
+		})
+
+		Specify("rateLimitPolicy is accepted", func() {
+			rlpNsName := types.NamespacedName{Name: "ls-route-rate-limit", Namespace: namespace}
+
+			err := waitForRateLimitPolicyStatus(
+				rlpNsName,
+				1,
+				metav1.ConditionTrue,
+				gatewayv1.PolicyReasonAccepted,
+			)
+			Expect(err).ToNot(HaveOccurred(), "ls-route-rate-limit was not accepted")
+		})
+
+		Context("verify working traffic", func() {
+			It("should return HTTP 200 initially and a custom error code once the rate limit is exceeded", func() {
+				Eventually(
+					func() error {
+						return verifyRateLimitPolicyWorksAsExpected(baseCoffeeURL, address, "URI: /coffee", 466)
+					}).
+					WithTimeout(timeoutConfig.RequestTimeout).
+					WithPolling(500 * time.Millisecond).
+					Should(Succeed())
+			})
+		})
+
+		Context("nginx directives", func() {
+			var conf *framework.Payload
+
+			BeforeAll(func() {
+				var err error
+				conf, err = resourceManager.GetNginxConfig(nginxPodName, namespace, "")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("are set properly for",
+				func(getCfgs func() []framework.ExpectedNginxField) {
+					for _, expCfg := range getCfgs() {
+						Expect(framework.ValidateNginxFieldExists(conf, expCfg)).To(Succeed())
+					}
+				},
+				Entry("listenerset route policy", func() []framework.ExpectedNginxField {
+					return []framework.ExpectedNginxField{
+						{
+							Directive: "include",
+							Value:     fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_internal_http.conf"),
+							File:      "http.conf",
+						},
+						{
+							File:      fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_internal_http.conf"),
+							Directive: "limit_req_zone",
+							Value: fmt.Sprintf(
+								"$binary_remote_addr zone=%s_rl_ls-route-rate-limit_rule0:10m rate=1r/m",
+								namespace,
+							),
+						},
+						{
+							Directive: "include",
+							Value:     fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_route.conf"),
+							File:      "http.conf",
+							Server:    "ls.example.com",
+							Location:  "/coffee",
+						},
+						{
+							File:      fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_route.conf"),
+							Directive: "limit_req",
+							Value:     fmt.Sprintf("zone=%s_rl_ls-route-rate-limit_rule0 burst=3", namespace),
+						},
+						{
+							File:      fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_route.conf"),
+							Directive: "limit_req_log_level",
+							Value:     "warn",
+						},
+						{
+							File:      fmt.Sprintf("%s%s", filePrefix, "_ls-route-rate-limit_route.conf"),
+							Directive: "limit_req_status",
+							Value:     "466",
+						},
+					}
+				}),
+			)
+		})
+	})
 })
 
 // waitForRateLimitPolicyStatus waits until the RateLimitPolicy has the
 // specified number of ancestors and the specified condition status and reason.
+//
+//nolint:unparam // condStatus and condReason are kept as parameters for readability at call sites
 func waitForRateLimitPolicyStatus(
 	rlpNsName types.NamespacedName,
 	ancestorCount int,
@@ -546,6 +658,7 @@ func findTargetRefForAncestor(
 	return gatewayv1.LocalPolicyTargetReference{}, false
 }
 
+//nolint:unparam // responseBodyMessage is kept as a parameter for readability at call sites
 func verifyRateLimitPolicyWorksAsExpected(appURL, address, responseBodyMessage string, expectedCode int) error {
 	err := framework.ExpectRequestToSucceed(timeoutConfig.RequestTimeout, appURL, address, responseBodyMessage)
 	if err != nil {


### PR DESCRIPTION
### Proposed changes

Problem: When a route is attached to a Gateway through a ListenerSet, several code paths fail to recognise the attachment because they only check parentRef.Kind == kinds.Gateway. This leads to an NGINX reload failure when a RateLimitPolicy targets such a route - limit_req is generated at the location level but the corresponding limit_req_zone is not generated at the http level. A similar gap also affects SnippetsPolicy propagation, route overlap detection, WAF bundle pending checks, WAF deployment targeting, ExternalName DNS validation, and telemetry/ WAF global settings validation.

Solution: Add a GatewayNsName field to ParentRef that always resolves to the underlying Gatewat regardless of parent type, and propagate EffectiveNginxProxy to ListenerSet parents by inheriting it from the parent Gateway.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed an issue where some policies, SnippetsFilters, and validation were being skipped for routes attached to a Gateway via ListenerSet.
```
