### PR TITLE
Sort map-derived NGINX config for deterministic output (#5486)

### DIFF
--- a/internal/controller/nginx/config/maps.go
+++ b/internal/controller/nginx/config/maps.go
@@ -310,8 +310,16 @@ func buildAddHeaderMaps(servers []dataplane.VirtualServer) []shared.Map {
 		}
 	}
 
-	maps := make([]shared.Map, 0, len(addHeaderNames))
+	// Sort the names so that the maps are emitted in a stable order and identical
+	// input doesn't trigger an unnecessary reload.
+	names := make([]string, 0, len(addHeaderNames))
 	for m := range addHeaderNames {
+		names = append(names, m)
+	}
+	sort.Strings(names)
+
+	maps := make([]shared.Map, 0, len(names))
+	for _, m := range names {
 		maps = append(maps, createAddHeadersMap(m))
 	}
 	return maps

--- a/internal/controller/nginx/config/maps_test.go
+++ b/internal/controller/nginx/config/maps_test.go
@@ -119,6 +119,10 @@ func TestExecuteMaps(t *testing.T) {
 func TestBuildAddHeaderMaps(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
+	// Add headers are deliberately provided in non-alphabetical order (and with a duplicate) so the
+	// expected maps below verify that the output is deduplicated and emitted in a stable, sorted
+	// order. The maps are derived from a Go map, whose iteration order is randomized; emitting them
+	// unsorted causes spurious NGINX reloads.
 	pathRules := []dataplane.PathRule{
 		{
 			MatchRules: []dataplane.MatchRule{
@@ -126,6 +130,10 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Add: []dataplane.HTTPHeader{
+								{
+									Name:  "my-zeta-add-header",
+									Value: "some-value-123",
+								},
 								{
 									Name:  "my-add-header",
 									Value: "some-value-123",
@@ -159,6 +167,10 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 							},
 							Add: []dataplane.HTTPHeader{
 								{
+									Name:  "my-alpha-add-header",
+									Value: "some-value-123",
+								},
+								{
 									Name:  "my-add-header",
 									Value: "some-value-123",
 								},
@@ -181,6 +193,7 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 			IsDefault: true,
 		},
 	}
+	// expectedMap is in alphabetical order, matching the deterministic order buildAddHeaderMaps emits.
 	expectedMap := []shared.Map{
 		{
 			Source:   "${http_my_add_header}",
@@ -190,6 +203,17 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 				{
 					Value:  "~.*",
 					Result: "${http_my_add_header},",
+				},
+			},
+		},
+		{
+			Source:   "${http_my_alpha_add_header}",
+			Variable: "$my_alpha_add_header_header_var",
+			Parameters: []shared.MapParameter{
+				{Value: "default", Result: "''"},
+				{
+					Value:  "~.*",
+					Result: "${http_my_alpha_add_header},",
 				},
 			},
 		},
@@ -204,10 +228,21 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 				},
 			},
 		},
+		{
+			Source:   "${http_my_zeta_add_header}",
+			Variable: "$my_zeta_add_header_header_var",
+			Parameters: []shared.MapParameter{
+				{Value: "default", Result: "''"},
+				{
+					Value:  "~.*",
+					Result: "${http_my_zeta_add_header},",
+				},
+			},
+		},
 	}
 	maps := buildAddHeaderMaps(testServers)
 
-	g.Expect(maps).To(ConsistOf(expectedMap))
+	g.Expect(maps).To(Equal(expectedMap))
 }
 
 func TestExecuteStreamMaps(t *testing.T) {

--- a/internal/controller/nginx/config/policies/upstreamsettings/validator.go
+++ b/internal/controller/nginx/config/policies/upstreamsettings/validator.go
@@ -2,6 +2,7 @@ package upstreamsettings
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -202,5 +203,7 @@ func getLoadBalancingMethodList(lbMethods map[ngfAPI.LoadBalancingType]struct{})
 	for method := range lbMethods {
 		methods = append(methods, string(method))
 	}
+	// Sort so that the error message is deterministic regardless of map iteration order.
+	sort.Strings(methods)
 	return strings.Join(methods, ", ")
 }

--- a/internal/controller/nginx/config/policies/upstreamsettings/validator_test.go
+++ b/internal/controller/nginx/config/policies/upstreamsettings/validator_test.go
@@ -1,6 +1,7 @@
 package upstreamsettings_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -17,6 +18,18 @@ import (
 )
 
 const plusDisabled = false
