### PR TITLE
Fix ListenerSet listeners not being included in provisioned Service and container ports

### DIFF
--- a/internal/controller/provisioner/handler.go
+++ b/internal/controller/provisioner/handler.go
@@ -236,12 +236,13 @@ func (h *eventHandler) provisionResource(
 		var err error
 		resourceName := controller.CreateNginxResourceName(gatewayNSName.Name, h.gcName)
 
-		// Provision NGINX resources only when listeners are defined on the Gateway.
-		if len(resources.Gateway.Source.Spec.Listeners) > 0 {
+		// Provision NGINX resources only when listeners are defined on the Gateway (including ListenerSets).
+		if len(resources.Gateway.Listeners) > 0 {
 			objects, err = h.provisioner.buildNginxResourceObjects(
 				resourceName,
 				resources.Gateway.Source,
 				resources.Gateway.EffectiveNginxProxy,
+				resources.Gateway.Listeners,
 			)
 			if err != nil {
 				logger.Error(err, "error building some nginx resources")
@@ -291,6 +292,7 @@ func (h *eventHandler) reprovisionResources(ctx context.Context, event *events.D
 				resourceName,
 				gateway.Source,
 				gateway.EffectiveNginxProxy,
+				gateway.Listeners,
 			); err != nil {
 				return err
 			}

--- a/internal/controller/provisioner/handler_test.go
+++ b/internal/controller/provisioner/handler_test.go
@@ -125,7 +125,16 @@ func TestHandleEventBatch_Upsert(t *testing.T) {
 
 	store.registerResourceInGatewayConfig(
 		client.ObjectKeyFromObject(gateway),
-		&graph.Gateway{Source: gateway, Valid: true},
+		&graph.Gateway{
+			Source: gateway,
+			Valid:  true,
+			Listeners: []*graph.Listener{
+				{
+					Name:   "listener-80",
+					Source: gatewayv1.Listener{Port: 80},
+				},
+			},
+		},
 	)
 
 	// Test handling Deployment
@@ -254,7 +263,16 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 
 	store.registerResourceInGatewayConfig(
 		client.ObjectKeyFromObject(gateway),
-		&graph.Gateway{Source: gateway, Valid: true},
+		&graph.Gateway{
+			Source: gateway,
+			Valid:  true,
+			Listeners: []*graph.Listener{
+				{
+					Name:   "listener-80",
+					Source: gatewayv1.Listener{Port: 80},
+				},
+			},
+		},
 	)
 
 	deployment := &appsv1.Deployment{

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -88,10 +88,13 @@ type resourceNames struct {
 }
 
 // buildNginxResourceObjects builds all the NGINX resource objects for a given Gateway and EffectiveNginxProxy.
+// The allListeners parameter must include all listeners from both the Gateway and any attached ListenerSets;
+// these are used to determine which ports the Service and container should expose.
 func (p *NginxProvisioner) buildNginxResourceObjects(
 	resourceName string,
 	gateway *gatewayv1.Gateway,
 	nProxyCfg *graph.EffectiveNginxProxy,
+	allListeners []*graph.Listener,
 ) ([]client.Object, error) {
 	// NOTE: When adding new fields to the generated objects, please ensure to update the corresponding spec
 	// setter function in setter.go to set the new fields when updating the object.
@@ -149,8 +152,8 @@ func (p *NginxProvisioner) buildNginxResourceObjects(
 		}
 	}
 
-	// build ports from gateway listeners
-	ports := p.buildPortsFromListeners(gateway.Spec.Listeners)
+	// build ports from all listeners (Gateway + ListenerSets)
+	ports := p.buildPortsFromListeners(allListeners)
 
 	// Add healthcheck port to service if expose is enabled
 	var healthcheckPort int32
@@ -306,20 +309,21 @@ func (p *NginxProvisioner) buildServiceAccount(
 	return serviceAccount, nil
 }
 
-// buildPortsFromListeners builds a list of port/protocol entries from the Gateway listeners.
+// buildPortsFromListeners builds a list of port/protocol entries from the graph listeners.
+// This includes listeners from both the Gateway and any attached ListenerSets.
 // A port number can appear multiple times if it has different protocols (e.g., TCP and UDP on port 53).
-func (p *NginxProvisioner) buildPortsFromListeners(listeners []gatewayv1.Listener) []portProtoEntry {
+func (p *NginxProvisioner) buildPortsFromListeners(listeners []*graph.Listener) []portProtoEntry {
 	seen := make(map[portProtoEntry]struct{}, len(listeners))
 	ports := make([]portProtoEntry, 0, len(listeners))
 	for _, listener := range listeners {
 		var protocol corev1.Protocol
-		switch listener.Protocol {
+		switch listener.Source.Protocol {
 		case gatewayv1.UDPProtocolType:
 			protocol = corev1.ProtocolUDP
 		default:
 			protocol = corev1.ProtocolTCP
 		}
-		entry := portProtoEntry{Port: listener.Port, Protocol: protocol}
+		entry := portProtoEntry{Port: listener.Source.Port, Protocol: protocol}
 		if _, exists := seen[entry]; !exists {
 			seen[entry] = struct{}{}
 			ports = append(ports, entry)

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -27,6 +27,18 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
 )
 
+// graphListenersFromGateway converts raw Gateway spec listeners to graph Listeners for testing.
+func graphListenersFromGateway(gw *gatewayv1.Gateway) []*graph.Listener {
+	listeners := make([]*graph.Listener, 0, len(gw.Spec.Listeners))
+	for _, l := range gw.Spec.Listeners {
+		listeners = append(listeners, &graph.Listener{
+			Name:   string(l.Name),
+			Source: l,
+		})
+	}
+	return listeners
+}
+
 func findDaemonSet(objects []client.Object) *appsv1.DaemonSet {
 	for _, obj := range objects {
 		if ds, ok := obj.(*appsv1.DaemonSet); ok {
@@ -150,7 +162,9 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 					},
 				},
 			},
-		})
+		},
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(6))
@@ -277,6 +291,115 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 	g.Expect(initContainer.ImagePullPolicy).To(Equal(defaultImagePullPolicy))
 }
 
+// TestBuildNginxResourceObjects_ListenerSetPorts verifies that listeners from ListenerSets
+// are included in the Service and container ports. This is a regression test for a bug where
+// a ListenerSet adding an HTTPS listener on port 443 would not create a LB rule for that port.
+func TestBuildNginxResourceObjects_ListenerSetPorts(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	agentTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentTLSTestSecretName,
+			Namespace: ngfNamespace,
+		},
+		Data: map[string][]byte{secrets.TLSCertKey: []byte("tls")},
+	}
+	fakeClient := createFakeClientWithScheme(agentTLSSecret)
+
+	provisioner := &NginxProvisioner{
+		cfg: Config{
+			GatewayPodConfig: &config.GatewayPodConfig{
+				Namespace: ngfNamespace,
+				Version:   "1.0.0",
+				Image:     "ngf-image",
+			},
+			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
+		},
+		baseLabelSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		k8sClient: fakeClient,
+	}
+
+	// Gateway only defines port 80
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+
+	// The graph has merged listeners from both the Gateway (port 80) and a ListenerSet (port 443)
+	hostname := gatewayv1.Hostname("example.org")
+	allListeners := []*graph.Listener{
+		{
+			Name:   "http",
+			Source: gatewayv1.Listener{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+		},
+		{
+			Name:   "https",
+			Source: gatewayv1.Listener{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, Hostname: &hostname},
+		},
+	}
+
+	resourceName := "gw-nginx"
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		&graph.EffectiveNginxProxy{},
+		allListeners,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Find the Service and verify it has both port 80 and port 443
+	var svc *corev1.Service
+	for _, obj := range objects {
+		if s, ok := obj.(*corev1.Service); ok {
+			svc = s
+			break
+		}
+	}
+	g.Expect(svc).ToNot(BeNil(), "Service should be created")
+
+	var hasPort80, hasPort443 bool
+	for _, port := range svc.Spec.Ports {
+		if port.Port == 80 {
+			hasPort80 = true
+		}
+		if port.Port == 443 {
+			hasPort443 = true
+		}
+	}
+	g.Expect(hasPort80).To(BeTrue(), "Service should have port 80 from Gateway listener")
+	g.Expect(hasPort443).To(BeTrue(), "Service should have port 443 from ListenerSet listener")
+
+	// Find the Deployment and verify container ports include 443
+	dep := findDeployment(objects)
+	g.Expect(dep).ToNot(BeNil(), "Deployment should be created")
+
+	var containerHasPort443 bool
+	for _, port := range dep.Spec.Template.Spec.Containers[0].Ports {
+		if port.ContainerPort == 443 {
+			containerHasPort443 = true
+			break
+		}
+	}
+	g.Expect(containerHasPort443).To(BeTrue(), "Container should have port 443 from ListenerSet listener")
+}
+
 func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
@@ -369,7 +492,12 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 		},
 	}
 
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, nProxyCfg)
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(7))
@@ -541,7 +669,12 @@ func TestBuildNginxResourceObjects_ExposeHealthcheck(t *testing.T) {
 				k8sClient: fakeClient,
 			}
 
