### PR TITLE
Apply TargetConflict reason to policies targeting HTTPRoutes that share a hostname

### DIFF
--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -695,29 +695,31 @@ func checkForRouteOverlap(route *L7Route, gatewayHostPortPaths map[string]string
 			port := parentRef.Attachment.ListenerPort
 			// FIXME(sarthyparty): https://github.com/nginx/nginx-gateway-fabric/issues/3811
 			// Need to merge listener hostnames with route hostnames so wildcards are handled correctly
-			// Also the AcceptedHostnames is a map of slices of strings, so we need to flatten it
-			for _, hostname := range parentRef.Attachment.AcceptedHostnames {
-				for _, rule := range route.Spec.Rules {
-					for _, match := range rule.Matches {
-						if match.Path != nil && match.Path.Value != nil {
-							// Use GatewayNsName to ensure overlap detection works across routes
-							// attached directly to a Gateway and those attached via ListenerSet.
-							key := fmt.Sprintf(
-								"%s:%s:%d%s",
-								parentRef.GatewayNsName.String(),
-								hostname,
-								port,
-								*match.Path.Value,
-							)
-							if val, ok := gatewayHostPortPaths[key]; ok && val != currentRouteName {
-								msg := fmt.Sprintf(
-									"Policy cannot be applied to target %q since another "+
-										"Route %q shares a namespace/gateway-name:hostname:port/path combination with this target",
-									val, currentRouteName,
+			for _, hostnames := range parentRef.Attachment.AcceptedHostnames {
+				for _, hostname := range hostnames {
+					for _, rule := range route.Spec.Rules {
+						for _, match := range rule.Matches {
+							if match.Path != nil && match.Path.Value != nil {
+								// Use GatewayNsName to ensure overlap detection works across routes
+								// attached directly to a Gateway and those attached via ListenerSet.
+								key := fmt.Sprintf(
+									"%s:%s:%d%s",
+									parentRef.GatewayNsName.String(),
+									hostname,
+									port,
+									*match.Path.Value,
 								)
-								cond := conditions.NewPolicyNotAcceptedTargetConflict(msg)
+								if val, ok := gatewayHostPortPaths[key]; ok && val != currentRouteName {
+									msg := fmt.Sprintf(
+										"Policy cannot be applied to target %q since another "+
+											"Route %q shares a namespace/gateway-name:hostname:port/path "+
+											"combination with this target",
+										val, currentRouteName,
+									)
+									cond := conditions.NewPolicyNotAcceptedTargetConflict(msg)
 
-								return &cond
+									return &cond
+								}
 							}
 						}
 					}
@@ -738,18 +740,20 @@ func buildGatewayHostPortPaths(route *L7Route) map[string]string {
 	for _, parentRef := range route.ParentRefs {
 		if parentRef.Attachment != nil {
 			port := parentRef.Attachment.ListenerPort
-			for _, hostname := range parentRef.Attachment.AcceptedHostnames {
-				for _, rule := range route.Spec.Rules {
-					for _, match := range rule.Matches {
-						if match.Path != nil && match.Path.Value != nil {
-							key := fmt.Sprintf(
-								"%s:%s:%d%s",
-								parentRef.GatewayNsName.String(),
-								hostname,
-								port,
-								*match.Path.Value,
-							)
-							gatewayHostPortPaths[key] = routeName
+			for _, hostnames := range parentRef.Attachment.AcceptedHostnames {
+				for _, hostname := range hostnames {
+					for _, rule := range route.Spec.Rules {
+						for _, match := range rule.Matches {
+							if match.Path != nil && match.Path.Value != nil {
+								key := fmt.Sprintf(
+									"%s:%s:%d%s",
+									parentRef.GatewayNsName.String(),
+									hostname,
+									port,
+									*match.Path.Value,
+								)
+								gatewayHostPortPaths[key] = routeName
+							}
 						}
 					}
 				}

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -1480,6 +1480,36 @@ func TestProcessPolicies_RouteOverlap(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name:      "overlap detected when routes share a hostname but have different hostname sets",
+			validator: &policiesfakes.FakeValidator{},
+			policies: map[PolicyKey]policies.Policy{
+				pol1Key: pol1,
+			},
+			routes: map[RouteKey]*L7Route{
+				// hr-coffee: the route targeted by pol1's targetRef
+				{
+					RouteType:      RouteTypeHTTP,
+					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "hr-coffee"},
+				}: createTestRouteWithPaths("hr-coffee", "/coffee"),
+				// hr-multi-host: not targeted by pol1, but present in the cluster and overlapping on foo.example.com:/coffee
+				{
+					RouteType:      RouteTypeHTTP,
+					NamespacedName: types.NamespacedName{Namespace: testNs, Name: "hr-multi-host"},
+				}: createTestRouteWithMultipleHostnames("hr-multi-host", "/coffee"),
+			},
+			valid: false,
+			expConditions: []conditions.Condition{
+				{
+					Type:   "Accepted",
+					Status: "False",
+					Reason: "TargetConflict",
+					Message: "Policy cannot be applied to target \"test/hr-coffee\" since another Route " +
+						"\"test/hr-multi-host\" shares a namespace/gateway-name:hostname:port/path " +
+						"combination with this target",
+				},
+			},
+		},
 	}
 
 	gateways := map[types.NamespacedName]*Gateway{
@@ -1930,6 +1960,47 @@ func createTestRouteWithMultipleGateways(name string, gatewayNames []string, pat
 	}
 
 	return route
+}
+
+// createTestRouteWithMultipleHostnames creates a route with multiple accepted hostnames on the same listener.
+func createTestRouteWithMultipleHostnames(name string, paths ...string) *L7Route {
+	routeMatches := make([]v1.HTTPRouteMatch, 0, len(paths))
+
+	for _, path := range paths {
+		routeMatches = append(routeMatches, v1.HTTPRouteMatch{
+			Path: &v1.HTTPPathMatch{
+				Type:  helpers.GetPointer(v1.PathMatchExact),
+				Value: helpers.GetPointer(path),
+			},
+		})
+	}
+
+	gwNsName := types.NamespacedName{Namespace: testNs, Name: "gw"}
+	return &L7Route{
+		Source: &v1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNs,
+			},
+		},
+		Spec: L7RouteSpec{
+			Rules: []RouteRule{
+				{Matches: routeMatches},
+			},
+		},
+		ParentRefs: []ParentRef{
+			{
+				Kind:           kinds.Gateway,
+				NamespacedName: gwNsName,
+				GatewayNsName:  gwNsName,
+				Attachment: &ParentRefAttachmentStatus{
+					// Two hostnames: foo.example.com (shared with other routes) and bar.example.com (extra).
+					AcceptedHostnames: map[string][]string{"listener-1": {"foo.example.com", "bar.example.com"}},
+					ListenerPort:      80,
+				},
+			},
+		},
+	}
 }
 
 func getGatewayParentRef(gwNsName types.NamespacedName) v1.ParentReference {

--- a/tests/suite/client_settings_test.go
+++ b/tests/suite/client_settings_test.go
@@ -377,6 +377,36 @@ var _ = Describe("ClientSettingsPolicy", Ordered, Label("functional", "cspolicy"
 			})
 		})
 	})
+
+	// Test: overlap-route-1 (hostname "overlap.example.com") and overlap-route-2
+	// (hostnames "overlap.example.com" and "b.example.com") share the same
+	// gateway:hostname:port/path on "overlap.example.com" with PathPrefix "/",
+	// differentiated only by a header match. Given both routes share a hostname (overlap.example.com)
+	// they are still considered as overlapping.
+	// The CSP targets overlap-route-1 directly. Because the target route overlaps
+	// with overlap-route-2, the CSP must receive a TargetConflict (Accepted: False).
+	Context("TargetConflict with overlapping routes", func() {
+		When("the CSP targets a route that overlaps with another route that has an additional hostname", func() {
+			overlapConflictFiles := []string{
+				"clientsettings/target-conflict-routes-hostname-set.yaml",
+				"clientsettings/overlap-target-csp.yaml",
+			}
+
+			BeforeAll(func() {
+				Expect(resourceManager.ApplyFromFiles(overlapConflictFiles, namespace)).To(Succeed())
+				Expect(resourceManager.WaitForAppsToBeReady(namespace)).To(Succeed())
+			})
+
+			AfterAll(func() {
+				Expect(resourceManager.DeleteFromFiles(overlapConflictFiles, namespace)).To(Succeed())
+			})
+
+			Specify("the policy is conflicted because the target route overlaps with another route", func() {
+				nsname := types.NamespacedName{Name: "overlap-target-csp", Namespace: namespace}
+				Expect(waitForCSPolicyToHaveTargetConflict(nsname)).To(Succeed())
+			})
+		})
+	})
 })
 
 func waitForCSPolicyToBeAccepted(policyNsname types.NamespacedName) error {
@@ -405,6 +435,23 @@ func waitForCSPolicyToBeConflicted(policyNsname types.NamespacedName) error {
 		policyNsname,
 		metav1.ConditionFalse,
 		v1.PolicyReasonConflicted,
+	)
+}
+
+func waitForCSPolicyToHaveTargetConflict(policyNsname types.NamespacedName) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
+	defer cancel()
+
+	GinkgoWriter.Printf(
+		"Waiting for ClientSettingsPolicy %q to have the condition Accepted/False/TargetConflict\n",
+		policyNsname,
+	)
+
+	return waitForClientSettingsAncestorStatus(
+		ctx,
+		policyNsname,
+		metav1.ConditionFalse,
+		"TargetConflict",
 	)
 }
 

--- a/tests/suite/manifests/clientsettings/overlap-target-csp.yaml
+++ b/tests/suite/manifests/clientsettings/overlap-target-csp.yaml
@@ -1,0 +1,16 @@
+# ClientSettingsPolicy targeting overlap-route-1.
+# Because overlap-route-1 and overlap-route-2 share hostname "overlap.example.com"
+# with PathPrefix "/" (differing only by a header match), they overlap.
+# A CSP targeting one of these overlapping routes must receive a TargetConflict
+# (Accepted: False, Reason: Conflicted).
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: overlap-target-csp
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: overlap-route-1
+  body:
+    maxSize: "5000"

--- a/tests/suite/manifests/clientsettings/overlap-target-csp.yaml
+++ b/tests/suite/manifests/clientsettings/overlap-target-csp.yaml
@@ -2,7 +2,7 @@
 # Because overlap-route-1 and overlap-route-2 share hostname "overlap.example.com"
 # with PathPrefix "/" (differing only by a header match), they overlap.
 # A CSP targeting one of these overlapping routes must receive a TargetConflict
-# (Accepted: False, Reason: Conflicted).
+# (Accepted: False, Reason: TargetConflict).
 apiVersion: gateway.nginx.org/v1alpha1
 kind: ClientSettingsPolicy
 metadata:

--- a/tests/suite/manifests/clientsettings/target-conflict-routes-hostname-set.yaml
+++ b/tests/suite/manifests/clientsettings/target-conflict-routes-hostname-set.yaml
@@ -2,7 +2,7 @@
 # one with hostname "overlap.example.com" with PathPrefix "/".
 # one with hostname "overlap.example.com, b.example.com" with PathPrefix "/" and a header match.
 # Given they share one of the same hostnames, they should generate the same gateway:hostname:port/path.
-# For a policy targeting either route, a TargetConflict should be generated due this overlap.
+# For a policy targeting either route, a TargetConflict should be generated due to this overlap.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/tests/suite/manifests/clientsettings/target-conflict-routes-hostname-set.yaml
+++ b/tests/suite/manifests/clientsettings/target-conflict-routes-hostname-set.yaml
@@ -1,0 +1,46 @@
+# Two HTTPRoutes:
+# one with hostname "overlap.example.com" with PathPrefix "/".
+# one with hostname "overlap.example.com, b.example.com" with PathPrefix "/" and a header match.
+# Given they share one of the same hostnames, they should generate the same gateway:hostname:port/path.
+# For a policy targeting either route, a TargetConflict should be generated due this overlap.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overlap-route-1
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "overlap.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: coffee
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overlap-route-2
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "overlap.example.com"
+  - "b.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: X-Version
+        value: v2
+    backendRefs:
+    - name: tea
+      port: 80


### PR DESCRIPTION
### Proposed changes

Problem: A Policy targeting a HTTPRoute which shares the same Gateway, hostname, port and path is currently applied to only one of these routes. This can cause inconsistent behavour in deployments where these HTTPRoutes differ in how they accept traffic (i.e. having the same hostname, port and path, but different header matching for A/B testing).

Solution: Set `Accepted: False` condition for any Policy targeting a `HTTPRoute` where the `HTTPRoute` shares the same `gateway:hostname:port/path` as another `HTTPRoute`

Testing: 
- Manually tested on local kind cluster. 
- Added new functional test "TargetConflict with overlapping routes" which validates the `TargetConflict` reason is applied to a Policy in a scenario where two HTTPRoutes share a hostname.

Closes https://github.com/nginx/nginx-gateway-fabric/issues/5425

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
