### PR TITLE
Fix flaky test for `useClusterIP`

### DIFF
--- a/tests/suite/upstream_settings_test.go
+++ b/tests/suite/upstream_settings_test.go
@@ -438,10 +438,7 @@ var _ = Describe("UpstreamSettingsPolicy", Ordered, Label("functional", "uspolic
 		})
 
 		Context("nginx config", func() {
-			var (
-				conf      *framework.Payload
-				clusterIP string
-			)
+			var clusterIP string
 
 			BeforeAll(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetStatusTimeout)
@@ -455,10 +452,6 @@ var _ = Describe("UpstreamSettingsPolicy", Ordered, Label("functional", "uspolic
 				)
 				Expect(err).ToNot(HaveOccurred())
 				clusterIP = svc.Spec.ClusterIP
-
-				var cfgErr error
-				conf, cfgErr = resourceManager.GetNginxConfig(nginxPodName, namespace, "")
-				Expect(cfgErr).ToNot(HaveOccurred())
 			})
 
 			It("uses the Service ClusterIP as the upstream server", func() {
@@ -469,12 +462,22 @@ var _ = Describe("UpstreamSettingsPolicy", Ordered, Label("functional", "uspolic
 					serverAddr = fmt.Sprintf("%s:80", clusterIP)
 				}
 
-				Expect(framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
-					Directive: "server",
-					Value:     serverAddr,
-					Upstream:  "uspolicy_coffee_80",
-					File:      "http.conf",
-				})).To(Succeed())
+				Eventually(func() error {
+					conf, err := resourceManager.GetNginxConfig(nginxPodName, namespace, "")
+					if err != nil {
+						return err
+					}
+
+					return framework.ValidateNginxFieldExists(conf, framework.ExpectedNginxField{
+						Directive: "server",
+						Value:     serverAddr,
+						Upstream:  "uspolicy_coffee_80",
+						File:      "http.conf",
+					})
+				}).
+					WithTimeout(timeoutConfig.GetStatusTimeout).
+					WithPolling(500 * time.Millisecond).
+					Should(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: The functional test "uses the Service ClusterIP as the upstream server" fails intermittently when reading a stale NGINX config. 

Solution: Call `GetNginxConfig` within an `Eventually` block to re-read the NGINX config on each poll iteration. This gives the test a chance to eventually find the expected config.

Testing: Ran the functional test multiple times locally. Saw no failures.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ x I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
