### PR TITLE
Update operator dockerfile package dependency flags

### DIFF
--- a/operators/Dockerfile
+++ b/operators/Dockerfile
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 
 # Update system packages to fix vulnerabilities
 USER root
-RUN microdnf update -y && microdnf clean all
+RUN microdnf update -y --refresh --nobest && microdnf clean all
 
 ENV HOME=/opt/helm \
     USER_NAME=helm \


### PR DESCRIPTION
### Proposed changes

Problem: Current package dependency update via `RUN microdnf update -y && microdnf clean all` is erroring because of an image version skew in packages.

Solution: Adding the `--refresh` and `--nobest` flags fix this issue. `--refresh`  refreshes the repository metadata to help with resolving packages and `--nobest` ensures the update doesn't fail if the newest package can't be installed/resolved.

Testing: Pipeline passes.

Closes 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
