### PR TITLE
Add WAF-enabled deployment to longevity nfr test

### DIFF
--- a/.github/workflows/longevity-start.yml
+++ b/.github/workflows/longevity-start.yml
@@ -25,6 +25,11 @@ on:
         description: GKE cluster region
         required: true
         default: us-west1
+      waf_enabled:
+        description: Enable WAF+PLM longevity scenario (requires NGINX Plus + WAF images, amd64)
+        required: false
+        default: false
+        type: boolean
 
 env:
   PLUS_USAGE_ENDPOINT: ${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}
@@ -108,12 +113,20 @@ jobs:
           echo "NGF_VERSION=${{ needs.vars.outputs.version }}" >> vars.env
           echo "GKE_MACHINE_TYPE=n2d-standard-16" >> vars.env
           echo "PLUS_USAGE_ENDPOINT=${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}" >> vars.env
+          echo "WAF_ENABLED=${{ inputs.waf_enabled && matrix.type == 'plus' || false }}" >> vars.env
+          echo "REGISTRY_JWT_FILE=~/nginx-gateway-fabric/dockerconfig.jwt" >> vars.env
 
       - name: Setup license file for plus
         if: matrix.type == 'plus'
         env:
           PLUS_LICENSE: ${{ secrets.JWT_PLUS_REPORTING }}
         run: echo "${PLUS_LICENSE}" > license.jwt
+
+      - name: Setup registry JWT for WAF images
+        if: ${{ inputs.waf_enabled == true && matrix.type == 'plus' }}
+        env:
+          IMAGE_PULL_SECRET: ${{ secrets.JWT_PLUS_REGISTRY }}
+        run: echo "${IMAGE_PULL_SECRET}" > dockerconfig.jwt
 
       - name: Create GKE cluster
         working-directory: ./tests

--- a/.github/workflows/longevity-start.yml
+++ b/.github/workflows/longevity-start.yml
@@ -25,7 +25,7 @@ on:
         description: GKE cluster region
         required: true
         default: us-west1
-      waf_enabled:
+      waf_plm_enabled:
         description: Enable WAF+PLM longevity scenario (requires NGINX Plus + WAF images, amd64)
         required: false
         default: false
@@ -113,7 +113,7 @@ jobs:
           echo "NGF_VERSION=${{ needs.vars.outputs.version }}" >> vars.env
           echo "GKE_MACHINE_TYPE=n2d-standard-16" >> vars.env
           echo "PLUS_USAGE_ENDPOINT=${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}" >> vars.env
-          echo "WAF_ENABLED=${{ inputs.waf_enabled && matrix.type == 'plus' || false }}" >> vars.env
+          echo "WAF_PLM_ENABLED=${{ inputs.waf_plm_enabled && matrix.type == 'plus' || false }}" >> vars.env
           echo "REGISTRY_JWT_FILE=~/nginx-gateway-fabric/dockerconfig.jwt" >> vars.env
 
       - name: Setup license file for plus
@@ -123,7 +123,7 @@ jobs:
         run: echo "${PLUS_LICENSE}" > license.jwt
 
       - name: Setup registry JWT for WAF images
-        if: ${{ inputs.waf_enabled == true && matrix.type == 'plus' }}
+        if: ${{ inputs.waf_plm_enabled == true && matrix.type == 'plus' }}
         env:
           IMAGE_PULL_SECRET: ${{ secrets.JWT_PLUS_REGISTRY }}
         run: echo "${IMAGE_PULL_SECRET}" > dockerconfig.jwt

--- a/.github/workflows/longevity-stop.yml
+++ b/.github/workflows/longevity-stop.yml
@@ -34,7 +34,7 @@ on:
         required: true
         default: us-west1
       waf_plm_enabled:
-        description: Was the WAF+PLM longevity scenario enabled when the test was started?
+        description: Indicates whether the WAF+PLM longevity scenario was enabled when the test run was initiated.
         required: false
         default: false
         type: boolean

--- a/.github/workflows/longevity-stop.yml
+++ b/.github/workflows/longevity-stop.yml
@@ -33,6 +33,11 @@ on:
         description: GKE cluster region
         required: true
         default: us-west1
+      waf_enabled:
+        description: Was the WAF+PLM longevity scenario enabled when the test was started?
+        required: false
+        default: false
+        type: boolean
 
 env:
   PLUS_USAGE_ENDPOINT: ${{ secrets.JWT_PLUS_REPORTING_ENDPOINT }}
@@ -111,6 +116,7 @@ jobs:
           echo "ADD_VM_IP_AUTH_NETWORKS=true" >> vars.env
           echo "PLUS_ENABLED=${{ matrix.type == 'plus' }}" >> vars.env
           echo "NGF_VERSION=${{ needs.vars.outputs.version }}" >> vars.env
+          echo "WAF_ENABLED=${{ inputs.waf_enabled || false }}" >> vars.env
 
       - name: Update firewall
         working-directory: ./tests

--- a/.github/workflows/longevity-stop.yml
+++ b/.github/workflows/longevity-stop.yml
@@ -33,7 +33,7 @@ on:
         description: GKE cluster region
         required: true
         default: us-west1
-      waf_enabled:
+      waf_plm_enabled:
         description: Was the WAF+PLM longevity scenario enabled when the test was started?
         required: false
         default: false
@@ -116,7 +116,7 @@ jobs:
           echo "ADD_VM_IP_AUTH_NETWORKS=true" >> vars.env
           echo "PLUS_ENABLED=${{ matrix.type == 'plus' }}" >> vars.env
           echo "NGF_VERSION=${{ needs.vars.outputs.version }}" >> vars.env
-          echo "WAF_ENABLED=${{ inputs.waf_enabled || false }}" >> vars.env
+          echo "WAF_PLM_ENABLED=${{ inputs.waf_plm_enabled || false }}" >> vars.env
 
       - name: Update firewall
         working-directory: ./tests

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -34,6 +34,7 @@ rules:
       tests/suite/manifests/proxy-settings-policy/app.yaml
       tests/suite/manifests/longevity
       tests/suite/manifests/authentication-filter/keycloak.yaml
+      tests/suite/manifests/longevity-waf
   key-duplicates: enable
   key-ordering: disable
   line-length:
@@ -43,6 +44,7 @@ rules:
     ignore: |
       .github/
       tests/suite/manifests/longevity/cronjob.yaml
+      tests/suite/manifests/longevity-waf/cronjob.yaml
       .goreleaser.yml
       charts/nginx-gateway-fabric/
       operators/config/crd/bases/gateway.nginx.org_nginxgatewayfabrics.yaml

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -191,7 +191,7 @@ ipv6-tests: ## Example usage: make ipv6-tests TAG=release-X.Y-rc
 		--pull-policy=$(PULL_POLICY) --service-type=$(GW_SERVICE_TYPE) \
 		--plus-enabled=$(PLUS_ENABLED) --plus-license-file-name=$(PLUS_LICENSE_FILE) \
 		--plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) --gke-project=$(GKE_PROJECT) \
-		--waf-enabled=$(WAF_ENABLED) --nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE)
+        --waf-enabled=$(WAF_ENABLED) $(if $(filter true,$(WAF_ENABLED)),--nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE))
 
 .PHONY: test
 test: build-crossplane-image ## Runs the functional tests on your kind k8s cluster

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -173,6 +173,8 @@ start-longevity-test: nfr-test ## Start the longevity test to run for 3 days in 
 stop-longevity-test: export STOP_LONGEVITY=true
 stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 
+WAF_ENABLED ?= false## Set to true to enable WAF+PLM longevity scenario (requires NGINX Plus + WAF images, amd64)
+
 .PHONY: ipv6-tests
 ipv6-tests: GOARCH=amd64
 ipv6-tests: ## Example usage: make ipv6-tests TAG=release-X.Y-rc
@@ -188,7 +190,8 @@ ipv6-tests: ## Example usage: make ipv6-tests TAG=release-X.Y-rc
 		--ngf-image-repo=$(PREFIX) --nginx-image-repo=$(NGINX_PREFIX) --nginx-plus-image-repo=$(NGINX_PLUS_PREFIX) \
 		--pull-policy=$(PULL_POLICY) --service-type=$(GW_SERVICE_TYPE) \
 		--plus-enabled=$(PLUS_ENABLED) --plus-license-file-name=$(PLUS_LICENSE_FILE) \
