### PR TITLE
Refactor createHTTPFilters to remove gocyclo nolint

### DIFF
--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -1791,7 +1791,6 @@ func getPath(path *v1.HTTPPathMatch) string {
 	return *path.Value
 }
 
-//nolint:gocyclo
 func createHTTPFilters(
 	filters []graph.Filter,
 	ruleIdx int,
@@ -1806,65 +1805,115 @@ func createHTTPFilters(
 	for _, f := range filters {
 		switch f.FilterType {
 		case graph.FilterRequestRedirect:
-			if result.RequestRedirect == nil {
-				// using the first filter
-				result.RequestRedirect = convertHTTPRequestRedirectFilter(f.RequestRedirect)
-			}
+			result.addRequestRedirect(f.RequestRedirect)
 		case graph.FilterURLRewrite:
-			if result.RequestURLRewrite == nil {
-				// using the first filter
-				result.RequestURLRewrite = convertHTTPURLRewriteFilter(f.URLRewrite)
-			}
+			result.addURLRewrite(f.URLRewrite)
 		case graph.FilterRequestMirror:
-			result.RequestMirrors = append(
-				result.RequestMirrors,
-				convertHTTPRequestMirrorFilter(f.RequestMirror, ruleIdx, routeNsName),
-			)
+			result.addRequestMirror(f.RequestMirror, ruleIdx, routeNsName)
 		case graph.FilterRequestHeaderModifier:
-			if result.RequestHeaderModifiers == nil {
-				// using the first filter
-				result.RequestHeaderModifiers = convertHTTPHeaderFilter(f.RequestHeaderModifier)
-			}
+			result.addRequestHeaderModifier(f.RequestHeaderModifier)
 		case graph.FilterResponseHeaderModifier:
-			if result.ResponseHeaderModifiers == nil {
-				// using the first filter
-				result.ResponseHeaderModifiers = convertHTTPHeaderFilter(f.ResponseHeaderModifier)
-			}
+			result.addResponseHeaderModifier(f.ResponseHeaderModifier)
 		case graph.FilterExtensionRef:
-			if f.ResolvedExtensionRef != nil {
-				if f.ResolvedExtensionRef.SnippetsFilter != nil {
-					result.SnippetsFilters = append(
-						result.SnippetsFilters,
-						convertSnippetsFilter(f.ResolvedExtensionRef.SnippetsFilter),
-					)
-				}
-				if f.ResolvedExtensionRef.AuthenticationFilter != nil {
-					result.AuthenticationFilter = convertAuthenticationFilter(
-						f.ResolvedExtensionRef.AuthenticationFilter,
-						referencedSecrets,
-					)
-				}
-			}
+			result.addExtensionRef(f.ResolvedExtensionRef, referencedSecrets)
 		case graph.FilterCORS:
-			if result.CORSFilter == nil {
-				result.CORSFilter = convertHTTPCORSFilter(f.CORS)
-			}
+			result.addCORS(f.CORS)
 		case graph.FilterExternalAuth:
-			if result.ExternalAuthFilter == nil {
-				for _, br := range backendRefs {
-					if br.IsExternalAuthBackend && br.Valid {
-						result.ExternalAuthFilter = convertHTTPExternalAuthFilter(f.ExternalAuth, br, routeNsName, ruleIdx, gwNsName)
-						if result.ExternalAuthFilter.VerifyTLS != nil && extAuthCertBundleIDs != nil {
-							extAuthCertBundleIDs[result.ExternalAuthFilter.VerifyTLS.CertBundleID] = struct{}{}
-						}
-						break
-					}
-				}
-			}
+			result.addExternalAuth(f.ExternalAuth, backendRefs, routeNsName, ruleIdx, gwNsName, extAuthCertBundleIDs)
 		}
 	}
 
 	return result
+}
+
+func (hf *HTTPFilters) addRequestRedirect(redirect *v1.HTTPRequestRedirectFilter) {
+	if hf.RequestRedirect == nil {
+		// using the first filter
+		hf.RequestRedirect = convertHTTPRequestRedirectFilter(redirect)
+	}
+}
+
+func (hf *HTTPFilters) addURLRewrite(rewrite *v1.HTTPURLRewriteFilter) {
+	if hf.RequestURLRewrite == nil {
+		// using the first filter
+		hf.RequestURLRewrite = convertHTTPURLRewriteFilter(rewrite)
+	}
+}
+
+func (hf *HTTPFilters) addRequestMirror(
+	mirror *v1.HTTPRequestMirrorFilter,
+	ruleIdx int,
+	routeNsName types.NamespacedName,
+) {
+	hf.RequestMirrors = append(
+		hf.RequestMirrors,
+		convertHTTPRequestMirrorFilter(mirror, ruleIdx, routeNsName),
+	)
+}
+
+func (hf *HTTPFilters) addRequestHeaderModifier(modifier *v1.HTTPHeaderFilter) {
+	if hf.RequestHeaderModifiers == nil {
+		// using the first filter
+		hf.RequestHeaderModifiers = convertHTTPHeaderFilter(modifier)
+	}
+}
+
+func (hf *HTTPFilters) addResponseHeaderModifier(modifier *v1.HTTPHeaderFilter) {
+	if hf.ResponseHeaderModifiers == nil {
+		// using the first filter
+		hf.ResponseHeaderModifiers = convertHTTPHeaderFilter(modifier)
+	}
+}
+
+func (hf *HTTPFilters) addExtensionRef(
+	ref *graph.ExtensionRefFilter,
+	referencedSecrets map[types.NamespacedName]*secrets.Secret,
+) {
+	if ref == nil {
+		return
+	}
+
+	if ref.SnippetsFilter != nil {
+		hf.SnippetsFilters = append(
+			hf.SnippetsFilters,
+			convertSnippetsFilter(ref.SnippetsFilter),
+		)
+	}
+	if ref.AuthenticationFilter != nil {
+		hf.AuthenticationFilter = convertAuthenticationFilter(
+			ref.AuthenticationFilter,
+			referencedSecrets,
+		)
+	}
+}
+
+func (hf *HTTPFilters) addCORS(cors *v1.HTTPCORSFilter) {
+	if hf.CORSFilter == nil {
+		hf.CORSFilter = convertHTTPCORSFilter(cors)
+	}
+}
+
+func (hf *HTTPFilters) addExternalAuth(
+	extAuth *v1.HTTPExternalAuthFilter,
+	backendRefs []graph.BackendRef,
+	routeNsName types.NamespacedName,
+	ruleIdx int,
+	gwNsName types.NamespacedName,
+	extAuthCertBundleIDs map[CertBundleID]struct{},
+) {
+	if hf.ExternalAuthFilter != nil {
+		return
+	}
+
+	for _, br := range backendRefs {
+		if br.IsExternalAuthBackend && br.Valid {
+			hf.ExternalAuthFilter = convertHTTPExternalAuthFilter(extAuth, br, routeNsName, ruleIdx, gwNsName)
+			if hf.ExternalAuthFilter.VerifyTLS != nil && extAuthCertBundleIDs != nil {
+				extAuthCertBundleIDs[hf.ExternalAuthFilter.VerifyTLS.CertBundleID] = struct{}{}
+			}
+			break
+		}
+	}
 }
 
 // listenerHostnameMoreSpecific returns true if host1 is more specific than host2.


### PR DESCRIPTION
### Proposed changes

Problem: `createHTTPFilters` (internal/controller/state/dataplane/configuration.go) carries a `//nolint:gocyclo`. Its single for/switch over filter types pushed cyclomatic complexity to ~24, well past the project `min-complexity: 15` gate.

Solution: decompose per-filter-type handling into 8 `*HTTPFilters` methods (addRequestRedirect / addURLRewrite / addRequestMirror / addRequestHeaderModifier / addResponseHeaderModifier / addExtensionRef / addCORS / addExternalAuth). The for loop now only dispatches each case to a method, dropping the dispatcher complexity to 10 and removing the `//nolint:gocyclo`. Behavior is unchanged: the "first filter wins" guard, the external-auth backend-ref scan, the break, and the cert-bundle-ID map mutation are all preserved. The two `if X != nil { ... }` blocks were converted to `if X == nil { return }` early-returns (equivalent).

This is one slice of #5253 (removing the nolint:gocyclo suppressions function by function).

Validation:
- `go test ./internal/controller/state/dataplane/...` → pass (existing `TestCreateFilters` + `TestCreateFiltersExternalAuthSkipsInvalidBackendRef` tables unchanged and green → behavior preserved)
- `golangci-lint run ./internal/controller/state/dataplane/...` → 0 issues (gocyclo threshold cleared)
- gofmt / go vet / go build clean

related: #5253

```release-note
NONE
```