### PR TITLE
Fix agent startup race condition when waf is enabled

### DIFF
--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -25,6 +25,27 @@ const (
 	headerAuth = "authorization"
 )
 
+// PodCheckRetry controls how long validateToken will wait for the agent's Pod
+// to appear as Running in the cache. This handles a startup race where the
+// agent dials before NGF's Pod informer reflects the new Pod (for example, when
+// a WAF-enabled NGINX Pod starts and the agent dials before NGF has seen the
+// Pod's Running status, or while sidecars like waf-config-mgr are still
+// initializing).
+type PodCheckRetry struct {
+	// InitialBackoff is the initial wait between retries.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the per-attempt wait between retries.
+	MaxBackoff time.Duration
+	// Timeout is the total time spent retrying before giving up.
+	Timeout time.Duration
+}
+
+var defaultPodCheckRetry = PodCheckRetry{
+	InitialBackoff: 100 * time.Millisecond,
+	MaxBackoff:     1 * time.Second,
+	Timeout:        15 * time.Second,
+}
+
 // streamHandler is a struct that implements StreamHandler, allowing the interceptor to replace the context.
 type streamHandler struct {
 	grpc.ServerStream
@@ -38,12 +59,14 @@ func (sh *streamHandler) Context() context.Context {
 type ContextSetter struct {
 	k8sClient client.Client
 	audience  string
+	podCheck  PodCheckRetry
 }
 
 func NewContextSetter(k8sClient client.Client, audience string) ContextSetter {
 	return ContextSetter{
 		k8sClient: k8sClient,
 		audience:  audience,
+		podCheck:  defaultPodCheckRetry,
 	}
 }
 
@@ -54,7 +77,7 @@ func (c ContextSetter) Stream(logger logr.Logger) grpc.StreamServerInterceptor {
 		_ *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		ctx, err := c.validateConnection(ss.Context())
+		ctx, err := c.validateConnection(ss.Context(), logger)
 		if err != nil {
 			logger.Error(err, "error validating connection")
 			return err
@@ -73,7 +96,7 @@ func (c ContextSetter) Unary(logger logr.Logger) grpc.UnaryServerInterceptor {
 		_ *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp any, err error) {
-		if ctx, err = c.validateConnection(ctx); err != nil {
+		if ctx, err = c.validateConnection(ctx, logger); err != nil {
 			logger.Error(err, "error validating connection")
 			return nil, err
 		}
@@ -83,13 +106,13 @@ func (c ContextSetter) Unary(logger logr.Logger) grpc.UnaryServerInterceptor {
 
 // validateConnection checks that the connection is valid and returns a new
 // context containing information used by the gRPC command/file services.
-func (c ContextSetter) validateConnection(ctx context.Context) (context.Context, error) {
+func (c ContextSetter) validateConnection(ctx context.Context, logger logr.Logger) (context.Context, error) {
 	grpcInfo, err := getGrpcInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.validateToken(ctx, grpcInfo)
+	return c.validateToken(ctx, grpcInfo, logger)
 }
 
 func getGrpcInfo(ctx context.Context) (*grpcContext.GrpcInfo, error) {
@@ -114,7 +137,11 @@ func getGrpcInfo(ctx context.Context) (*grpcContext.GrpcInfo, error) {
 	}, nil
 }
 
-func (c ContextSetter) validateToken(ctx context.Context, grpcInfo *grpcContext.GrpcInfo) (context.Context, error) {
+func (c ContextSetter) validateToken(
+	ctx context.Context,
+	grpcInfo *grpcContext.GrpcInfo,
+	logger logr.Logger,
+) (context.Context, error) {
 	tokenReview := &authv1.TokenReview{
 		Spec: authv1.TokenReviewSpec{
 			Audiences: []string{c.audience},
@@ -142,32 +169,87 @@ func (c ContextSetter) validateToken(ctx context.Context, grpcInfo *grpcContext.
 		return nil, status.Error(codes.Unauthenticated, msg)
 	}
 
-	getCtx, getCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer getCancel()
+	saNamespace := usernameItems[2]
+	saName := usernameItems[3]
 
-	var podList corev1.PodList
 	opts := &client.ListOptions{
-		Namespace: usernameItems[2],
+		Namespace: saNamespace,
 		LabelSelector: labels.Set(map[string]string{
-			controller.AppNameLabel: usernameItems[3],
+			controller.AppNameLabel: saName,
 		}).AsSelector(),
 	}
 
-	if err := c.k8sClient.List(getCtx, &podList, opts); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error listing pods: %s", err.Error()))
-	}
-
-	runningCount := 0
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == corev1.PodRunning {
-			runningCount++
-		}
-	}
-
-	if runningCount < 1 {
-		msg := fmt.Sprintf("no running pods found for service account %s/%s", usernameItems[2], usernameItems[3])
-		return nil, status.Error(codes.Unauthenticated, msg)
+	if err := c.waitForRunningPod(ctx, logger, opts, saNamespace, saName); err != nil {
+		return nil, err
 	}
 
 	return grpcContext.NewGrpcContext(ctx, *grpcInfo), nil
+}
+
+// waitForRunningPod retries the Pod listing for the agent's ServiceAccount
+// with bounded exponential backoff. This absorbs a brief startup race where
+// the agent dials before NGF's cache has observed the new Pod as Running
+// (e.g. when slower sidecars like waf-config-mgr delay full Pod readiness).
+// Authentication failures are returned immediately by validateToken; this
+// helper only handles the "no running pods yet" transient case.
+func (c ContextSetter) waitForRunningPod(
+	ctx context.Context,
+	logger logr.Logger,
+	opts *client.ListOptions,
+	saNamespace, saName string,
+) error {
+	retry := c.podCheck
+	if retry.InitialBackoff <= 0 || retry.MaxBackoff <= 0 || retry.Timeout <= 0 {
+		retry = defaultPodCheckRetry
+	}
+
+	deadline := time.Now().Add(retry.Timeout)
+	backoff := retry.InitialBackoff
+	start := time.Now()
+	attempt := 0
+
+	for {
+		attempt++
+
+		listCtx, listCancel := context.WithTimeout(ctx, 30*time.Second)
+		var podList corev1.PodList
+		listErr := c.k8sClient.List(listCtx, &podList, opts)
+		listCancel()
+		if listErr != nil {
+			return status.Error(codes.Internal, fmt.Sprintf("error listing pods: %s", listErr.Error()))
+		}
+
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return nil
+			}
+		}
+
+		logger.V(1).Info(
+			"no running pods found for agent service account; retrying",
+			"namespace", saNamespace,
+			"serviceAccount", saName,
+			"attempt", attempt,
+			"elapsed", time.Since(start).String(),
+		)
+
+		if time.Now().Add(backoff).After(deadline) {
+			return status.Error(codes.Unavailable, fmt.Sprintf(
+				"no running pods found for service account %s/%s after %d attempts (%s); "+
+					"the agent's Pod may still be starting",
+				saNamespace, saName, attempt, time.Since(start),
+			))
+		}
+
+		select {
+		case <-ctx.Done():
+			return status.FromContextError(ctx.Err()).Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > retry.MaxBackoff {
+			backoff = retry.MaxBackoff
+		}
+	}
 }

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -14,6 +14,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	grpcContext "github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/agent/grpc/context"
@@ -32,18 +33,15 @@ const (
 // Pod's Running status, or while sidecars like waf-config-mgr are still
 // initializing).
 type PodCheckRetry struct {
-	// InitialBackoff is the initial wait between retries.
-	InitialBackoff time.Duration
-	// MaxBackoff caps the per-attempt wait between retries.
-	MaxBackoff time.Duration
-	// Timeout is the total time spent retrying before giving up.
+	// PollInterval is the interval between Pod list attempts.
+	PollInterval time.Duration
+	// Timeout is the total time spent polling before giving up.
 	Timeout time.Duration
 }
 
 var defaultPodCheckRetry = PodCheckRetry{
-	InitialBackoff: 100 * time.Millisecond,
-	MaxBackoff:     1 * time.Second,
-	Timeout:        15 * time.Second,
+	PollInterval: 500 * time.Millisecond,
+	Timeout:      15 * time.Second,
 }
 
 // streamHandler is a struct that implements StreamHandler, allowing the interceptor to replace the context.
@@ -186,12 +184,12 @@ func (c ContextSetter) validateToken(
 	return grpcContext.NewGrpcContext(ctx, *grpcInfo), nil
 }
 
-// waitForRunningPod retries the Pod listing for the agent's ServiceAccount
-// with bounded exponential backoff. This absorbs a brief startup race where
-// the agent dials before NGF's cache has observed the new Pod as Running
-// (e.g. when slower sidecars like waf-config-mgr delay full Pod readiness).
-// Authentication failures are returned immediately by validateToken; this
-// helper only handles the "no running pods yet" transient case.
+// waitForRunningPod polls for a Running Pod that matches the agent's
+// ServiceAccount. This absorbs a brief startup race where the agent dials
+// before NGF's cache has observed the new Pod as Running (e.g. when slower
+// sidecars like waf-config-mgr delay full Pod readiness). Authentication
+// failures are returned immediately by validateToken; this helper only
+// handles the "no running pods yet" transient case.
 func (c ContextSetter) waitForRunningPod(
 	ctx context.Context,
 	logger logr.Logger,
@@ -199,57 +197,59 @@ func (c ContextSetter) waitForRunningPod(
 	saNamespace, saName string,
 ) error {
 	retry := c.podCheck
-	if retry.InitialBackoff <= 0 || retry.MaxBackoff <= 0 || retry.Timeout <= 0 {
+	if retry.PollInterval <= 0 || retry.Timeout <= 0 {
 		retry = defaultPodCheckRetry
 	}
 
-	deadline := time.Now().Add(retry.Timeout)
-	backoff := retry.InitialBackoff
+	waitCtx, cancel := context.WithTimeout(ctx, retry.Timeout)
+	defer cancel()
+
 	start := time.Now()
-	attempt := 0
+	var (
+		attempt int
+		listErr error
+	)
 
-	for {
-		attempt++
-
-		listCtx, listCancel := context.WithTimeout(ctx, 30*time.Second)
-		var podList corev1.PodList
-		listErr := c.k8sClient.List(listCtx, &podList, opts)
-		listCancel()
-		if listErr != nil {
-			return status.Error(codes.Internal, fmt.Sprintf("error listing pods: %s", listErr.Error()))
-		}
-
-		for _, pod := range podList.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return nil
+	pollErr := wait.PollUntilContextCancel(waitCtx, retry.PollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			attempt++
+			var podList corev1.PodList
+			if err := c.k8sClient.List(ctx, &podList, opts); err != nil {
+				listErr = status.Error(codes.Internal, fmt.Sprintf("error listing pods: %s", err.Error()))
+				return false, listErr
 			}
-		}
 
-		logger.V(1).Info(
-			"no running pods found for agent service account; retrying",
-			"namespace", saNamespace,
-			"serviceAccount", saName,
-			"attempt", attempt,
-			"elapsed", time.Since(start).String(),
-		)
+			for _, pod := range podList.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					return true, nil
+				}
+			}
 
-		if time.Now().Add(backoff).After(deadline) {
-			return status.Error(codes.Unavailable, fmt.Sprintf(
-				"no running pods found for service account %s/%s after %d attempts (%s); "+
-					"the agent's Pod may still be starting",
-				saNamespace, saName, attempt, time.Since(start),
-			))
-		}
-
-		select {
-		case <-ctx.Done():
-			return status.FromContextError(ctx.Err()).Err()
-		case <-time.After(backoff):
-		}
-
-		backoff *= 2
-		if backoff > retry.MaxBackoff {
-			backoff = retry.MaxBackoff
-		}
+			logger.V(1).Info(
+				"no running pods found for agent service account; retrying",
+				"namespace", saNamespace,
+				"serviceAccount", saName,
+				"attempt", attempt,
+				"elapsed", time.Since(start).String(),
+			)
+			return false, nil
+		},
+	)
+	if pollErr == nil {
+		return nil
 	}
+	// If the wait was interrupted (deadline/cancel) rather than the condition
+	// returning a hard error, surface the startup-not-ready signal as
+	// Unavailable so callers can retry; otherwise propagate the List error.
+	if wait.Interrupted(pollErr) {
+		return status.Error(codes.Unavailable, fmt.Sprintf(
+			"no running pods found for service account %s/%s after %d attempts (%s); "+
+				"the agent's Pod may still be starting",
+			saNamespace, saName, attempt, time.Since(start),
+		))
+	}
+	if listErr != nil {
+		return listErr
+	}
+	return pollErr
 }

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
@@ -26,9 +26,8 @@ import (
 // fastPodCheck makes test runs that exercise the no-running-pods retry loop
 // complete quickly while still exercising at least one retry iteration.
 var fastPodCheck = PodCheckRetry{
-	InitialBackoff: time.Millisecond,
-	MaxBackoff:     2 * time.Millisecond,
-	Timeout:        20 * time.Millisecond,
+	PollInterval: time.Millisecond,
+	Timeout:      20 * time.Millisecond,
 }
 
 type mockServerStream struct {
@@ -445,9 +444,8 @@ func TestValidateToken_RetriesUntilPodIsRunning(t *testing.T) {
 	rc := &retryListClient{runningAfter: 2}
 	cs := NewContextSetter(rc, "ngf-audience")
 	cs.podCheck = PodCheckRetry{
-		InitialBackoff: time.Millisecond,
-		MaxBackoff:     2 * time.Millisecond,
-		Timeout:        time.Second,
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
 	}
 
 	resultCtx, err := cs.validateToken(t.Context(), &grpcContext.GrpcInfo{Token: "dummy"}, logr.Discard())

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
@@ -3,7 +3,9 @@ package interceptor
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
@@ -21,6 +23,14 @@ import (
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/controller"
 )
 
+// fastPodCheck makes test runs that exercise the no-running-pods retry loop
+// complete quickly while still exercising at least one retry iteration.
+var fastPodCheck = PodCheckRetry{
+	InitialBackoff: time.Millisecond,
+	MaxBackoff:     2 * time.Millisecond,
+	Timeout:        20 * time.Millisecond,
+}
+
 type mockServerStream struct {
 	grpc.ServerStream
 	ctx context.Context
@@ -35,6 +45,8 @@ type mockClient struct {
 	createErr, listErr              error
 	username, appName, podNamespace string
 	authenticated                   bool
+	// noRunningPods, when true, returns a pod that is not in Running phase.
+	noRunningPods bool
 }
 
 func (m *mockClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
@@ -61,13 +73,18 @@ func (m *mockClient) List(_ context.Context, obj client.ObjectList, _ ...client.
 		}
 	}
 
+	phase := corev1.PodRunning
+	if m.noRunningPods {
+		phase = corev1.PodPending
+	}
+
 	podList.Items = []corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: m.podNamespace,
 				Labels:    labels,
 			},
-			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			Status: corev1.PodStatus{Phase: phase},
 		},
 	}
 
@@ -92,6 +109,7 @@ func TestInterceptor(t *testing.T) {
 		name          string
 		expErrMsg     string
 		authenticated bool
+		noRunningPods bool
 		expErrCode    codes.Code
 	}{
 		{
@@ -184,6 +202,17 @@ func TestInterceptor(t *testing.T) {
 			expErrCode:    codes.Unauthenticated,
 			expErrMsg:     "must be of the format",
 		},
+		{
+			name:          "no running pods times out as Unavailable",
+			md:            validMetadata,
+			username:      "system:serviceaccount:default:gateway-nginx",
+			appName:       "gateway-nginx",
+			podNamespace:  "default",
+			authenticated: true,
+			noRunningPods: true,
+			expErrCode:    codes.Unavailable,
+			expErrMsg:     "no running pods found for service account default/gateway-nginx",
+		},
 	}
 
 	streamHandler := func(_ any, _ grpc.ServerStream) error {
@@ -206,8 +235,10 @@ func TestInterceptor(t *testing.T) {
 				username:      test.username,
 				appName:       test.appName,
 				podNamespace:  test.podNamespace,
+				noRunningPods: test.noRunningPods,
 			}
 			cs := NewContextSetter(mockK8sClient, "ngf-audience")
+			cs.podCheck = fastPodCheck
 
 			ctx := t.Context()
 			if test.md != nil {
@@ -351,15 +382,108 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 
 			patchedClient := &patchClient{fakeClient}
 			csPatched := NewContextSetter(patchedClient, "ngf-audience")
+			csPatched.podCheck = fastPodCheck
 
-			resultCtx, err := csPatched.validateToken(t.Context(), tc.grpcInfo)
+			resultCtx, err := csPatched.validateToken(t.Context(), tc.grpcInfo, logr.Discard())
 			if tc.shouldErr {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring("no running pods"))
+				g.Expect(status.Code(err)).To(Equal(codes.Unavailable))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resultCtx).ToNot(BeNil())
 			}
 		})
 	}
+}
+
+// retryListClient simulates the cache race where a Pod listing returns no
+// running Pods on the first N calls and a Running Pod afterwards.
+type retryListClient struct {
+	client.Client
+	runningAfter int32
+	calls        atomic.Int32
+}
+
+func (r *retryListClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	if tr, ok := obj.(*authv1.TokenReview); ok {
+		tr.Status.Authenticated = true
+		tr.Status.User.Username = "system:serviceaccount:default:gateway-nginx"
+	}
+	return nil
+}
+
+func (r *retryListClient) List(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
+	podList, ok := obj.(*corev1.PodList)
+	if !ok {
+		return errors.New("couldn't convert object to PodList")
+	}
+
+	phase := corev1.PodPending
+	if r.calls.Add(1) > r.runningAfter {
+		phase = corev1.PodRunning
+	}
+
+	podList.Items = []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Labels: map[string]string{
+					controller.AppNameLabel: "gateway-nginx",
+				},
+			},
+			Status: corev1.PodStatus{Phase: phase},
+		},
+	}
+	return nil
+}
+
+func TestValidateToken_RetriesUntilPodIsRunning(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	rc := &retryListClient{runningAfter: 2}
+	cs := NewContextSetter(rc, "ngf-audience")
+	cs.podCheck = PodCheckRetry{
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     2 * time.Millisecond,
+		Timeout:        time.Second,
+	}
+
+	resultCtx, err := cs.validateToken(t.Context(), &grpcContext.GrpcInfo{Token: "dummy"}, logr.Discard())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resultCtx).ToNot(BeNil())
+	g.Expect(rc.calls.Load()).To(BeNumerically(">", int32(2)),
+		"expected at least one retry before pod was observed as Running")
+}
+
+// notAuthenticatedClient always rejects the TokenReview, simulating a true auth failure.
+type notAuthenticatedClient struct {
+	client.Client
+}
+
+func (n *notAuthenticatedClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	if tr, ok := obj.(*authv1.TokenReview); ok {
+		tr.Status.Authenticated = false
+		tr.Status.Error = "bad token"
+	}
+	return nil
+}
+
+func TestValidateToken_AuthFailureIsImmediateUnauthenticated(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	cs := NewContextSetter(&notAuthenticatedClient{}, "ngf-audience")
+	// Use the production retry config to make sure auth failures still return
+	// immediately rather than going through the retry path.
+	start := time.Now()
+	_, err := cs.validateToken(t.Context(), &grpcContext.GrpcInfo{Token: "dummy"}, logr.Discard())
+	elapsed := time.Since(start)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+	g.Expect(err.Error()).To(ContainSubstring("invalid authorization"))
+	g.Expect(elapsed).To(BeNumerically("<", time.Second),
+		"auth failure should not go through the pod-check retry loop")
 }

--- a/tests/suite/waf_policy_test.go
+++ b/tests/suite/waf_policy_test.go
@@ -100,6 +100,17 @@ var _ = Describe("WAFPolicy", Ordered, Label("waf"), func() {
 
 		nginxPodName = nginxPodNames[0]
 
+		// Explicitly gate on the WAF sidecar containers being Ready before we
+		// proceed to agent-dependent assertions. PodReady implies all containers
+		// are ready, but waf-config-mgr can lag behind nginx; this gives a
+		// clear diagnostic if a specific container fails to come up.
+		Expect(waitForContainersReady(
+			namespace,
+			nginxPodName,
+			[]string{"nginx", "waf-config-mgr", "waf-enforcer"},
+			timeoutConfig.GetStatusTimeout,
+		)).To(Succeed())
+
 		setUpPortForward(nginxPodName, namespace)
 	})
 
@@ -1193,4 +1204,58 @@ func waitForWAFPolicyAncestorStatus(
 			return false, nil
 		},
 	)
+}
+
+// waitForContainersReady polls until every named container in the given Pod
+// reports Ready=true. On timeout it reports which specific containers were
+// missing or not ready, which helps diagnose WAF startup ordering issues
+// (e.g. waf-config-mgr lagging behind nginx).
+func waitForContainersReady(
+	namespace, podName string,
+	containerNames []string,
+	timeout time.Duration,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	GinkgoWriter.Printf(
+		"Waiting for containers %v in Pod %s/%s to be Ready\n",
+		containerNames, namespace, podName,
+	)
+
+	var lastNotReady []string
+	pollErr := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true,
+		func(ctx context.Context) (bool, error) {
+			var pod core.Pod
+			if err := resourceManager.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, &pod); err != nil {
+				return false, err
+			}
+
+			statusByName := make(map[string]core.ContainerStatus, len(pod.Status.ContainerStatuses))
+			for _, cs := range pod.Status.ContainerStatuses {
+				statusByName[cs.Name] = cs
+			}
+
+			notReady := make([]string, 0, len(containerNames))
+			for _, name := range containerNames {
+				cs, ok := statusByName[name]
+				if !ok {
+					notReady = append(notReady, fmt.Sprintf("%s(missing)", name))
+					continue
+				}
+				if !cs.Ready {
+					notReady = append(notReady, fmt.Sprintf("%s(ready=false)", name))
+				}
+			}
+			lastNotReady = notReady
+			return len(notReady) == 0, nil
+		},
+	)
+	if pollErr != nil {
+		return fmt.Errorf(
+			"timed out waiting for containers in Pod %s/%s to be Ready (not ready: %v): %w",
+			namespace, podName, lastNotReady, pollErr,
+		)
+	}
+	return nil
 }


### PR DESCRIPTION
### Proposed changes

Problem: When NGF starts the NGINX data-plane Pod, the in-Pod NGINX agent dials the NGF control plane's gRPC server as soon as it can. NGF's connection validator authenticates the bearer token via a TokenReview and then lists Pods for the agent's ServiceAccount, requiring at least one in PodRunning phase. On a fresh startup — especially for WAF-enabled deployments where the waf-config-mgr sidecar boots slower than nginx and the NGF Pod informer is still warming — the list returns no Running pods, and validation returned an immediate `Unauthenticated` ("no running pods found for service account waf-policy/gateway-nginx-1"). That terminated the gRPC stream, blocked NGINX config delivery, kept the Pod from becoming Ready, and failed the WAFPolicy `BeforeAll`.

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