-		--plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) --gke-project=$(GKE_PROJECT)
+		--plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) --gke-project=$(GKE_PROJECT) \
+		--waf-enabled=$(WAF_ENABLED) --nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE)
 
 .PHONY: test
 test: build-crossplane-image ## Runs the functional tests on your kind k8s cluster

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -173,7 +173,7 @@ start-longevity-test: nfr-test ## Start the longevity test to run for 3 days in 
 stop-longevity-test: export STOP_LONGEVITY=true
 stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 
-WAF_ENABLED ?= false## Set to true to enable WAF+PLM longevity scenario (requires NGINX Plus + WAF images, amd64)
+WAF_PLM_ENABLED ?= false## Set to true to enable WAF+PLM longevity scenario (requires NGINX Plus + WAF images, amd64)
 
 .PHONY: ipv6-tests
 ipv6-tests: GOARCH=amd64
@@ -191,7 +191,7 @@ ipv6-tests: ## Example usage: make ipv6-tests TAG=release-X.Y-rc
 		--pull-policy=$(PULL_POLICY) --service-type=$(GW_SERVICE_TYPE) \
 		--plus-enabled=$(PLUS_ENABLED) --plus-license-file-name=$(PLUS_LICENSE_FILE) \
 		--plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT) --gke-project=$(GKE_PROJECT) \
