### PR TITLE
helm: add hook-delete-policy + pre-upgrade to cert-generator RBAC

### DIFF
--- a/charts/nginx-gateway-fabric/templates/certs-job.yaml
+++ b/charts/nginx-gateway-fabric/templates/certs-job.yaml
@@ -7,7 +7,8 @@ metadata:
   labels:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 automountServiceAccountToken: false
 {{- if or .Values.nginxGateway.serviceAccount.imagePullSecret .Values.nginxGateway.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
@@ -29,7 +30,8 @@ metadata:
   labels:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups:
   - ""
@@ -48,7 +50,8 @@ metadata:
   labels:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -67,7 +70,8 @@ metadata:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 allowPrivilegeEscalation: false
 allowHostDirVolumePlugin: false
 allowHostIPC: false


### PR DESCRIPTION
### Proposed changes

**Problem:** The pre-install hook resources for the cert-generator (`ServiceAccount`, `Role`, `RoleBinding`, `SecurityContextConstraints`) in `charts/nginx-gateway-fabric/templates/certs-job.yaml` carry only `"helm.sh/hook": pre-install` — no `helm.sh/hook-delete-policy`, and no `pre-upgrade` scope. Two consequences:

1. After `helm install`, the RBAC resources stay in the cluster as orphans. Helm doesn't track them, and they're left behind on uninstall.
2. ArgoCD users see the orphans in `Synced` state with no health status, which leaves the Application in `Degraded` health indefinitely even though the controller Pod, `GatewayClass`, `Gateway` (`PROGRAMMED=True`), and `Service type=LoadBalancer` are all healthy. This is the same symptom reported in the now-closed [#4904](https://github.com/nginx/nginx-gateway-fabric/pull/4904).
3. On `helm upgrade`, the cert-generator Job re-runs (it's already annotated `pre-install, pre-upgrade`), but its supporting SA/Role/RoleBinding/SCC are not — so the upgrade path relies on the pre-install resources still being there. If they were ever pruned (e.g. ArgoCD pruning orphans), the upgrade Job would fail.

**Solution:** On each of the four cert-generator hook resources:

- Add `"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded` — Helm now deletes the resources after the hook Job succeeds, and re-creates them cleanly on the next install/upgrade.
- Extend `"helm.sh/hook"` to `pre-install, pre-upgrade` — aligns with the Job, so the supporting RBAC exists for both phases.

The Job itself is left untouched (already `pre-install, pre-upgrade`; users may want to keep the Job around for debugging via `certGenerator.annotations`).

**Testing:** Reproduced the orphan-resource / ArgoCD Degraded behavior on a live OKE cluster running v2.6.3 via the Naviteq umbrella chart. After applying this change in the rendered manifests:
- `helm install` → cert-generator hooks run, RBAC/SA/SCC are gone after `hook-succeeded`, controller Pod + Gateway + LoadBalancer all reach Healthy.
- ArgoCD Application transitions from `Synced/Degraded` to `Synced/Healthy`.
- `helm upgrade` → Job re-runs cleanly with fresh RBAC.

**Please focus on:** the scope alignment between the RBAC resources and the Job (both now `pre-install, pre-upgrade`). Confirm this matches the cert-rotation intent — the Job already supports both phases, so this just makes the supporting resources match.

Closes the cert-generator-orphan symptom from [#4904](https://github.com/nginx/nginx-gateway-fabric/pull/4904) with a smaller, more focused fix.

Closes #4896 

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I will agree to the F5 CLA on PR creation
- [x] I have updated necessary documentation (template-only change; no values added)
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Add `helm.sh/hook-delete-policy` and `pre-upgrade` scope to cert-generator RBAC hook resources so Helm cleans them up after each install/upgrade. Removes orphan `ServiceAccount`/`Role`/`RoleBinding`/`SecurityContextConstraints` resources that left ArgoCD Applications in `Degraded` state.
```