-			objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, test.nProxyCfg)
+			objects, err := provisioner.buildNginxResourceObjects(
+				resourceName,
+				gateway,
+				test.nProxyCfg,
+				graphListenersFromGateway(gateway),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Find the service object
@@ -710,7 +843,12 @@ func TestBuildNginxResourceObjects_DeploymentReplicasFromHPA(t *testing.T) {
 				},
 			}
 
-			objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, nProxyCfg)
+			objects, err := provisioner.buildNginxResourceObjects(
+				resourceName,
+				gateway,
+				nProxyCfg,
+				graphListenersFromGateway(gateway),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Find the deployment object
@@ -806,7 +944,12 @@ func TestBuildNginxResourceObjects_Plus(t *testing.T) {
 	}
 
 	resourceName := "gw-nginx"
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, &graph.EffectiveNginxProxy{})
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		&graph.EffectiveNginxProxy{},
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(9))
@@ -956,7 +1099,12 @@ func TestBuildNginxResourceObjects_DockerSecrets(t *testing.T) {
 	}
 
 	resourceName := "gw-nginx"
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, &graph.EffectiveNginxProxy{})
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		&graph.EffectiveNginxProxy{},
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(9))
@@ -1085,7 +1233,12 @@ func TestBuildNginxResourceObjects_DaemonSet(t *testing.T) {
 	}
 
 	resourceName := "gw-nginx"
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, nProxyCfg)
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// 2 secrets (agentTLS, JWT) + 2 configmaps (includes, agent) + serviceaccount + service + daemonset
@@ -1166,7 +1319,12 @@ func TestBuildNginxResourceObjects_OpenShift(t *testing.T) {
 	}
 
 	resourceName := "gw-nginx"
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, &graph.EffectiveNginxProxy{})
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		&graph.EffectiveNginxProxy{},
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(8))
@@ -1243,7 +1401,12 @@ func TestBuildNginxResourceObjects_DataplaneKeySecret(t *testing.T) {
 	}
 
 	resourceName := "gw-nginx"
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, &graph.EffectiveNginxProxy{})
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		&graph.EffectiveNginxProxy{},
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(7)) // 2 secrets, 2 configmaps, serviceaccount, service, deployment
 
