### PR TITLE
Remove idle timeout to ensure seamless integration with Gateway API v1.6

### DIFF
--- a/docs/proposals/session-persistence.md
+++ b/docs/proposals/session-persistence.md
@@ -133,7 +133,6 @@ Users can configure [sessionPersistence](https://gateway-api.sigs.k8s.io/referen
 | ---------- | --------------- | ------------------- |
 | `sessionName` | `name` | Direct mapping to `sticky cookie` name. |
 | `absoluteTimeout` | `expires` | Only used when `cookieConfig.lifetimeType=Permanent`; not enforced for `Session` cookies. |
-| `idleTimeout` | _not supported_ | NGINX does not support idle-based invalidation for sticky cookies. Sessions expire only when the cookie expires or the session ends. |
 | `type` | `cookie` | Only cookie-based persistence is supported. If Header is specified, the sessionPersistence spec is ignored and a warning/status message is reported on the route, but the route itself remains valid. |
 | `cookieConfig.lifetimeType=Session` | _no `expires` set_ | Session cookies expire when the browser session ends. |
 | `cookieConfig.lifetimeType=Permanent` | `expires=<absoluteTimeout>` | Cookie persists until the specified timeout. `absoluteTimeout` is required when `lifetimeType` is `Permanent`. |

--- a/internal/controller/state/graph/route_common.go
+++ b/internal/controller/state/graph/route_common.go
@@ -1546,13 +1546,6 @@ func validateSessionPersistenceConfig(
 		))
 	}
 
-	if sp.IdleTimeout != nil {
-		errors.warn = append(errors.warn, field.Forbidden(
-			path.Child("idleTimeout"),
-			"IdleTimeout",
-		))
-	}
-
 	var timeout string
 	if sp.AbsoluteTimeout != nil {
 		if absoluteTimeout, err := validator.ValidateDuration(string(*sp.AbsoluteTimeout)); err != nil {

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -5871,22 +5871,6 @@ func TestValidateSessionPersistence(t *testing.T) {
 			validator: createDurationValidator(),
 		},
 		{
-			name: "session persistence returns error when idleTimeout is specified",
-			sessionPersistence: &gatewayv1.SessionPersistence{
-				Type:        helpers.GetPointer(gatewayv1.CookieBasedSessionPersistence),
-				IdleTimeout: helpers.GetPointer(gatewayv1.Duration("10m")),
-			},
-			expectedErrors: routeRuleErrors{
-				warn: field.ErrorList{
-					field.Forbidden(
-						sessionPersistencePath.Child("idleTimeout"),
-						"IdleTimeout",
-					),
-				},
-			},
-			validator: createDurationValidator(),
-		},
-		{
 			name: "session persistence returns error when absoluteTimeout is invalid",
 			sessionPersistence: &gatewayv1.SessionPersistence{
 				Type:            helpers.GetPointer(gatewayv1.CookieBasedSessionPersistence),

--- a/tests/suite/manifests/session-persistence/route-invalid-sp-config.yaml
+++ b/tests/suite/manifests/session-persistence/route-invalid-sp-config.yaml
@@ -19,7 +19,6 @@ spec:
     sessionPersistence:
       sessionName: invalid-config
       type: Header
-      idleTimeout: 30m
       absoluteTimeout: 10000h # duration too long for NGINX
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -41,5 +40,4 @@ spec:
     sessionPersistence:
       sessionName: invalid-config
       type: Header
-      idleTimeout: 30m
       absoluteTimeout: 10000h # duration too long for NGINX

--- a/tests/suite/session_persistence_test.go
+++ b/tests/suite/session_persistence_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 var invalidSPErrMsgs = "[spec.rules[0].sessionPersistence.type: Unsupported value: \"Header\": " +
-	"supported values: \"Cookie\", spec.rules[0].sessionPersistence.idleTimeout: " +
-	"Forbidden: IdleTimeout, spec.rules[0].sessionPersistence.absoluteTimeout: " +
+	"supported values: \"Cookie\", spec.rules[0].sessionPersistence.absoluteTimeout: " +
 	"Invalid value: \"10000h\": duration is too large for NGINX format (exceeds 9999h), " +
 	"spec.rules[0].sessionPersistence: Invalid value: \"spec.rules[0].sessionPersistence\":" +
 	" session persistence is ignored because there are errors in the configuration]"
@@ -221,6 +220,7 @@ var _ = Describe("SessionPersistence Plus", Ordered, Label("functional", "sessio
 				if !*plusEnabled {
 					Skip("Skipping Session Persistence Plus tests on NGINX OSS deployment")
 				}
+
 				Eventually(
 					func() error {
 						return expectRequestToSucceedAndReuseCookie(baseCoffeeURL, address, "URI: /coffee", 11)


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: The idleTimeout field is removed from the sessionPersistence spec on the HTTPRoute in Gateway API version v1.6.0. This is causing some conformance tests to fail.

Solution: Remove idleTimeout field from sessionPersistence spec on HTTPRoutes.

No documentation changes needed

Testing: Functional tests pass and unit tests have been updated.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5555 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Removes references to idleTimeout field in HTTPRoute sessionPersistence spec as it is removed from the Gateway API in version 1.6.
```