+
+// Expected, deterministically-ordered list of supported load balancing methods in validation error
+// messages. The methods are derived from a Go map, so the validator sorts them; asserting against
+// these exact strings verifies that ordering stays stable.
+const (
+	ossLBMethods = "hash, hash consistent, ip_hash, least_conn, " +
+		"random, random two, random two least_conn, round_robin"
+	plusLBMethods = "hash, hash consistent, ip_hash, least_conn, least_time header, " +
+		"least_time header inflight, least_time last_byte, least_time last_byte inflight, " +
+		"random, random two, random two least_conn, random two least_time=header, " +
+		"random two least_time=last_byte, round_robin"
+)
 
 type policyModFunc func(policy *ngfAPI.UpstreamSettingsPolicy) *ngfAPI.UpstreamSettingsPolicy
 
@@ -334,7 +347,7 @@ func TestValidate_ValidateLoadBalancingMethod(t *testing.T) {
 			},
 			expConditions: []conditions.Condition{
 				conditions.NewPolicyInvalid("spec.loadBalancingMethod: Invalid value: \"least_time last_byte\": " +
-					"NGINX OSS supports the following load balancing methods: "),
+					"NGINX OSS supports the following load balancing methods: " + ossLBMethods),
 			},
 		},
 		{
@@ -356,7 +369,7 @@ func TestValidate_ValidateLoadBalancingMethod(t *testing.T) {
 			},
 			expConditions: []conditions.Condition{
 				conditions.NewPolicyInvalid("spec.loadBalancingMethod: Invalid value: \"invalid-method\": " +
-					"NGINX OSS supports the following load balancing methods: "),
+					"NGINX OSS supports the following load balancing methods: " + ossLBMethods),
 			},
 		},
 		{
@@ -368,7 +381,7 @@ func TestValidate_ValidateLoadBalancingMethod(t *testing.T) {
 			},
 			expConditions: []conditions.Condition{
 				conditions.NewPolicyInvalid("spec.loadBalancingMethod: Invalid value: \"invalid-method\": " +
-					"NGINX Plus supports the following load balancing methods: "),
+					"NGINX Plus supports the following load balancing methods: " + plusLBMethods),
 			},
 			plusEnabled: true,
 		},
@@ -384,7 +397,10 @@ func TestValidate_ValidateLoadBalancingMethod(t *testing.T) {
 
 			if test.expConditions != nil {
 				g.Expect(conds).To(HaveLen(1))
-				g.Expect(conds[0].Message).To(ContainSubstring(test.expConditions[0].Message))
+				fmt.Println(conds[0].Message)
+				g.Expect(conds[0].Message).To(Equal(test.expConditions[0].Message))
+			} else {
+				g.Expect(conds).To(BeNil())
 			}
 		})
 	}

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -282,7 +282,29 @@ func buildL4Servers(logger logr.Logger, gateway *graph.Gateway, protocol v1.Prot
 		}
 	}
 
+	// L4 routes are iterated from a map, so sort the resulting servers to produce a stable order.
+	// Preserve order so that this doesn't trigger an unnecessary reload.
+	sort.Slice(servers, func(i, j int) bool {
+		if servers[i].Port != servers[j].Port {
+			return servers[i].Port < servers[j].Port
+		}
+		if servers[i].Hostname != servers[j].Hostname {
+			return servers[i].Hostname < servers[j].Hostname
+		}
+		return layer4UpstreamsKey(servers[i].Upstreams) < layer4UpstreamsKey(servers[j].Upstreams)
+	})
+
 	return servers
+}
+
+// layer4UpstreamsKey builds a stable comparison key from a server's upstreams so that L4 servers
+// sharing the same port and hostname are ordered deterministically.
+func layer4UpstreamsKey(upstreams []Layer4Upstream) string {
+	names := make([]string, 0, len(upstreams))
+	for _, u := range upstreams {
+		names = append(names, u.Name)
+	}
+	return strings.Join(names, ",")
 }
 
 // buildStreamUpstreams builds all stream upstreams.