@@ -1940,7 +2103,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err := provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err := provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(6))
 
@@ -1985,7 +2153,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(6))
 
@@ -2016,7 +2189,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(6))
 
@@ -2057,7 +2235,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("failed to apply service patches"))
 	g.Expect(err.Error()).To(ContainSubstring("failed to apply deployment patches"))
@@ -2079,7 +2262,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("unsupported patch type"))
 	g.Expect(objects).To(HaveLen(6))
@@ -2104,7 +2292,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(6))
 
@@ -2144,7 +2337,12 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 		},
 	}
 
-	objects, err = provisioner.buildNginxResourceObjects("gw-nginx", gateway, nProxyCfg)
+	objects, err = provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).To(HaveLen(6))
 
@@ -2224,7 +2422,12 @@ func TestBuildNginxResourceObjects_InferenceExtension(t *testing.T) {
 			},
 		},
 	}
-	objects, err := provisioner.buildNginxResourceObjects("gw-nginx", gateway, npCfg)
+	objects, err := provisioner.buildNginxResourceObjects(
+		"gw-nginx",
+		gateway,
+		npCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Find the deployment object
@@ -2349,7 +2552,12 @@ func TestOwnerReferencesAreSet(t *testing.T) {
 	resourceName := controller.CreateNginxResourceName(gateway.Name, "nginx")
 
 	// Build resources
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, nil)
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		nil,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(objects).ToNot(BeEmpty())
 
@@ -2447,7 +2655,12 @@ func TestBuildNginxResourceObjects_ClusterIPWithExternalIPs(t *testing.T) {
 				},
 			}
 