-        --waf-enabled=$(WAF_ENABLED) $(if $(filter true,$(WAF_ENABLED)),--nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE))
+        --waf-enabled=$(WAF_PLM_ENABLED) $(if $(filter true,$(WAF_PLM_ENABLED)),--nginx-image-jwt-file-name=$(REGISTRY_JWT_FILE))
 
 .PHONY: test
 test: build-crossplane-image ## Runs the functional tests on your kind k8s cluster

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,18 +21,21 @@ This directory contains the tests for NGINX Gateway Fabric. The tests are divide
     - [Option 1 - Build and install NGINX Gateway Fabric from local to configured kind cluster](#option-1---build-and-install-nginx-gateway-fabric-from-local-to-configured-kind-cluster)
     - [Option 2 - Install NGINX Gateway Fabric from local already built image to configured kind cluster](#option-2---install-nginx-gateway-fabric-from-local-already-built-image-to-configured-kind-cluster)
   - [Step 2 - Build conformance test runner image](#step-2---build-conformance-test-runner-image)
-  - [Step 3 - Run Conformance tests](#step-3---run-conformance-tests)
+  - [Step 3 - Deploy MetalLB to the kind cluster](#step-3---deploy-metallb-to-the-kind-cluster)
+    - [To deploy MetalLB to the kind cluster](#to-deploy-metallb-to-the-kind-cluster)
+  - [Step 4 - Run Conformance tests](#step-4---run-conformance-tests)
     - [To run Gateway conformance tests](#to-run-gateway-conformance-tests)
     - [To run Inference conformance tests](#to-run-inference-conformance-tests)
-  - [Step 4 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric](#step-4---cleanup-the-conformance-test-fixtures-and-uninstall-nginx-gateway-fabric)
-  - [Step 5 - Revert changes to Go modules](#step-5---revert-changes-to-go-modules)
-  - [Step 6 - Delete kind cluster](#step-6---delete-kind-cluster)
+  - [Step 5 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric](#step-5---cleanup-the-conformance-test-fixtures-and-uninstall-nginx-gateway-fabric)
+  - [Step 6 - Revert changes to Go modules](#step-6---revert-changes-to-go-modules)
+  - [Step 7 - Delete kind cluster](#step-7---delete-kind-cluster)
 - [System Testing](#system-testing)
   - [Logging in tests](#logging-in-tests)
   - [Step 1 - Run the tests](#step-1---run-the-tests)
     - [Run the functional tests locally](#run-the-functional-tests-locally)
     - [Run the NFR tests on a GKE cluster from a GCP VM](#run-the-nfr-tests-on-a-gke-cluster-from-a-gcp-vm)
       - [Longevity testing](#longevity-testing)
+        - [WAF+PLM longevity scenario](#wafplm-longevity-scenario)
     - [Run the WAF tests on a GKE cluster](#run-the-waf-tests-on-a-gke-cluster)
   - [Common test amendments](#common-test-amendments)
   - [Step 2 - Cleanup](#step-2---cleanup)
@@ -210,7 +213,18 @@ go mod tidy
 make build-test-runner-image
 ```
 
-### Step 3 - Run Conformance tests
+### Step 3 - Deploy MetalLB to the kind cluster
+
+#### To deploy MetalLB to the kind cluster
+
+> This is needed to assign external IPs to the Loadbalancer Services spun up in the conformance test.
+> If your cluster can already do this, it is okay to skip
+
+```makefile
+make deploy-metallb
+```
+
+### Step 4 - Run Conformance tests
 
 #### To run Gateway conformance tests
 
@@ -224,7 +238,7 @@ make run-conformance-tests
 make run-inference-conformance-tests
 ```
 
-### Step 4 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric
+### Step 5 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric
 
 ```makefile
 make cleanup-conformance-tests
@@ -234,7 +248,7 @@ make cleanup-conformance-tests
 make uninstall-ngf
 ```
 
-### Step 5 - Revert changes to Go modules
+### Step 6 - Revert changes to Go modules
 
 **Optional** Not required if you aren't running the `main` Gateway API tests.
 
@@ -242,7 +256,7 @@ make uninstall-ngf
 make reset-go-modules
 ```
 
-### Step 6 - Delete kind cluster
+### Step 7 - Delete kind cluster
 
 ```makefile
 make delete-kind-cluster
@@ -384,6 +398,41 @@ make stop-longevity-test
 
 > Note if running from your machine instead of the pipeline: If you want to re-run the longevity test, you need to clear out the `cafe.example.com` entry from the `/etc/hosts` file on your VM.
 
+###### WAF+PLM longevity scenario
+
+The longevity test optionally includes a WAF+PLM scenario that runs alongside the standard longevity test. It deploys a second NGF release (`ngf-longevity-waf`) using the `nginx-plus-f5waf` image and the F5 WAF Policy Lifecycle Manager (PLM), then sustains clean and attack traffic for the duration of the run.
+
+**Requirements:**
+- NGINX Plus with NAP WAF images (amd64 only — not supported on arm64)
+- Access to `private-registry.nginx.com` (used to pull PLM and WAF sidecar images)
+- A `dockerconfig.jwt` file at the repo root (registry pull secret for `private-registry.nginx.com`)
+- A `license.jwt` file at the repo root (NGINX Plus billing/reporting JWT)
+
+**In the pipeline:** Enable the WAF scenario by setting the `waf_enabled` input to `true` when triggering the [longevity-start workflow](https://github.com/nginx/nginx-gateway-fabric/actions/workflows/longevity-start.yml). The WAF scenario only runs for the `plus` matrix job; it is automatically skipped for the `oss` job.
+
+**Manually:** Place `dockerconfig.jwt` at the repo root, then pass `WAF_ENABLED=true` and `REGISTRY_JWT_FILE` when starting the test:
+
+```makefile
+make start-longevity-test PLUS_ENABLED=true WAF_ENABLED=true REGISTRY_JWT_FILE=$(pwd)/../dockerconfig.jwt
+```
+
+The setup (`longevity-setup` label) will:
+1. Create the image pull secret in the `plm` namespace from `dockerconfig.jwt`
+2. Install PLM (`f5-waf-policy-controller` Helm chart) into the `plm` namespace
+3. Install the `ngf-longevity-waf` NGF Helm release with `gatewayClassName: nginx-waf` and unique TLS secret names to avoid colliding with the standard longevity release
+4. Apply WAF application resources to the `longevity-waf` namespace (APPolicy, APLogConf, WAFPolicy, Gateway, HTTPRoutes, CronJobs)
+5. Wait for the WAFPolicy to reach `Accepted` state — confirming PLM compiled the bundle and NGF loaded it into the data plane
+
+The `suite/scripts/longevity-wrk-waf.sh` script is started automatically and runs for the duration of the test. It sends clean traffic to `/coffee` and `/tea` on `waf.example.com`, and periodically sends XSS and SQLi attack probes. Attack results are written to `~/waf-attacks.txt` in CSV format — a `blocked=true` entry for every row confirms the WAF is enforcing correctly.
+
+> Note: The WAF uses NAP WAF's default block response (HTTP 200 with a "Request Rejected" body). Attack probes are detected as blocked by checking for this string in the response body.
+
+At teardown (`longevity-teardown` label), the results file will include:
+- `## WAF Traffic` — wrk summaries for clean traffic on `/coffee` and `/tea`
+- `## WAF Attack Results` — a count of blocked probes and a table of any unexpected (unblocked) rows. If all probes were blocked, a single summary line is written instead.
+
+> Note if running from your machine instead of the pipeline: If you want to re-run the WAF longevity test, you need to clear out the `waf.example.com` entry from the `/etc/hosts` file on your VM in addition to the `cafe.example.com` entry.
+
 #### Run the WAF tests on a GKE cluster
 
 WAF tests require NGINX Plus with NAP WAF images and run on GKE (amd64 only). Before running:
@@ -397,6 +446,8 @@ WAF tests require NGINX Plus with NAP WAF images and run on GKE (amd64 only). Be
    ```
 
    This will compile the WAF policy bundles from the JSON sources in `suite/manifests/waf-policy/`, create the image pull secret in the `nginx-gateway` namespace so the WAF sidecar images (`waf-enforcer`, `waf-config-mgr`) can be pulled from `private-registry.nginx.com`, and run the tests labelled `waf` against the GKE cluster.
+
+> Note: For the WAF longevity scenario, see the [WAF+PLM longevity scenario](#wafplm-longevity-scenario) section above.
 
 ### Common test amendments
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -408,12 +408,12 @@ The longevity test optionally includes a WAF+PLM scenario that runs alongside th
 - A `dockerconfig.jwt` file at the repo root (registry pull secret for `private-registry.nginx.com`)
 - A `license.jwt` file at the repo root (NGINX Plus billing/reporting JWT)
 
-**In the pipeline:** Enable the WAF scenario by setting the `waf_enabled` input to `true` when triggering the [longevity-start workflow](https://github.com/nginx/nginx-gateway-fabric/actions/workflows/longevity-start.yml). The WAF scenario only runs for the `plus` matrix job; it is automatically skipped for the `oss` job.
+**In the pipeline:** Enable the WAF scenario by setting the `waf_plm_enabled` input to `true` when triggering the [longevity-start workflow](https://github.com/nginx/nginx-gateway-fabric/actions/workflows/longevity-start.yml). The WAF scenario only runs for the `plus` matrix job; it is automatically skipped for the `oss` job.
 
-**Manually:** Place `dockerconfig.jwt` at the repo root, then pass `WAF_ENABLED=true` and `REGISTRY_JWT_FILE` when starting the test:
+**Manually:** Place `dockerconfig.jwt` at the repo root, then pass `WAF_PLM_ENABLED=true` and `REGISTRY_JWT_FILE` when starting the test:
 
 ```makefile
-make start-longevity-test PLUS_ENABLED=true WAF_ENABLED=true REGISTRY_JWT_FILE=$(pwd)/../dockerconfig.jwt
+make start-longevity-test PLUS_ENABLED=true WAF_PLM_ENABLED=true REGISTRY_JWT_FILE=$(pwd)/../dockerconfig.jwt
 ```
 
 The setup (`longevity-setup` label) will:

--- a/tests/README.md
+++ b/tests/README.md
@@ -218,7 +218,7 @@ make build-test-runner-image
 #### To deploy MetalLB to the kind cluster
 
 > This is needed to assign external IPs to the Loadbalancer Services spun up in the conformance test.
-> If your cluster can already do this, it is okay to skip
+> If your cluster can already do this, it is okay to skip.
 
 ```makefile
 make deploy-metallb
@@ -410,10 +410,16 @@ The longevity test optionally includes a WAF+PLM scenario that runs alongside th
 
 **In the pipeline:** Enable the WAF scenario by setting the `waf_plm_enabled` input to `true` when triggering the [longevity-start workflow](https://github.com/nginx/nginx-gateway-fabric/actions/workflows/longevity-start.yml). The WAF scenario only runs for the `plus` matrix job; it is automatically skipped for the `oss` job.
 
-**Manually:** Place `dockerconfig.jwt` at the repo root, then pass `WAF_PLM_ENABLED=true` and `REGISTRY_JWT_FILE` when starting the test:
+**Manually:** Place `dockerconfig.jwt` at the repo root (the default location for `REGISTRY_JWT_FILE`), then run:
 
 ```makefile
-make start-longevity-test PLUS_ENABLED=true WAF_PLM_ENABLED=true REGISTRY_JWT_FILE=$(pwd)/../dockerconfig.jwt
+make start-longevity-test PLUS_ENABLED=true WAF_PLM_ENABLED=true
+```
+
+If your `dockerconfig.jwt` is elsewhere, override the variable explicitly:
+
+```makefile
+make start-longevity-test PLUS_ENABLED=true WAF_PLM_ENABLED=true REGISTRY_JWT_FILE=/path/to/dockerconfig.jwt
 ```
 
 The setup (`longevity-setup` label) will:

--- a/tests/scripts/create-and-setup-gcp-vm.sh
+++ b/tests/scripts/create-and-setup-gcp-vm.sh
@@ -60,6 +60,11 @@ fi
 
 gcloud compute scp --quiet --zone "${GKE_CLUSTER_ZONE}" --project="${GKE_PROJECT}" "${REPO_DIR}"/license.jwt username@"${RESOURCE_NAME}":~/nginx-gateway-fabric/
 
+# Copy the registry JWT for WAF image pulls if it exists (written by CI for WAF longevity runs).
+if [ -f "${REPO_DIR}/dockerconfig.jwt" ]; then
+    gcloud compute scp --quiet --zone "${GKE_CLUSTER_ZONE}" --project="${GKE_PROJECT}" "${REPO_DIR}"/dockerconfig.jwt username@"${RESOURCE_NAME}":~/nginx-gateway-fabric/
+fi
+
 gcloud compute ssh --zone "${GKE_CLUSTER_ZONE}" --project="${GKE_PROJECT}" username@"${RESOURCE_NAME}" \
     --command="bash -i <<EOF
 cd nginx-gateway-fabric/tests

--- a/tests/scripts/create-and-setup-gcp-vm.sh
+++ b/tests/scripts/create-and-setup-gcp-vm.sh
@@ -62,6 +62,7 @@ gcloud compute scp --quiet --zone "${GKE_CLUSTER_ZONE}" --project="${GKE_PROJECT
 
 # Copy the registry JWT for WAF image pulls if it exists (written by CI for WAF longevity runs).
 if [ -f "${REPO_DIR}/dockerconfig.jwt" ]; then
+    echo "Copying over registry JWT for WAF image pulls..."
     gcloud compute scp --quiet --zone "${GKE_CLUSTER_ZONE}" --project="${GKE_PROJECT}" "${REPO_DIR}"/dockerconfig.jwt username@"${RESOURCE_NAME}":~/nginx-gateway-fabric/
 fi
 

--- a/tests/scripts/remote-scripts/run-nfr-tests.sh
+++ b/tests/scripts/remote-scripts/run-nfr-tests.sh
@@ -10,13 +10,13 @@ elif [ "${STOP_LONGEVITY}" == "true" ]; then
     GINKGO_LABEL="longevity-teardown"
 fi
 
-cd nginx-gateway-fabric/tests && make .vm-nfr-test CI=${CI} TAG="${TAG}" PREFIX="${PREFIX}" NGINX_PREFIX="${NGINX_PREFIX}" NGINX_PLUS_PREFIX="${NGINX_PLUS_PREFIX}" PLUS_ENABLED="${PLUS_ENABLED}" GINKGO_LABEL=${GINKGO_LABEL} GINKGO_FLAGS="${GINKGO_FLAGS}" PULL_POLICY=Always GW_SERVICE_TYPE=LoadBalancer NGF_VERSION="${NGF_VERSION}" PLUS_USAGE_ENDPOINT="${PLUS_USAGE_ENDPOINT}" GKE_PROJECT="${GKE_PROJECT}" WAF_ENABLED="${WAF_ENABLED:-false}" REGISTRY_JWT_FILE="${REGISTRY_JWT_FILE:-}"
+cd nginx-gateway-fabric/tests && make .vm-nfr-test CI=${CI} TAG="${TAG}" PREFIX="${PREFIX}" NGINX_PREFIX="${NGINX_PREFIX}" NGINX_PLUS_PREFIX="${NGINX_PLUS_PREFIX}" PLUS_ENABLED="${PLUS_ENABLED}" GINKGO_LABEL=${GINKGO_LABEL} GINKGO_FLAGS="${GINKGO_FLAGS}" PULL_POLICY=Always GW_SERVICE_TYPE=LoadBalancer NGF_VERSION="${NGF_VERSION}" PLUS_USAGE_ENDPOINT="${PLUS_USAGE_ENDPOINT}" GKE_PROJECT="${GKE_PROJECT}" WAF_PLM_ENABLED="${WAF_PLM_ENABLED:-false}" REGISTRY_JWT_FILE="${REGISTRY_JWT_FILE:-}"
 
 if [ "${START_LONGEVITY}" == "true" ]; then
     suite/scripts/longevity-wrk.sh
 
     # If WAF is enabled, also start the WAF traffic generator.
-    if [ "${WAF_ENABLED:-false}" == "true" ]; then
+    if [ "${WAF_PLM_ENABLED:-false}" == "true" ]; then
         suite/scripts/longevity-wrk-waf.sh
     fi
 fi

--- a/tests/scripts/remote-scripts/run-nfr-tests.sh
+++ b/tests/scripts/remote-scripts/run-nfr-tests.sh
@@ -10,8 +10,13 @@ elif [ "${STOP_LONGEVITY}" == "true" ]; then
     GINKGO_LABEL="longevity-teardown"
 fi
 
-cd nginx-gateway-fabric/tests && make .vm-nfr-test CI=${CI} TAG="${TAG}" PREFIX="${PREFIX}" NGINX_PREFIX="${NGINX_PREFIX}" NGINX_PLUS_PREFIX="${NGINX_PLUS_PREFIX}" PLUS_ENABLED="${PLUS_ENABLED}" GINKGO_LABEL=${GINKGO_LABEL} GINKGO_FLAGS="${GINKGO_FLAGS}" PULL_POLICY=Always GW_SERVICE_TYPE=LoadBalancer NGF_VERSION="${NGF_VERSION}" PLUS_USAGE_ENDPOINT="${PLUS_USAGE_ENDPOINT}" GKE_PROJECT="${GKE_PROJECT}"
+cd nginx-gateway-fabric/tests && make .vm-nfr-test CI=${CI} TAG="${TAG}" PREFIX="${PREFIX}" NGINX_PREFIX="${NGINX_PREFIX}" NGINX_PLUS_PREFIX="${NGINX_PLUS_PREFIX}" PLUS_ENABLED="${PLUS_ENABLED}" GINKGO_LABEL=${GINKGO_LABEL} GINKGO_FLAGS="${GINKGO_FLAGS}" PULL_POLICY=Always GW_SERVICE_TYPE=LoadBalancer NGF_VERSION="${NGF_VERSION}" PLUS_USAGE_ENDPOINT="${PLUS_USAGE_ENDPOINT}" GKE_PROJECT="${GKE_PROJECT}" WAF_ENABLED="${WAF_ENABLED:-false}" REGISTRY_JWT_FILE="${REGISTRY_JWT_FILE:-}"
 
 if [ "${START_LONGEVITY}" == "true" ]; then
     suite/scripts/longevity-wrk.sh
+
+    # If WAF is enabled, also start the WAF traffic generator.
+    if [ "${WAF_ENABLED:-false}" == "true" ]; then
+        suite/scripts/longevity-wrk-waf.sh
+    fi
 fi

--- a/tests/suite/longevity_test.go
+++ b/tests/suite/longevity_test.go
@@ -189,8 +189,6 @@ func writeTrafficResults(resultsFile *os.File, homeDir, filename, testname strin
 }
 
 // setupWAFLongevity installs PLM and the NGF WAF release, applies WAF resources, and waits for them to be ready.
-// This mirrors the installPLM() + createNGFInstallConfig() pattern from system_suite_test.go that
-// the functional WAF tests use in SynchronizedBeforeSuite.
 func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
 	GinkgoWriter.Println("Setting up WAF+PLM longevity test")
 
@@ -201,13 +199,9 @@ func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
 	Expect(framework.CreateImagePullSecret(resourceManager, framework.PLMNamespace, *nginxImageJWTFileName)).
 		To(Succeed())
 
-	// Install the PLM controller (f5-waf-policy-controller). Chart coordinates are hardcoded in
-	// framework.InstallPLM — no dynamic chart URL/version variables are needed.
 	output, err := framework.InstallPLM()
 	Expect(err).ToNot(HaveOccurred(), string(output))
 
-	// Build the install config for the WAF-specific NGF release (ngf-longevity-waf).
-	// It uses nginx-plus-f5waf (NGINX Plus with NAP WAF bundled) instead of nginx-plus.
 	wafInstallCfg := framework.InstallationConfig{
 		ReleaseName:          "ngf-longevity-waf",
 		Namespace:            ngfNamespace,
@@ -234,6 +228,8 @@ func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
 
 	// Install the WAF NGF release. plmNGFInstallArgs() configures the PLM storage URL and
 	// credentials so NGF can fetch compiled NAP policy bundles from SeaweedFS.
+	// TLS secret names are set to unique values to avoid conflict with non-waf ngf release
+	// in same namespace.
 	extraArgs := append(plmNGFInstallArgs(),
 		"--set", "nginx.imagePullSecret="+framework.PlusImagePullSecretName,
 		"--set", "certGenerator.serverTLSSecretName=ngf-longevity-waf-server-tls",
@@ -261,9 +257,7 @@ func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
 }
 
 // teardownWAFLongevity collects WAF traffic results, logs, removes WAF application resources,
-// and uninstalls PLM. This mirrors the SynchronizedAfterSuite PLM cleanup in system_suite_test.go.
-// The ngf-longevity-waf Helm release is left running; it will be cleaned up when SynchronizedAfterSuite
-// teardown("ngf-longevity") deletes the nginx-gateway namespace.
+// and uninstalls PLM.
 func teardownWAFLongevity(resultsFile *os.File, homeDir string, wafNs core.Namespace, wafFiles []string) {
 	GinkgoWriter.Println("Tearing down WAF+PLM longevity test")
 
@@ -285,8 +279,7 @@ func teardownWAFLongevity(resultsFile *os.File, homeDir string, wafNs core.Names
 	Expect(resourceManager.DeleteFromFiles(wafFiles, wafNs.Name)).To(Succeed())
 	Expect(resourceManager.DeleteNamespace(wafNs.Name)).To(Succeed())
 
-	// Uninstall PLM and clean up its namespace. PLM lives in its own namespace (framework.PLMNamespace),
-	// separate from nginx-gateway, so this is safe before SynchronizedAfterSuite runs.
+	// Uninstall PLM and clean up its namespace.
 	output, err := framework.UninstallPLM()
 	Expect(err).ToNot(HaveOccurred(), string(output))
 	framework.RemovePLMFinalizers()

--- a/tests/suite/longevity_test.go
+++ b/tests/suite/longevity_test.go
@@ -90,6 +90,8 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 			} else {
 				setupWAFLongevity(wafNs, wafFiles)
 			}
+		} else {
+			GinkgoWriter.Println("Skipping WAF longevity setup: --waf-enabled and --plus-enabled flags are not both set")
 		}
 	})
 
@@ -138,7 +140,6 @@ func writeWAFAttackResults(resultsFile *os.File, homeDir string) error {
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
-	var header string
 	var unexpected []string
 	blockedCount := 0
 
@@ -151,7 +152,7 @@ func writeWAFAttackResults(resultsFile *os.File, homeDir string) error {
 		}
 		fields := strings.Split(line, ",")
 
-		// successful lines should looks like this:
+		// successful lines should look like this:
 		// 2026-06-11T18:53:40Z,/coffee,xss,200,true
 		// 2026-06-11T18:53:40Z,/tea,sqli,200,true
 		if len(fields) >= 5 && fields[len(fields)-1] == "true" {
@@ -165,7 +166,6 @@ func writeWAFAttackResults(resultsFile *os.File, homeDir string) error {
 	fmt.Fprintf(&out, "WAF Attack Log (blocked: %d, unexpected: %d):\n\n", blockedCount, len(unexpected))
 	if len(unexpected) > 0 {
 		out.WriteString("```text\n")
-		out.WriteString(header + "\n")
 		for _, line := range unexpected {
 			out.WriteString(line + "\n")
 		}

--- a/tests/suite/longevity_test.go
+++ b/tests/suite/longevity_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/tests/framework"
@@ -31,7 +33,20 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 			"longevity/prom.yaml",
 		}
 
-		ns core.Namespace
+		// WAF+PLM longevity resources. Only deployed when --waf-enabled is set.
+		wafFiles = []string{
+			"longevity-waf/cafe.yaml",
+			"longevity-waf/nginx-proxy.yaml",
+			"longevity-waf/gateway.yaml",
+			"longevity-waf/cafe-routes.yaml",
+			"longevity-waf/appolicy.yaml",
+			"longevity-waf/aplogconf.yaml",
+			"longevity-waf/wafpolicy-plm.yaml",
+			"longevity-waf/cronjob.yaml",
+		}
+
+		ns    core.Namespace
+		wafNs core.Namespace
 
 		labelFilter = GinkgoLabelFilter()
 	)
@@ -40,6 +55,11 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 		ns = core.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "longevity",
+			},
+		}
+		wafNs = core.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "longevity-waf",
 			},
 		}
 
@@ -62,6 +82,15 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 		Expect(resourceManager.ApplyFromFiles(files, ns.Name)).To(Succeed())
 		Expect(resourceManager.ApplyFromFiles(promFile, ngfNamespace)).To(Succeed())
 		Expect(resourceManager.WaitForAppsToBeReady(ns.Name, framework.WithLoggingDisabled())).To(Succeed())
+
+		// WAF+PLM longevity setup — only when running with NGINX Plus and NAP WAF images.
+		if *wafEnabled && *plusEnabled {
+			if runtime.GOARCH == "arm64" {
+				GinkgoWriter.Println("Skipping WAF longevity setup: NAP WAF does not support ARM architecture")
+			} else {
+				setupWAFLongevity(wafNs, wafFiles)
+			}
+		}
 	})
 
 	It("collects results", Label("longevity-teardown"), func() {
@@ -90,6 +119,11 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 		framework.AddNginxLogsAndEventsToReport(resourceManager, ns.Name)
 		Expect(resourceManager.DeleteFromFiles(files, ns.Name)).To(Succeed())
 		Expect(resourceManager.DeleteNamespace(ns.Name)).To(Succeed())
+
+		// WAF+PLM longevity teardown — collect results and clean up.
+		if *wafEnabled && *plusEnabled && runtime.GOARCH != "arm64" {
+			teardownWAFLongevity(resultsFile, homeDir, wafNs, wafFiles)
+		}
 	})
 })
 
@@ -102,4 +136,109 @@ func writeTrafficResults(resultsFile *os.File, homeDir, filename, testname strin
 
 	formattedContent := fmt.Sprintf("%s:\n\n```text\n%s```\n", testname, string(content))
 	return framework.WriteContent(resultsFile, formattedContent)
+}
+
+// setupWAFLongevity installs PLM and the NGF WAF release, applies WAF resources, and waits for them to be ready.
+// This mirrors the installPLM() + createNGFInstallConfig() pattern from system_suite_test.go that
+// the functional WAF tests use in SynchronizedBeforeSuite.
+func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
+	GinkgoWriter.Println("Setting up WAF+PLM longevity test")
+
+	// Create the image pull secret that PLM uses to pull its images from private-registry.nginx.com.
+	// The same JWT is reused for the nginx-plus-f5waf data plane image.
+	Expect(*nginxImageJWTFileName).ToNot(BeEmpty(),
+		"WAF longevity requires --nginx-image-jwt-file-name to pull PLM and WAF images")
+	Expect(framework.CreateImagePullSecret(resourceManager, framework.PLMNamespace, *nginxImageJWTFileName)).
+		To(Succeed())
+
+	// Install the PLM controller (f5-waf-policy-controller). Chart coordinates are hardcoded in
+	// framework.InstallPLM — no dynamic chart URL/version variables are needed.
+	output, err := framework.InstallPLM()
+	Expect(err).ToNot(HaveOccurred(), string(output))
+
+	// Build the install config for the WAF-specific NGF release (ngf-longevity-waf).
+	// It uses nginx-plus-f5waf (NGINX Plus with NAP WAF bundled) instead of nginx-plus.
+	wafInstallCfg := framework.InstallationConfig{
+		ReleaseName:          "ngf-longevity-waf",
+		Namespace:            ngfNamespace,
+		ChartPath:            localChartPath,
+		ServiceType:          *serviceType,
+		Plus:                 true,
+		PlusUsageEndpoint:    *plusUsageEndpoint,
+		GatewayClassName:     "nginx-waf",
+		NginxImagePullSecret: *nginxImageJWTFileName,
+		NgfImageRepository:   *ngfImageRepository,
+		ImageTag:             *imageTag,
+		ImagePullPolicy:      *imagePullPolicy,
+	}
+
+	// Derive the nginx-plus-f5waf image repository. When running in GKE (gkeProject is set),
+	// build the GAR path. Otherwise fall back to *nginxPlusImageRepository (local testing).
+	if *gkeProject != "" {
+		wafInstallCfg.NginxImageRepository = fmt.Sprintf(
+			"us-docker.pkg.dev/%s/nginx-gateway-fabric/nginx-plus-f5waf", *gkeProject,
+		)
+	} else {
+		wafInstallCfg.NginxImageRepository = *nginxPlusImageRepository
+	}
+
+	// Install the WAF NGF release. plmNGFInstallArgs() configures the PLM storage URL and
+	// credentials so NGF can fetch compiled NAP policy bundles from SeaweedFS.
+	extraArgs := append(plmNGFInstallArgs(),
+		"--set", "nginx.imagePullSecret="+framework.PlusImagePullSecretName,
+	)
+	output, err = framework.InstallNGF(wafInstallCfg, extraArgs...)
+	Expect(err).ToNot(HaveOccurred(), string(output))
+
+	// Scale the WAF NGF controller to 2 replicas to test leader election alongside WAF.
+	wafNGFDeployment, err := resourceManager.GetNGFDeployment(ngfNamespace, "ngf-longevity-waf")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resourceManager.ScaleDeployment(ngfNamespace, wafNGFDeployment.GetName(), 2)).To(Succeed())
+
+	// Apply WAF application resources and wait for all pods to be ready.
+	Expect(resourceManager.Apply([]client.Object{&wafNs})).To(Succeed())
+	Expect(resourceManager.ApplyFromFiles(wafFiles, wafNs.Name)).To(Succeed())
+	Expect(resourceManager.WaitForAppsToBeReady(wafNs.Name, framework.WithLoggingDisabled())).To(Succeed())
+
+	// Wait for the WAFPolicy to be accepted — confirms PLM has compiled the bundle
+	// and NGF has fetched and deployed it to the NGINX data plane.
+	nsname := types.NamespacedName{Name: "gateway-waf-plm", Namespace: wafNs.Name}
+	Expect(waitForWAFPolicyAccepted(nsname)).To(Succeed())
+
+	GinkgoWriter.Println("WAF+PLM longevity test setup complete")
+}
+
+// teardownWAFLongevity collects WAF traffic results, logs, removes WAF application resources,
+// and uninstalls PLM. This mirrors the SynchronizedAfterSuite PLM cleanup in system_suite_test.go.
+// The ngf-longevity-waf Helm release is left running; it will be cleaned up when SynchronizedAfterSuite
+// teardown("ngf-longevity") deletes the nginx-gateway namespace.
+func teardownWAFLongevity(resultsFile *os.File, homeDir string, wafNs core.Namespace, wafFiles []string) {
+	GinkgoWriter.Println("Tearing down WAF+PLM longevity test")
+
+	Expect(framework.WriteContent(resultsFile, "\n## WAF Traffic\n")).To(Succeed())
+	Expect(writeTrafficResults(resultsFile, homeDir, "waf-coffee.txt", "WAF HTTP (coffee)")).To(Succeed())
+	Expect(writeTrafficResults(resultsFile, homeDir, "waf-tea.txt", "WAF HTTP (tea)")).To(Succeed())
+
+	// Write attack traffic results (blocked/allowed counts).
+	Expect(framework.WriteContent(resultsFile, "\n## WAF Attack Results\n")).To(Succeed())
+	Expect(writeTrafficResults(resultsFile, homeDir, "waf-attacks.txt", "WAF Attack Log")).To(Succeed())
+
+	// Verify the WAFPolicy is still accepted at teardown to confirm sustained enforcement.
+	nsname := types.NamespacedName{Name: "gateway-waf-plm", Namespace: wafNs.Name}
+	if err := waitForWAFPolicyAccepted(nsname); err != nil {
+		GinkgoWriter.Printf("WARNING: WAFPolicy not in Accepted state at teardown: %v\n", err)
+	}
+
+	framework.AddNginxLogsAndEventsToReport(resourceManager, wafNs.Name)
+	Expect(resourceManager.DeleteFromFiles(wafFiles, wafNs.Name)).To(Succeed())
+	Expect(resourceManager.DeleteNamespace(wafNs.Name)).To(Succeed())
+
+	// Uninstall PLM and clean up its namespace. PLM lives in its own namespace (framework.PLMNamespace),
+	// separate from nginx-gateway, so this is safe before SynchronizedAfterSuite runs.
+	output, err := framework.UninstallPLM()
+	Expect(err).ToNot(HaveOccurred(), string(output))
+	framework.RemovePLMFinalizers()
+	Expect(resourceManager.DeleteNamespace(framework.PLMNamespace)).To(Succeed())
+
+	GinkgoWriter.Println("WAF+PLM longevity teardown complete")
 }

--- a/tests/suite/longevity_test.go
+++ b/tests/suite/longevity_test.go
@@ -186,6 +186,8 @@ func setupWAFLongevity(wafNs core.Namespace, wafFiles []string) {
 	// credentials so NGF can fetch compiled NAP policy bundles from SeaweedFS.
 	extraArgs := append(plmNGFInstallArgs(),
 		"--set", "nginx.imagePullSecret="+framework.PlusImagePullSecretName,
+		"--set", "certGenerator.serverTLSSecretName=ngf-longevity-waf-server-tls",
+		"--set", "certGenerator.agentTLSSecretName=ngf-longevity-waf-agent-tls",
 	)
 	output, err = framework.InstallNGF(wafInstallCfg, extraArgs...)
 	Expect(err).ToNot(HaveOccurred(), string(output))

--- a/tests/suite/longevity_test.go
+++ b/tests/suite/longevity_test.go
@@ -127,6 +127,56 @@ var _ = Describe("Longevity", Label("longevity-setup", "longevity-teardown"), fu
 	})
 })
 
+// writeWAFAttackResults reads waf-attacks.txt, counts successfully blocked probes, and writes
+// only the unexpected (unblocked) rows to the results file. This keeps the results concise while
+// still surfacing any enforcement failures.
+func writeWAFAttackResults(resultsFile *os.File, homeDir string) error {
+	file := fmt.Sprintf("%s/waf-attacks.txt", homeDir)
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	var header string
+	var unexpected []string
+	blockedCount := 0
+
+	for i, line := range lines {
+		if i == 0 {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ",")
+
+		// successful lines should looks like this:
+		// 2026-06-11T18:53:40Z,/coffee,xss,200,true
+		// 2026-06-11T18:53:40Z,/tea,sqli,200,true
+		if len(fields) >= 5 && fields[len(fields)-1] == "true" {
+			blockedCount++
+		} else {
+			unexpected = append(unexpected, line)
+		}
+	}
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "WAF Attack Log (blocked: %d, unexpected: %d):\n\n", blockedCount, len(unexpected))
+	if len(unexpected) > 0 {
+		out.WriteString("```text\n")
+		out.WriteString(header + "\n")
+		for _, line := range unexpected {
+			out.WriteString(line + "\n")
+		}
+		out.WriteString("```\n")
+	} else {
+		out.WriteString("All attack probes were blocked successfully.\n")
+	}
+
+	return framework.WriteContent(resultsFile, out.String())
+}
+
 func writeTrafficResults(resultsFile *os.File, homeDir, filename, testname string) error {
 	file := fmt.Sprintf("%s/%s", homeDir, filename)
 	content, err := os.ReadFile(file)
@@ -221,9 +271,9 @@ func teardownWAFLongevity(resultsFile *os.File, homeDir string, wafNs core.Names
 	Expect(writeTrafficResults(resultsFile, homeDir, "waf-coffee.txt", "WAF HTTP (coffee)")).To(Succeed())
 	Expect(writeTrafficResults(resultsFile, homeDir, "waf-tea.txt", "WAF HTTP (tea)")).To(Succeed())
 
-	// Write attack traffic results (blocked/allowed counts).
+	// Write attack traffic results — only unexpected (unblocked) rows plus a blocked count.
 	Expect(framework.WriteContent(resultsFile, "\n## WAF Attack Results\n")).To(Succeed())
-	Expect(writeTrafficResults(resultsFile, homeDir, "waf-attacks.txt", "WAF Attack Log")).To(Succeed())
+	Expect(writeWAFAttackResults(resultsFile, homeDir)).To(Succeed())
 
 	// Verify the WAFPolicy is still accepted at teardown to confirm sustained enforcement.
 	nsname := types.NamespacedName{Name: "gateway-waf-plm", Namespace: wafNs.Name}

--- a/tests/suite/manifests/longevity-waf/aplogconf.yaml
+++ b/tests/suite/manifests/longevity-waf/aplogconf.yaml
@@ -1,0 +1,11 @@
+apiVersion: appprotect.f5.com/v1
+kind: APLogConf
+metadata:
+  name: log-illegal
+spec:
+  filter:
+    request_type: illegal
+  content:
+    format: default
+    max_request_size: any
+    max_message_size: 15k

--- a/tests/suite/manifests/longevity-waf/appolicy.yaml
+++ b/tests/suite/manifests/longevity-waf/appolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: appprotect.f5.com/v1
+kind: APPolicy
+metadata:
+  name: attack-signatures-blocking
+spec:
+  policy:
+    name: attack-signatures-blocking
+    template:
+      name: POLICY_TEMPLATE_NGINX_BASE
+    applicationLanguage: utf-8
+    enforcementMode: blocking
+    signature-sets:
+    - name: All Signatures
+      block: true
+      alarm: true
+    cookies:
+    - name: "*"
+      attackSignaturesCheck: true
+      enforcementType: enforce
+      maskValueInLogs: false

--- a/tests/suite/manifests/longevity-waf/appolicy.yaml
+++ b/tests/suite/manifests/longevity-waf/appolicy.yaml
@@ -9,6 +9,10 @@ spec:
       name: POLICY_TEMPLATE_NGINX_BASE
     applicationLanguage: utf-8
     enforcementMode: blocking
+    response-pages:
+    - responseStatusCode: "403"
+      responseType: default
+      type: default
     signature-sets:
     - name: All Signatures
       block: true

--- a/tests/suite/manifests/longevity-waf/appolicy.yaml
+++ b/tests/suite/manifests/longevity-waf/appolicy.yaml
@@ -9,10 +9,6 @@ spec:
       name: POLICY_TEMPLATE_NGINX_BASE
     applicationLanguage: utf-8
     enforcementMode: blocking
-    response-pages:
-    - responseStatusCode: "403"
-      responseType: default
-      type: default
     signature-sets:
     - name: All Signatures
       block: true

--- a/tests/suite/manifests/longevity-waf/cafe-routes.yaml
+++ b/tests/suite/manifests/longevity-waf/cafe-routes.yaml
@@ -1,0 +1,64 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coffee
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "waf.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /coffee
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.nginx.org
+        kind: SnippetsFilter
+        name: loggable-snippet
+    backendRefs:
+    - name: coffee
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tea
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "waf.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tea
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.nginx.org
+        kind: SnippetsFilter
+        name: loggable-snippet
+    backendRefs:
+    - name: tea
+      port: 80
+---
+# Only log non-200 responses
+apiVersion: gateway.nginx.org/v1alpha1
+kind: SnippetsFilter
+metadata:
+  name: loggable-snippet
+spec:
+  snippets:
+  - context: http
+    value: |
+      map $status $loggable {
+        ~^[2] 0;
+        default 1;
+      }
+      access_log /dev/stdout combined if=$loggable;

--- a/tests/suite/manifests/longevity-waf/cafe.yaml
+++ b/tests/suite/manifests/longevity-waf/cafe.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep", "15"]
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-no-access-log
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep", "15"]
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-no-access-log
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-no-access-log
+data:
+  nginx.conf: |
+    events {}
+    http {
+      access_log off;
+      server {
+        listen 8080;
+        location / {
+          return 200;
+        }
+      }
+    }

--- a/tests/suite/manifests/longevity-waf/cronjob.yaml
+++ b/tests/suite/manifests/longevity-waf/cronjob.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollout-mgr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-mgr
+rules:
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - patch
+- apiGroups:
+  - "appprotect.f5.com"
+  resources:
+  - appolicies
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-mgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-mgr
+subjects:
+- kind: ServiceAccount
+  name: rollout-mgr
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coffee-rollout-mgr
+spec:
+  schedule: "* */6 * * *" # every minute every 6 hours
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: rollout-mgr
+          containers:
+          - name: coffee-rollout-mgr
+            image: curlimages/curl:8.20.0
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            args:
+            - |
+                TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                RESTARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                curl -X PATCH -s -k -v \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-type: application/merge-patch+json" \
+                --data-raw "{\"spec\": {\"template\": {\"metadata\": {\"annotations\": {\"kubectl.kubernetes.io/restartedAt\": \"$RESTARTED_AT\"}}}}}" \
+                "https://kubernetes.default/apis/apps/v1/namespaces/longevity-waf/deployments/coffee?fieldManager=kubectl-rollout" 2>&1
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tea-rollout-mgr
+spec:
+  schedule: "* 3,9,15,21 * * *" # every minute every 6 hours, 3 hours apart from coffee
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: rollout-mgr
+          containers:
+          - name: tea-rollout-mgr
+            image: curlimages/curl:8.20.0
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            args:
+            - |
+                TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                RESTARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                curl -X PATCH -s -k -v \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-type: application/merge-patch+json" \
+                --data-raw "{\"spec\": {\"template\": {\"metadata\": {\"annotations\": {\"kubectl.kubernetes.io/restartedAt\": \"$RESTARTED_AT\"}}}}}" \
+                "https://kubernetes.default/apis/apps/v1/namespaces/longevity-waf/deployments/tea?fieldManager=kubectl-rollout" 2>&1
+          restartPolicy: OnFailure
+---
+# Periodically update the APPolicy spec to exercise the PLM event-driven recompile → NGF fetch path.
+# A benign change (adding/toggling a comment field) is enough to trigger PLM recompilation.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: appolicy-updater
+spec:
+  schedule: "0 12 * * *" # once a day at noon
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: rollout-mgr
+          containers:
+          - name: appolicy-updater
+            image: curlimages/curl:8.20.0
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            args:
+            - |
+                TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                UPDATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                curl -X PATCH -s -k -v \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-type: application/merge-patch+json" \
+                --data-raw "{\"metadata\": {\"annotations\": {\"longevity.nginx.org/last-updated\": \"$UPDATED_AT\"}}}" \
+                "https://kubernetes.default/apis/appprotect.f5.com/v1/namespaces/longevity-waf/appolicies/attack-signatures-blocking?fieldManager=appolicy-updater" 2>&1
+          restartPolicy: OnFailure

--- a/tests/suite/manifests/longevity-waf/gateway.yaml
+++ b/tests/suite/manifests/longevity-waf/gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  gatewayClassName: nginx-waf
+  infrastructure:
+    annotations:
+      networking.gke.io/load-balancer-type: Internal
+    parametersRef:
+      name: waf-enabled-proxy
+      group: gateway.nginx.org
+      kind: NginxProxy
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"

--- a/tests/suite/manifests/longevity-waf/nginx-proxy.yaml
+++ b/tests/suite/manifests/longevity-waf/nginx-proxy.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: waf-enabled-proxy
+spec:
+  waf:
+    enable: true

--- a/tests/suite/manifests/longevity-waf/wafpolicy-plm.yaml
+++ b/tests/suite/manifests/longevity-waf/wafpolicy-plm.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-waf-plm
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  type: PLM
+  policyRef:
+    apPolicyRef:
+      name: attack-signatures-blocking
+  securityLogs:
+  - logRef:
+      apLogConfRef:
+        name: log-illegal
+    destination:
+      type: stderr

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -51,8 +51,8 @@ fi
 # --- Clean traffic (wrk) ---
 # Two wrk instances mirror the two routes verified by the functional PLM tests.
 echo "Starting wrk clean traffic..."
-nohup wrk -t2 -c80 -d2h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
-nohup wrk -t2 -c80 -d2h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
 
 # --- Attack traffic loop ---
 # XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -51,8 +51,8 @@ fi
 # --- Clean traffic (wrk) ---
 # Two wrk instances mirror the two routes verified by the functional PLM tests.
 echo "Starting wrk clean traffic..."
-nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
-nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
+nohup wrk -t2 -c80 -d1h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
+nohup wrk -t2 -c80 -d1h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
 
 # --- Attack traffic loop ---
 # XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -51,8 +51,8 @@ fi
 # --- Clean traffic (wrk) ---
 # Two wrk instances mirror the two routes verified by the functional PLM tests.
 echo "Starting wrk clean traffic..."
-nohup wrk -t2 -c80 -d1h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
-nohup wrk -t2 -c80 -d1h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
 
 # --- Attack traffic loop ---
 # XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -55,7 +55,6 @@ nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
 nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
 
 # --- Attack traffic loop ---
-# XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.
 echo "Starting WAF attack traffic loop..."
 nohup bash -c '
     WAF_HOST="'"${WAF_HOST}"'"
@@ -68,16 +67,14 @@ nohup bash -c '
     while true; do
         TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-        # XSS probe on /coffee — </script> matches the functional PLM test payload.
-        # NAP WAF blocks with HTTP 200 + "Request Rejected" body by default; also handle
-        # explicit 403 when APPolicy response-pages is configured.
+        # NAP WAF blocks with HTTP 200 + "Request Rejected" body by default.
         RESPONSE=$(curl -s -w "\n%{http_code}" \
             "http://${WAF_HOST}/coffee?x=${xss_payload}" \
             2>/dev/null || echo -e "\n000")
         STATUS=$(printf '%s' "${RESPONSE}" | tail -1)
         BODY=$(printf '%s' "${RESPONSE}" | head -n -1)
         BLOCKED="false"
-        if [[ "${STATUS}" != "200" ]] || echo "${BODY}" | grep -qi "request rejected"; then
+        if [[ "${STATUS}" == "200" ]] && echo "${BODY}" | grep -qi "request rejected"; then
             BLOCKED="true"
         fi
         echo "${TS},/coffee,xss,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"
@@ -90,7 +87,7 @@ nohup bash -c '
         STATUS=$(printf '%s' "${RESPONSE}" | tail -1)
         BODY=$(printf '%s' "${RESPONSE}" | head -n -1)
         BLOCKED="false"
-        if [[ "${STATUS}" != "200" ]] || echo "${BODY}" | grep -qi "request rejected"; then
+        if [[ "${STATUS}" == "200" ]] && echo "${BODY}" | grep -qi "request rejected"; then
             BLOCKED="true"
         fi
         echo "${TS},/tea,sqli,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# longevity-wrk-waf.sh — Traffic generator for the WAF longevity test.
+#
+# Starts two background processes:
+#   1. wrk (clean traffic) — sustained HTTP load to /coffee and /tea via waf.example.com
+#   2. Attack loop          — periodic XSS and SQLi probes that the WAF should block, results
+#                             written to ~/waf-attacks.txt for collection at teardown
+#
+# Expects the gateway-nginx LoadBalancer service in the longevity-waf namespace to be ready.
+
+set -euo pipefail
+
+WAF_NS="${WAF_NS:-longevity-waf}"
+WAF_HOST="waf.example.com"
+MAX_WAIT=300
+INTERVAL=5
+ELAPSED=0
+
+echo "Waiting for gateway-nginx LoadBalancer IP in namespace '${WAF_NS}'..."
+while true; do
+    SVC_IP=$(kubectl -n "${WAF_NS}" get svc gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+    if [[ -n ${SVC_IP} ]]; then
+        echo "LoadBalancer IP assigned: ${SVC_IP}"
+        break
+    fi
+    echo "Still waiting for nginx Service IP..."
+    sleep "${INTERVAL}"
+done
+
+echo "${SVC_IP} ${WAF_HOST}" | sudo tee -a /etc/hosts
+
+# Wait for both endpoints to return HTTP 200 before starting traffic
+echo "Waiting for endpoints to be ready..."
+while ((ELAPSED < MAX_WAIT)); do
+    COFFEE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://${WAF_HOST}/coffee" 2>/dev/null || echo "000")
+    TEA_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://${WAF_HOST}/tea" 2>/dev/null || echo "000")
+    if [[ ${COFFEE_STATUS} == "200" && ${TEA_STATUS} == "200" ]]; then
+        echo "Both endpoints are returning 200."
+        break
+    fi
+    echo "Waiting... (coffee: ${COFFEE_STATUS}, tea: ${TEA_STATUS})"
+    sleep "${INTERVAL}"
+    ((ELAPSED += INTERVAL))
+done
+
+if ((ELAPSED >= MAX_WAIT)); then
+    echo "ERROR: Endpoints did not return 200 within ${MAX_WAIT} seconds." >&2
+    exit 1
+fi
+
+# --- Clean traffic (wrk) ---
+# Two wrk instances mirror the two routes verified by the functional PLM tests.
+echo "Starting wrk clean traffic..."
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
+nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
+
+# --- Attack traffic loop ---
+# XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.
+echo "Starting WAF attack traffic loop..."
+nohup bash -c '
+    WAF_HOST="'"${WAF_HOST}"'"
+    ATTACK_FILE="${HOME}/waf-attacks.txt"
+    echo "attack_time,path,payload_type,http_status,blocked" > "${ATTACK_FILE}"
+
+    xss_payload="%3C%2Fscript%3E"
+    sqli_payload="'"'"' OR 1=1 --"
+
+    while true; do
+        TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        # XSS probe on /coffee — </script> matches the functional PLM test payload
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "http://${WAF_HOST}/coffee?x=${xss_payload}" \
+            2>/dev/null || echo "000")
+        BLOCKED="false"
+        [[ "${STATUS}" == "200" ]] || BLOCKED="true"
+        echo "${TS},/coffee,xss,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"
+
+        # SQLi probe on /tea
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --data-urlencode "q=${sqli_payload}" \
+            "http://${WAF_HOST}/tea" \
+            2>/dev/null || echo "000")
+        BLOCKED="false"
+        [[ "${STATUS}" == "200" ]] || BLOCKED="true"
+        echo "${TS},/tea,sqli,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"
+
+        sleep 5
+    done
+' >~/waf-attack-loop.log 2>&1 &
+
+echo "WAF longevity traffic started."
+echo "  Clean traffic log (coffee): ~/waf-coffee.txt"
+echo "  Clean traffic log (tea):    ~/waf-tea.txt"
+echo "  Attack results log:         ~/waf-attacks.txt"

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -6,7 +6,7 @@
 #   2. Attack loop          — periodic XSS and SQLi probes that the WAF should block, results
 #                             written to ~/waf-attacks.txt for collection at teardown
 #
-# Expects the gateway-nginx LoadBalancer service in the longevity-waf namespace to be ready.
+# Expects the gateway-nginx-waf LoadBalancer service in the longevity-waf namespace to be ready.
 
 set -euo pipefail
 
@@ -16,9 +16,9 @@ MAX_WAIT=300
 INTERVAL=5
 ELAPSED=0
 
-echo "Waiting for gateway-nginx LoadBalancer IP in namespace '${WAF_NS}'..."
+echo "Waiting for gateway-nginx-waf LoadBalancer IP in namespace '${WAF_NS}'..."
 while true; do
-    SVC_IP=$(kubectl -n "${WAF_NS}" get svc gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+    SVC_IP=$(kubectl -n "${WAF_NS}" get svc gateway-nginx-waf -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
     if [[ -n ${SVC_IP} ]]; then
         echo "LoadBalancer IP assigned: ${SVC_IP}"
         break

--- a/tests/suite/scripts/longevity-wrk-waf.sh
+++ b/tests/suite/scripts/longevity-wrk-waf.sh
@@ -51,8 +51,8 @@ fi
 # --- Clean traffic (wrk) ---
 # Two wrk instances mirror the two routes verified by the functional PLM tests.
 echo "Starting wrk clean traffic..."
-nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
-nohup wrk -t2 -c80 -d72h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
+nohup wrk -t2 -c80 -d2h "http://${WAF_HOST}/coffee" >~/waf-coffee.txt 2>&1 &
+nohup wrk -t2 -c80 -d2h "http://${WAF_HOST}/tea" >~/waf-tea.txt 2>&1 &
 
 # --- Attack traffic loop ---
 # XSS payload matches the functional PLM test (</script> encoded), SQLi on tea.
@@ -68,21 +68,31 @@ nohup bash -c '
     while true; do
         TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-        # XSS probe on /coffee — </script> matches the functional PLM test payload
-        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+        # XSS probe on /coffee — </script> matches the functional PLM test payload.
+        # NAP WAF blocks with HTTP 200 + "Request Rejected" body by default; also handle
+        # explicit 403 when APPolicy response-pages is configured.
+        RESPONSE=$(curl -s -w "\n%{http_code}" \
             "http://${WAF_HOST}/coffee?x=${xss_payload}" \
-            2>/dev/null || echo "000")
+            2>/dev/null || echo -e "\n000")
+        STATUS=$(printf '%s' "${RESPONSE}" | tail -1)
+        BODY=$(printf '%s' "${RESPONSE}" | head -n -1)
         BLOCKED="false"
-        [[ "${STATUS}" == "200" ]] || BLOCKED="true"
+        if [[ "${STATUS}" != "200" ]] || echo "${BODY}" | grep -qi "request rejected"; then
+            BLOCKED="true"
+        fi
         echo "${TS},/coffee,xss,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"
 
         # SQLi probe on /tea
-        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+        RESPONSE=$(curl -s -w "\n%{http_code}" \
             --data-urlencode "q=${sqli_payload}" \
             "http://${WAF_HOST}/tea" \
-            2>/dev/null || echo "000")
+            2>/dev/null || echo -e "\n000")
+        STATUS=$(printf '%s' "${RESPONSE}" | tail -1)
+        BODY=$(printf '%s' "${RESPONSE}" | head -n -1)
         BLOCKED="false"
-        [[ "${STATUS}" == "200" ]] || BLOCKED="true"
+        if [[ "${STATUS}" != "200" ]] || echo "${BODY}" | grep -qi "request rejected"; then
+            BLOCKED="true"
+        fi
         echo "${TS},/tea,sqli,${STATUS},${BLOCKED}" >> "${ATTACK_FILE}"
 
         sleep 5

--- a/tests/suite/scripts/longevity-wrk.sh
+++ b/tests/suite/scripts/longevity-wrk.sh
@@ -44,5 +44,5 @@ if ((ELAPSED >= MAX_WAIT)); then
     exit 1
 fi
 
-nohup wrk -t2 -c100 -d72h http://cafe.example.com/coffee &>~/coffee.txt &
-nohup wrk -t2 -c100 -d72h https://cafe.example.com/tea &>~/tea.txt &
+nohup wrk -t2 -c100 -d1h http://cafe.example.com/coffee &>~/coffee.txt &
+nohup wrk -t2 -c100 -d1h https://cafe.example.com/tea &>~/tea.txt &

--- a/tests/suite/scripts/longevity-wrk.sh
+++ b/tests/suite/scripts/longevity-wrk.sh
@@ -44,5 +44,5 @@ if ((ELAPSED >= MAX_WAIT)); then
     exit 1
 fi
 
-nohup wrk -t2 -c100 -d1h http://cafe.example.com/coffee &>~/coffee.txt &
-nohup wrk -t2 -c100 -d1h https://cafe.example.com/tea &>~/tea.txt &
+nohup wrk -t2 -c100 -d72h http://cafe.example.com/coffee &>~/coffee.txt &
+nohup wrk -t2 -c100 -d72h https://cafe.example.com/tea &>~/tea.txt &


### PR DESCRIPTION
### Proposed changes

Problem: We would like WAF + PLM to be tested in our NFR tests, more specifically the longevity test, to check that the feature is stable and working correctly.

Solution: On plus clusters with WAF+PLM enabled, a separate NGF deployment is deployed, with an associated WAF enabled Gateway. Normal wrk traffic and attack traffic are sent to the waf specific Gateway. A new file named "waf-attacks.txt" is created at the end of the longevity test which shows traffic being correctly blocked.

Testing: Confirmed normal wrk traffic to oss and plus clusters in addition to attack traffic to waf specific cluster works correctly. Confirmed longevity cluster without waf enabled still works as usual.

Please focus on: It was an intentional choice to spin up a separate NGF deployment and waf-enabled gateway pod to run alongside the normal plus NGF/NGINX pods in the waf-enabled longevity run. I believe this would more closely match a production scenario instead of a single NGF pod with a waf-enabled gateway pod and a normal nginx plus gateway pod, but I can change it if we think differently. 

Closes #3462 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Add WAF and PLM enabled NGF deployment to longevity NFR test.
```