@@ -369,6 +391,12 @@ func buildStreamUpstreams(
 	for _, up := range uniqueUpstreams {
 		upstreams = append(upstreams, up)
 	}
+
+	// Preserve order so that this doesn't trigger an unnecessary reload.
+	sort.Slice(upstreams, func(i, j int) bool {
+		return upstreams[i].Name < upstreams[j].Name
+	})
+
 	return upstreams
 }
 

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -5232,25 +5232,27 @@ func TestBuildStreamUpstreams(t *testing.T) {
 		referencedServices,
 	)
 
+	// Upstreams are sorted by name so that identical input produces a stable order and doesn't
+	// trigger spurious NGINX reloads.
 	expectedStreamUpstreams := []Upstream{
-		{
-			Name:     "default_secure-app_8443",
-			ErrorMsg: "error",
-		},
-		{
-			Name:      "default_secure-app5_8443",
-			Endpoints: fakeEndpoints,
-		},
 		{
 			Name: "default_external-app_443",
 			Endpoints: []resolver.Endpoint{
 				{Address: "external.example.com", Port: 443, Resolve: true},
 			},
 		},
+		{
+			Name:      "default_secure-app5_8443",
+			Endpoints: fakeEndpoints,
+		},
+		{
+			Name:     "default_secure-app_8443",
+			ErrorMsg: "error",
+		},
 	}
 	g := NewWithT(t)
 
-	g.Expect(streamUpstreams).To(ConsistOf(expectedStreamUpstreams))
+	g.Expect(streamUpstreams).To(Equal(expectedStreamUpstreams))
 }
 
 func TestBuildL4Servers(t *testing.T) {
@@ -5481,7 +5483,7 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.TCPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
 		},
 		{
 			name: "skips routes with no valid backends",
@@ -5521,7 +5523,7 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.TCPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
 		},
 		{
 			name: "skips routes with empty backend refs",
@@ -5551,7 +5553,7 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.TCPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
 		},
 		{
 			name: "skips invalid listeners",
@@ -5591,7 +5593,7 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.TCPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
 		},
 		{
 			name: "filters by protocol - TCP listener ignored for UDP protocol",
@@ -5631,7 +5633,7 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.UDPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
 		},
 		{
 			name: "multiple listeners and routes",
@@ -5764,7 +5766,71 @@ func TestBuildL4Servers(t *testing.T) {
 				},
 			},
 			protocol:        v1.TCPProtocolType,
-			expectedServers: []Layer4VirtualServer{},
+			expectedServers: nil,
+		},
+		{
+			// L4Routes is a map (randomized iteration order). The route names are chosen so that map
+			// order differs from the expected output, verifying the servers are sorted deterministically.
+			name: "multiple TCP routes on the same listener are sorted by upstream",
+			gateway: &graph.Gateway{
+				Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "gateway",
+					},
+				},
+				Listeners: []*graph.Listener{
+					{
+						Name:  "tcp-listener",
+						Valid: true,
+						Source: v1.Listener{
+							Protocol: v1.TCPProtocolType,
+							Port:     8080,
+						},
+						L4Routes: map[graph.L4RouteKey]*graph.L4Route{
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-c"}}: createL4Route(
+								"route-c", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-c"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+							),
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-a"}}: createL4Route(
+								"route-a", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-a"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+							),
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-d"}}: createL4Route(
+								"route-d", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-d"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+							),
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-b"}}: createL4Route(
+								"route-b", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-b"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+							),
+						},
+					},
+				},
+			},
+			protocol: v1.TCPProtocolType,
+			expectedServers: []Layer4VirtualServer{
+				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-a_8080", Weight: 1}}},
+				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-b_8080", Weight: 1}}},
+				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-c_8080", Weight: 1}}},
+				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-d_8080", Weight: 1}}},
+			},
 		},
 	}
 
@@ -5775,7 +5841,8 @@ func TestBuildL4Servers(t *testing.T) {
 
 			servers := buildL4Servers(logr.Discard(), tt.gateway, tt.protocol)
 
-			g.Expect(servers).To(ConsistOf(tt.expectedServers))
+			// Equal (not ConsistOf) so that the deterministic, sorted order of servers is verified.
+			g.Expect(servers).To(Equal(tt.expectedServers))
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

Cherry-pick for #5486 

Testing: Removes `least_time` from OSSLBMethods error list since that change is not yet released

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed non-deterministic NGINX config output (stream upstreams, L4 servers, and add-header maps) that could cause spurious reloads.
```