-			objects, err := provisioner.buildNginxResourceObjects("gw-nginx", gateway, test.nProxyCfg)
+			objects, err := provisioner.buildNginxResourceObjects(
+				"gw-nginx",
+				gateway,
+				test.nProxyCfg,
+				graphListenersFromGateway(gateway),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			var svc *corev1.Service
@@ -2554,7 +2767,12 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 		},
 	}
 
-	objects, err := provisioner.buildNginxResourceObjects(resourceName, gateway, nProxyCfg)
+	objects, err := provisioner.buildNginxResourceObjects(
+		resourceName,
+		gateway,
+		nProxyCfg,
+		graphListenersFromGateway(gateway),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// 2 secrets (agentTLS, JWT) + 2 configmaps (includes, agent) + serviceaccount + service + deployment

--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -440,14 +440,15 @@ func (p *NginxProvisioner) reprovisionNginx(
 	resourceName string,
 	gateway *gatewayv1.Gateway,
 	nProxyCfg *graph.EffectiveNginxProxy,
+	allListeners []*graph.Listener,
 ) error {
 	if !p.isLeader() {
 		return nil
 	}
-	if len(gateway.Spec.Listeners) == 0 {
+	if len(allListeners) == 0 {
 		return nil
 	}
-	objects, err := p.buildNginxResourceObjects(resourceName, gateway, nProxyCfg)
+	objects, err := p.buildNginxResourceObjects(resourceName, gateway, nProxyCfg, allListeners)
 	if err != nil {
 		p.cfg.Logger.Error(err, "error provisioning some nginx resources")
 	}
@@ -594,7 +595,12 @@ func (p *NginxProvisioner) RegisterGateway(
 	}
 
 	if gateway.Valid && len(gateway.Listeners) > 0 {
-		objects, err := p.buildNginxResourceObjects(resourceName, gateway.Source, gateway.EffectiveNginxProxy)
+		objects, err := p.buildNginxResourceObjects(
+			resourceName,
+			gateway.Source,
+			gateway.EffectiveNginxProxy,
+			gateway.Listeners,
+		)
 		if err != nil {
 			p.cfg.Logger.Error(err, "error building some nginx resources")
 		}

--- a/internal/controller/provisioner/provisioner_test.go
+++ b/internal/controller/provisioner/provisioner_test.go
@@ -638,7 +638,7 @@ func TestNonLeaderProvisioner(t *testing.T) {
 	g.Expect(provisioner.provisionNginx(t.Context(), "gw-nginx", nil, nil)).To(Succeed())
 	expectResourcesToNotExist(t, g, fakeClient, nsName)
 
-	g.Expect(provisioner.reprovisionNginx(t.Context(), "gw-nginx", nil, nil)).To(Succeed())
+	g.Expect(provisioner.reprovisionNginx(t.Context(), "gw-nginx", nil, nil, nil)).To(Succeed())
 	expectResourcesToNotExist(t, g, fakeClient, nsName)
 
 	g.Expect(provisioner.deprovisionNginxForInvalidGateway(t.Context(), nsName)).To(Succeed())

--- a/internal/controller/provisioner/store.go
+++ b/internal/controller/provisioner/store.go
@@ -308,7 +308,10 @@ func gatewayChanged(original, updated *graph.Gateway) bool {
 	return listenersChanged(original.Listeners, updated.Listeners)
 }
 
-// listenersChanged returns true if the set of listener ports/protocols has changed.
+// listenersChanged returns true if the set of listener names, ports, protocols, or hostnames
+// has changed. Order is intentionally ignored: the provisioner only cares about which ports
+// need to be exposed, not their order. Listener conflict resolution is handled upstream in
+// the graph builder and does not affect provisioned resources.
 func listenersChanged(original, updated []*graph.Listener) bool {
 	if len(original) != len(updated) {
 		return true

--- a/internal/controller/provisioner/store.go
+++ b/internal/controller/provisioner/store.go
@@ -299,7 +299,47 @@ func gatewayChanged(original, updated *graph.Gateway) bool {
 		return true
 	}
 
-	return !reflect.DeepEqual(original.EffectiveNginxProxy, updated.EffectiveNginxProxy)
+	if !reflect.DeepEqual(original.EffectiveNginxProxy, updated.EffectiveNginxProxy) {
+		return true
+	}
+
+	// Check if the effective set of listeners changed (e.g., due to ListenerSet additions/removals).
+	// We compare port/protocol pairs since those determine the Service and container ports.
+	return listenersChanged(original.Listeners, updated.Listeners)
+}
+
+// listenersChanged returns true if the set of listener ports/protocols has changed.
+func listenersChanged(original, updated []*graph.Listener) bool {
+	if len(original) != len(updated) {
+		return true
+	}
+
+	type listenerKey struct {
+		Name     string
+		Protocol gatewayv1.ProtocolType
+		Hostname string
+		Port     gatewayv1.PortNumber
+	}
+
+	buildSet := func(listeners []*graph.Listener) map[listenerKey]struct{} {
+		set := make(map[listenerKey]struct{}, len(listeners))
+		for _, l := range listeners {
+			hostname := ""
+			if l.Source.Hostname != nil {
+				hostname = string(*l.Source.Hostname)
+			}
+			key := listenerKey{
+				Name:     l.Name,
+				Port:     l.Source.Port,
+				Protocol: l.Source.Protocol,
+				Hostname: hostname,
+			}
+			set[key] = struct{}{}
+		}
+		return set
+	}
+
+	return !reflect.DeepEqual(buildSet(original), buildSet(updated))
 }
 
 func (s *store) getNginxResourcesForGateway(nsName types.NamespacedName) *NginxResources {

--- a/internal/controller/provisioner/store_test.go
+++ b/internal/controller/provisioner/store_test.go
@@ -449,6 +449,82 @@ func TestGatewayChanged(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "listener added via ListenerSet",
+			original: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+				},
+			},
+			updated: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+					{
+						Name:   "https",
+						Source: gatewayv1.Listener{Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			},
+			changed: true,
+		},
+		{
+			name: "listener removed from ListenerSet",
+			original: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+					{
+						Name:   "https",
+						Source: gatewayv1.Listener{Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			},
+			updated: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+				},
+			},
+			changed: true,
+		},
+		{
+			name: "same listeners including ListenerSet - no changes",
+			original: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+					{
+						Name:   "https",
+						Source: gatewayv1.Listener{Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			},
+			updated: &graph.Gateway{
+				Listeners: []*graph.Listener{
+					{
+						Name:   "http",
+						Source: gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+					{
+						Name:   "https",
+						Source: gatewayv1.Listener{Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			},
+			changed: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: When a ListenerSet adds a listener (e.g., HTTPS on port 443) to a Gateway, the provisioner only reads `gatewaySpec.Listeners` (the raw Gateway object) when building the NGINX Service and container ports. ListenerSet listeners, which are merged into `graph.Gateway.Listeners` are completely ignored. This means no LB rule or container port is created for ListenerSet-sourced listeners. Additionally, `gatewayChanged` doesn't detect ListenerSet additions since it only compares the raw Gateway source, so even if the port-building were fixed, the provisioner would skip the update.

Solution:
- Changed `buildPortsFromListeners` to accept the merged set including ListenerSet listeners
- Updated `gatewayChanged` to compare listener name/port/protocol/hostname sets so that ListenerSet additions and removals trigger a provisioner update.
- Fixed "has listeners" guards to check `graph. Gateway Listeners` instead of the raw spec.

Testing: Unit tests, local testing

Closes #5346 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix ListenerSet listener ports not being exposed on the provisioned NGINX Service and container.
```
