### PR TITLE
Fix GatewayStaticAddress test failure and provisioning bug

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -169,7 +169,6 @@ jobs:
 
       - name: Run conformance tests
         run: |
-          make deploy-metallb
           make run-conformance-tests CONFORMANCE_TAG=${{ github.sha }} NGF_VERSION=${{ github.ref_name }} CLUSTER_NAME=${{ github.run_id }}
           core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
           extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -969,6 +969,8 @@ func getGatewayAddresses(
 		svcName := controller.CreateNginxResourceName(gateway.Source.GetName(), gatewayClassName)
 		key := types.NamespacedName{Name: svcName, Namespace: gateway.Source.GetNamespace()}
 
+		expectLBIngress := gatewayExpectsLoadBalancerIngress(gateway)
+
 		pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
@@ -981,6 +983,16 @@ func getGatewayAddresses(
 					return false, nil //nolint:nilerr // need to retry without returning error
 				}
 
+				// When the Gateway declares IP-type spec addresses and the Service is a
+				// LoadBalancer, the provisioner patches Service.Status.LoadBalancer.Ingress
+				// with those IPs. The informer cache may not reflect that patch yet, so keep
+				// polling until the Ingress entries appear.
+				if expectLBIngress &&
+					gwSvc.Spec.Type == v1.ServiceTypeLoadBalancer &&
+					len(gwSvc.Status.LoadBalancer.Ingress) == 0 {
+					return false, nil
+				}
+
 				return true, nil
 			},
 		); err != nil {
@@ -991,6 +1003,18 @@ func getGatewayAddresses(
 	}
 
 	return getGatewayAddressesForStatus(&gwSvc), nil
+}
+
+// gatewayExpectsLoadBalancerIngress returns true when the Gateway declares at least one
+// IP-type spec address, meaning the provisioner will patch the Service's LoadBalancer
+// Ingress status with those IPs.
+func gatewayExpectsLoadBalancerIngress(gateway *graph.Gateway) bool {
+	for _, addr := range gateway.Source.Spec.Addresses {
+		if addr.Type != nil && *addr.Type == gatewayv1.IPAddressType {
+			return true
+		}
+	}
+	return false
 }
 
 func getGatewayAddressesForStatus(svc *v1.Service) (gwAddresses []gatewayv1.GatewayStatusAddress) {

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -246,23 +246,30 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 	// ensure headless "shadow" Services are created for any referenced InferencePools
 	h.ensureInferencePoolServices(ctx, gr.ReferencedInferencePools)
 
+	// Track RegisterGateway goroutines so we can wait for them to complete before
+	// enqueuing status updates. RegisterGateway may patch Service status with Gateway
+	// spec addresses (for static address support), and the status update reads from
+	// the Service. Without this synchronization the status update can race with the
+	// Service status patch, causing intermittent empty Gateway addresses.
+	var provisionerWg sync.WaitGroup
+	var statusObjects []*status.QueueObject
+
 	for _, gw := range gr.Gateways {
-		go func() {
+		provisionerWg.Go(func() {
 			if err := h.cfg.nginxProvisioner.RegisterGateway(ctx, gw, gw.DeploymentName.Name); err != nil {
 				logger.Error(err, "error from provisioner")
 			}
-		}()
+		})
 
 		// If no listeners or invalid, update status but skip config generation
 		if len(gw.Listeners) == 0 || !gw.Valid {
-			obj := &status.QueueObject{
+			statusObjects = append(statusObjects, &status.QueueObject{
 				Deployment: status.Deployment{
 					NamespacedName: gw.DeploymentName,
 					GatewayName:    gw.Source.GetName(),
 				},
 				UpdateType: status.UpdateAll,
-			}
-			h.cfg.statusQueue.Enqueue(obj)
+			})
 			continue
 		}
 
@@ -270,15 +277,14 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 			// Fail-closed (default): a pending bundle blocks the config push until the bundle is available.
 			// Enqueue a status update because the config is being withheld in this fail-closed case,
 			// making the pending condition visible to the operator.
-			obj := &status.QueueObject{
+			statusObjects = append(statusObjects, &status.QueueObject{
 				UpdateType: status.UpdateAll,
 				Deployment: status.Deployment{
 					NamespacedName: gw.DeploymentName,
 					GatewayName:    gw.Source.GetName(),
 				},
 				Error: errors.New("NGINX configuration update withheld: WAF bundle for Gateway is still pending"),
-			}
-			h.cfg.statusQueue.Enqueue(obj)
+			})
 			continue
 		}
 
@@ -303,27 +309,15 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 
 		h.setLatestConfiguration(gw, &cfg)
 
-		vm := []v1.VolumeMount{}
-		if gw.EffectiveNginxProxy != nil &&
-			gw.EffectiveNginxProxy.Kubernetes != nil {
-			if gw.EffectiveNginxProxy.Kubernetes.Deployment != nil {
-				vm = gw.EffectiveNginxProxy.Kubernetes.Deployment.Container.VolumeMounts
-			}
-
-			if gw.EffectiveNginxProxy.Kubernetes.DaemonSet != nil {
-				vm = gw.EffectiveNginxProxy.Kubernetes.DaemonSet.Container.VolumeMounts
-			}
-		}
-
 		deployment.FileLock.Lock()
-		h.updateNginxConf(deployment, cfg, vm)
+		h.updateNginxConf(deployment, cfg, effectiveVolumeMounts(gw.EffectiveNginxProxy))
 		deployment.FileLock.Unlock()
 
 		configErr := deployment.GetLatestConfigError()
 		upstreamErr := deployment.GetLatestUpstreamError()
 		err := errors.Join(configErr, upstreamErr)
 
-		obj := &status.QueueObject{
+		statusObjects = append(statusObjects, &status.QueueObject{
 			UpdateType:        status.UpdateAll,
 			Error:             err,
 			NginxConfigPushed: true,
@@ -331,9 +325,35 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 				NamespacedName: gw.DeploymentName,
 				GatewayName:    gw.Source.GetName(),
 			},
-		}
+		})
+	}
+
+	// Wait for all provisioner goroutines to finish before enqueuing status updates.
+	// This ensures Service status (e.g. LoadBalancer Ingress IPs) is fully patched
+	// before the status handler reads it to populate Gateway addresses.
+	provisionerWg.Wait()
+
+	for _, obj := range statusObjects {
 		h.cfg.statusQueue.Enqueue(obj)
 	}
+}
+
+// effectiveVolumeMounts returns the user-configured volume mounts from the EffectiveNginxProxy,
+// or nil if none are configured.
+func effectiveVolumeMounts(np *graph.EffectiveNginxProxy) []v1.VolumeMount {
+	if np == nil || np.Kubernetes == nil {
+		return nil
+	}
+
+	if np.Kubernetes.Deployment != nil {
+		return np.Kubernetes.Deployment.Container.VolumeMounts
+	}
+
+	if np.Kubernetes.DaemonSet != nil {
+		return np.Kubernetes.DaemonSet.Container.VolumeMounts
+	}
+
+	return nil
 }
 
 // reconcileWAFPollers starts, updates, or stops WAF bundle pollers based on the current graph state.

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -246,95 +246,82 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 	// ensure headless "shadow" Services are created for any referenced InferencePools
 	h.ensureInferencePoolServices(ctx, gr.ReferencedInferencePools)
 
-	// Track RegisterGateway goroutines so we can wait for them to complete before
-	// enqueuing status updates. RegisterGateway may patch Service status with Gateway
-	// spec addresses (for static address support), and the status update reads from
-	// the Service. Without this synchronization the status update can race with the
-	// Service status patch, causing intermittent empty Gateway addresses.
-	var provisionerWg sync.WaitGroup
-	var statusObjects []*status.QueueObject
-
 	for _, gw := range gr.Gateways {
-		provisionerWg.Go(func() {
-			if err := h.cfg.nginxProvisioner.RegisterGateway(ctx, gw, gw.DeploymentName.Name); err != nil {
-				logger.Error(err, "error from provisioner")
-			}
-		})
+		// Build the status object for this Gateway inline, then launch a goroutine
+		// that waits for RegisterGateway to complete before enqueuing it. This ensures
+		// Service status (e.g. LoadBalancer Ingress IPs patched by the provisioner) is
+		// fully written before the status handler reads it, without coupling unrelated
+		// Gateways together.
+		var statusObj *status.QueueObject
 
-		// If no listeners or invalid, update status but skip config generation
-		if len(gw.Listeners) == 0 || !gw.Valid {
-			statusObjects = append(statusObjects, &status.QueueObject{
+		switch {
+		// If no listeners or invalid, update status but skip config generation.
+		case len(gw.Listeners) == 0 || !gw.Valid:
+			statusObj = &status.QueueObject{
 				Deployment: status.Deployment{
 					NamespacedName: gw.DeploymentName,
 					GatewayName:    gw.Source.GetName(),
 				},
 				UpdateType: status.UpdateAll,
-			})
-			continue
-		}
-
-		if gatewayHasPendingWAFBundle(gr, gw) && !graph.WAFBundleFailOpenForNginxProxy(gw.EffectiveNginxProxy) {
-			// Fail-closed (default): a pending bundle blocks the config push until the bundle is available.
-			// Enqueue a status update because the config is being withheld in this fail-closed case,
-			// making the pending condition visible to the operator.
-			statusObjects = append(statusObjects, &status.QueueObject{
+			}
+		// Fail-closed (default): a pending bundle blocks the config push until the bundle is available.
+		// Enqueue a status update because the config is being withheld in this fail-closed case,
+		// making the pending condition visible to the operator.
+		case gatewayHasPendingWAFBundle(gr, gw) && !graph.WAFBundleFailOpenForNginxProxy(gw.EffectiveNginxProxy):
+			statusObj = &status.QueueObject{
 				UpdateType: status.UpdateAll,
 				Deployment: status.Deployment{
 					NamespacedName: gw.DeploymentName,
 					GatewayName:    gw.Source.GetName(),
 				},
 				Error: errors.New("NGINX configuration update withheld: WAF bundle for Gateway is still pending"),
-			})
-			continue
+			}
+		default:
+			deployment := h.cfg.nginxDeployments.GetOrStore(ctx, gw.DeploymentName, gw.Source.GetName())
+			if deployment == nil {
+				panic("expected deployment, got nil")
+			}
+
+			nginxImage, _ := provisioner.DetermineNginxImageName(
+				gw.EffectiveNginxProxy,
+				h.cfg.plus,
+				h.cfg.gatewayPodConfig.Version,
+			)
+			deployment.SetImageVersion(nginxImage)
+
+			cfg := dataplane.BuildConfiguration(ctx, logger, gr, gw, h.cfg.serviceResolver, h.cfg.plus)
+			depCtx, getErr := h.getDeploymentContext(ctx)
+			if getErr != nil {
+				logger.Error(getErr, "error getting deployment context for usage reporting")
+			}
+			cfg.DeploymentContext = depCtx
+
+			h.setLatestConfiguration(gw, &cfg)
+
+			deployment.FileLock.Lock()
+			h.updateNginxConf(deployment, cfg, effectiveVolumeMounts(gw.EffectiveNginxProxy))
+			deployment.FileLock.Unlock()
+
+			configErr := deployment.GetLatestConfigError()
+			upstreamErr := deployment.GetLatestUpstreamError()
+
+			statusObj = &status.QueueObject{
+				UpdateType:        status.UpdateAll,
+				Error:             errors.Join(configErr, upstreamErr),
+				NginxConfigPushed: true,
+				Deployment: status.Deployment{
+					NamespacedName: gw.DeploymentName,
+					GatewayName:    gw.Source.GetName(),
+				},
+			}
 		}
 
-		deployment := h.cfg.nginxDeployments.GetOrStore(ctx, gw.DeploymentName, gw.Source.GetName())
-		if deployment == nil {
-			panic("expected deployment, got nil")
-		}
-
-		nginxImage, _ := provisioner.DetermineNginxImageName(
-			gw.EffectiveNginxProxy,
-			h.cfg.plus,
-			h.cfg.gatewayPodConfig.Version,
-		)
-		deployment.SetImageVersion(nginxImage)
-
-		cfg := dataplane.BuildConfiguration(ctx, logger, gr, gw, h.cfg.serviceResolver, h.cfg.plus)
-		depCtx, getErr := h.getDeploymentContext(ctx)
-		if getErr != nil {
-			logger.Error(getErr, "error getting deployment context for usage reporting")
-		}
-		cfg.DeploymentContext = depCtx
-
-		h.setLatestConfiguration(gw, &cfg)
-
-		deployment.FileLock.Lock()
-		h.updateNginxConf(deployment, cfg, effectiveVolumeMounts(gw.EffectiveNginxProxy))
-		deployment.FileLock.Unlock()
-
-		configErr := deployment.GetLatestConfigError()
-		upstreamErr := deployment.GetLatestUpstreamError()
-		err := errors.Join(configErr, upstreamErr)
-
-		statusObjects = append(statusObjects, &status.QueueObject{
-			UpdateType:        status.UpdateAll,
-			Error:             err,
-			NginxConfigPushed: true,
-			Deployment: status.Deployment{
-				NamespacedName: gw.DeploymentName,
-				GatewayName:    gw.Source.GetName(),
-			},
-		})
-	}
-
-	// Wait for all provisioner goroutines to finish before enqueuing status updates.
-	// This ensures Service status (e.g. LoadBalancer Ingress IPs) is fully patched
-	// before the status handler reads it to populate Gateway addresses.
-	provisionerWg.Wait()
-
-	for _, obj := range statusObjects {
-		h.cfg.statusQueue.Enqueue(obj)
+		go func() {
+			if err := h.cfg.nginxProvisioner.RegisterGateway(ctx, gw, gw.DeploymentName.Name); err != nil {
+				logger.Error(err, "error from provisioner")
+			}
+			h.cfg.statusQueue.Enqueue(statusObj)
+		}()
 	}
 }
 

--- a/internal/controller/provisioner/handler.go
+++ b/internal/controller/provisioner/handler.go
@@ -78,6 +78,10 @@ func (h *eventHandler) HandleEventBatch(ctx context.Context, logger logr.Logger,
 func (h *eventHandler) handleUpsertEvent(ctx context.Context, e *events.UpsertEvent, logger logr.Logger) error {
 	switch obj := e.Resource.(type) {
 	case *gatewayv1.Gateway:
+		// Clear the deleting mark when a Gateway is (re-)created. Without this, delete + re-create with the
+		// same name could leave a stale deleting entry
+		// that prevents reprovisionResources from re-creating managed resources.
+		h.store.clearGatewayDeleting(client.ObjectKeyFromObject(obj))
 		h.store.updateGateway(obj)
 	case *appsv1.Deployment, *appsv1.DaemonSet, *corev1.ServiceAccount,
 		*corev1.ConfigMap, *rbacv1.Role, *rbacv1.RoleBinding,
@@ -299,6 +303,13 @@ func (h *eventHandler) reprovisionResources(ctx context.Context, event *events.D
 			); err != nil {
 				return err
 			}
+		} else if h.store.isGatewayDeleting(gatewayNsName) {
+			h.provisioner.cfg.Logger.Info(
+				"Skipping reprovisioning of deleted resource because Gateway is marked as deleting",
+				"resource", event.NamespacedName,
+				"resourceType", fmt.Sprintf("%T", event.Type),
+				"gateway", gatewayNsName,
+			)
 		}
 	}
 

--- a/internal/controller/provisioner/handler_test.go
+++ b/internal/controller/provisioner/handler_test.go
@@ -412,7 +412,7 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 }
 
 // TestHandleEventBatch_GatewayDeletingClearedOnRecreate verifies that when a Gateway is deleted
-// and then a new Gateway with the same name/namespace is created (e.g. after namespace recycling),
+// and then a new Gateway with the same name/namespace is created,
 // the "deleting" mark is cleared so that reprovisionResources can re-create managed resources.
 func TestHandleEventBatch_GatewayDeletingClearedOnRecreate(t *testing.T) {
 	t.Parallel()

--- a/internal/controller/provisioner/handler_test.go
+++ b/internal/controller/provisioner/handler_test.go
@@ -411,6 +411,99 @@ func TestHandleEventBatch_Delete(t *testing.T) {
 	g.Expect(store.getGateway(client.ObjectKeyFromObject(gateway))).To(BeNil())
 }
 
+// TestHandleEventBatch_GatewayDeletingClearedOnRecreate verifies that when a Gateway is deleted
+// and then a new Gateway with the same name/namespace is created (e.g. after namespace recycling),
+// the "deleting" mark is cleared so that reprovisionResources can re-create managed resources.
+func TestHandleEventBatch_GatewayDeletingClearedOnRecreate(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	store := newStore([]string{dockerTestSecretName}, agentTLSTestSecretName, "", "", "", "")
+	provisioner, fakeClient, _ := defaultNginxProvisioner()
+	provisioner.cfg.StatusQueue = status.NewQueue()
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "nginx"},
+	}
+	gcName := "nginx"
+
+	handler, err := newEventHandler(store, provisioner, provisioner.k8sClient, labelSelector, gcName)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"app": "nginx"},
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{{Port: 80}},
+		},
+	}
+	gwKey := client.ObjectKeyFromObject(gateway)
+
+	graphGateway := &graph.Gateway{
+		Source: gateway,
+		Valid:  true,
+		Listeners: []*graph.Listener{
+			{
+				Name:   "listener-80",
+				Source: gatewayv1.Listener{Port: 80},
+			},
+		},
+	}
+
+	// Step 1: Upsert the Gateway and register it in the store.
+	store.registerResourceInGatewayConfig(gwKey, graphGateway)
+	upsertEvent := &events.UpsertEvent{Resource: gateway}
+	handler.HandleEventBatch(ctx, logger, events.EventBatch{upsertEvent})
+
+	g.Expect(store.isGatewayDeleting(gwKey)).To(BeFalse())
+	g.Expect(store.getGateway(gwKey)).ToNot(BeNil())
+
+	// Register a managed Deployment so we can verify reprovisioning.
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-nginx",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"app": "nginx", controller.GatewayLabel: "gw"},
+		},
+	}
+	g.Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
+	store.registerResourceInGatewayConfig(gwKey, deployment)
+
+	// Step 2: Delete the Gateway. It should be marked as deleting.
+	deleteEvent := &events.DeleteEvent{Type: gateway, NamespacedName: gwKey}
+	handler.HandleEventBatch(ctx, logger, events.EventBatch{deleteEvent})
+
+	g.Expect(store.isGatewayDeleting(gwKey)).To(BeTrue())
+	g.Expect(store.getGateway(gwKey)).To(BeNil())
+
+	// Step 3: Re-create the Gateway (simulating namespace recycling).
+	// The upsert should clear the deleting mark.
+	store.registerResourceInGatewayConfig(gwKey, graphGateway)
+	upsertEvent = &events.UpsertEvent{Resource: gateway}
+	handler.HandleEventBatch(ctx, logger, events.EventBatch{upsertEvent})
+
+	g.Expect(store.isGatewayDeleting(gwKey)).To(BeFalse(), "deleting mark should be cleared after Gateway re-create")
+	g.Expect(store.getGateway(gwKey)).ToNot(BeNil())
+
+	// Step 4: Simulate a stale delete event for a managed resource (e.g. old namespace Service
+	// delete event arriving after the new Gateway's resources were created). The deployment
+	// should be re-created because the Gateway is no longer marked as deleting.
+	store.registerResourceInGatewayConfig(gwKey, deployment)
+	g.Expect(fakeClient.Delete(ctx, deployment)).To(Succeed())
+
+	deleteEvent = &events.DeleteEvent{Type: deployment, NamespacedName: client.ObjectKeyFromObject(deployment)}
+	handler.HandleEventBatch(ctx, logger, events.EventBatch{deleteEvent})
+
+	g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})).To(Succeed(),
+		"managed Deployment should be reprovisioned after Gateway re-create clears the deleting mark")
+}
+
 func TestHandleEventBatch_NoListeners(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)

--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -408,6 +408,14 @@ func (p *NginxProvisioner) provisionNginx(
 		"resource names", objNames,
 	)
 
+	// If the desired Service has a different loadBalancerClass than the existing one,
+	// we must delete the existing Service first because loadBalancerClass is immutable.
+	// We clear it from the store before deleting so the event handler doesn't try to
+	// reprovision it.
+	if err := p.deleteServiceForLBClassChange(ctx, gateway, objects); err != nil {
+		return err
+	}
+
 	var state nginxProvisionState
 	for _, obj := range objects {
 		minimalObj, res, err := p.createOrUpdateNginxResource(ctx, resourceName, gateway, obj)
@@ -504,13 +512,6 @@ func (p *NginxProvisioner) createOrUpdateNginxResource(
 
 			if upsertErr != nil {
 				if apierrors.IsInvalid(upsertErr) { // log this error at the error level
-					// spec.loadBalancerClass is immutable in Kubernetes; it cannot be changed after
-					// a Service is created. We cannot delete and recreate the Service because that
-					// would release and re-allocate the external IP, breaking DNS for users.
-					// Return the error to stop retrying; the outer handler will log and surface it.
-					if _, ok := obj.(*corev1.Service); ok && isLoadBalancerClassImmutabilityErr(upsertErr) {
-						return false, upsertErr
-					}
 					p.cfg.Logger.Error(
 						upsertErr,
 						"Retrying CreateOrUpdate for nginx resource after error",
@@ -880,22 +881,117 @@ func needToDeleteDaemonSet(cfg *NginxResources) bool {
 	return false
 }
 
-// isLoadBalancerClassImmutabilityErr returns true when the error is a Kubernetes validation
-// error for the spec.loadBalancerClass field, which is immutable once a Service is created.
-func isLoadBalancerClassImmutabilityErr(err error) bool {
-	var statusErr *apierrors.StatusError
-	if !errors.As(err, &statusErr) {
-		return false
-	}
-	if statusErr.ErrStatus.Details == nil {
-		return false
-	}
-	for _, cause := range statusErr.ErrStatus.Details.Causes {
-		if cause.Field == "spec.loadBalancerClass" {
-			return true
+// deleteServiceForLBClassChange checks whether the desired Service's loadBalancerClass differs
+// from the existing Service. It first checks the in-memory store, falling back to a live GET
+// when the store doesn't yet have the Service (e.g. after a controller restart before the
+// informer delivers the event). If a mismatch is found, it clears the Service from the store
+// (so the delete-event handler does not attempt to reprovision it) and deletes the existing
+// Service. The subsequent CreateOrUpdate in the provisioning loop will then create a fresh
+// Service with the correct loadBalancerClass.
+//
+// Returns an error if the Service could not be deleted, so the caller can abort and requeue
+// rather than proceeding into the immutable-field Invalid error loop.
+func (p *NginxProvisioner) deleteServiceForLBClassChange(
+	ctx context.Context,
+	gateway *gatewayv1.Gateway,
+	objects []client.Object,
+) error {
+	var desiredSvc *corev1.Service
+	for _, obj := range objects {
+		if svc, ok := obj.(*corev1.Service); ok {
+			desiredSvc = svc
+			break
 		}
 	}
-	return false
+	if desiredSvc == nil {
+		return nil
+	}
+
+	gatewayNSName := client.ObjectKeyFromObject(gateway)
+
+	var existingLBClass *string
+	var svcToDelete *corev1.Service
+	inStore := false
+
+	nginxRes := p.store.getNginxResourcesForGateway(gatewayNSName)
+	if nginxRes != nil && nginxRes.Service.Name != "" {
+		existingLBClass = nginxRes.ServiceLBClass
+		svcToDelete = &corev1.Service{ObjectMeta: nginxRes.Service}
+		inStore = true
+	} else {
+		// Store doesn't have the Service yet; fall back to a live GET.
+		existing := &corev1.Service{}
+		key := types.NamespacedName{Name: desiredSvc.Name, Namespace: desiredSvc.Namespace}
+		if err := p.k8sClient.Get(ctx, key, existing); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to get existing Service for loadBalancerClass check: %w", err)
+		}
+		existingLBClass = existing.Spec.LoadBalancerClass
+		svcToDelete = existing
+	}
+
+	if !needToDeleteServiceForLBClassChange(existingLBClass, desiredSvc.Spec.LoadBalancerClass) {
+		return nil
+	}
+
+	p.cfg.Logger.Info(
+		"Deleting Service to update immutable loadBalancerClass field",
+		"namespace", svcToDelete.Namespace,
+		"name", svcToDelete.Name,
+	)
+
+	p.cfg.EventRecorder.Eventf(
+		desiredSvc,
+		gateway,
+		corev1.EventTypeNormal,
+		"RecreatingService",
+		"None",
+		"Deleting Service %s/%s to update immutable loadBalancerClass; it will be recreated",
+		svcToDelete.Namespace,
+		svcToDelete.Name,
+	)
+
+	// Save the store entry so we can restore it if the delete fails.
+	var savedSvc *corev1.Service
+	if inStore {
+		savedSvc = &corev1.Service{
+			ObjectMeta: nginxRes.Service,
+			Spec:       corev1.ServiceSpec{LoadBalancerClass: nginxRes.ServiceLBClass},
+		}
+
+		// Clear the Service from the store before deleting so the event handler
+		// does not treat this as an unexpected deletion requiring reprovisioning.
+		p.store.clearServiceForGateway(gatewayNSName)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := p.k8sClient.Delete(deleteCtx, svcToDelete); err != nil && !apierrors.IsNotFound(err) {
+		// Restore the store entry so the next reconcile can retry deletion.
+		if savedSvc != nil {
+			p.store.registerResourceInGatewayConfig(gatewayNSName, savedSvc)
+		}
+		return fmt.Errorf("failed to delete Service for loadBalancerClass change: %w", err)
+	}
+
+	return nil
+}
+
+// needToDeleteServiceForLBClassChange returns true when the existing and desired loadBalancerClass
+// values differ and therefore the Service must be deleted and recreated.
+func needToDeleteServiceForLBClassChange(existing, desired *string) bool {
+	// Both nil or both point to the same value → no change.
+	if (existing == nil) == (desired == nil) {
+		if existing == nil {
+			return false
+		}
+		return *existing != *desired
+	}
+	// One is nil and the other is not → change.
+	return true
 }
 
 // needToDeletePDB returns true if a PDB was previously created for this Gateway

--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -966,8 +966,10 @@ func (p *NginxProvisioner) deleteServiceForLBClassChange(
 		p.store.clearServiceForGateway(gatewayNSName)
 	}
 
-	deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+
+	key := client.ObjectKeyFromObject(svcToDelete)
 
 	if err := p.k8sClient.Delete(deleteCtx, svcToDelete); err != nil && !apierrors.IsNotFound(err) {
 		// Restore the store entry so the next reconcile can retry deletion.
@@ -975,6 +977,19 @@ func (p *NginxProvisioner) deleteServiceForLBClassChange(
 			p.store.registerResourceInGatewayConfig(gatewayNSName, savedSvc)
 		}
 		return fmt.Errorf("failed to delete Service for loadBalancerClass change: %w", err)
+	}
+
+	// The Service may stick around briefly (e.g. due to LoadBalancer finalizers). Wait until it is fully deleted
+	// so the subsequent CreateOrUpdate can create a fresh Service instead of retrying an immutable-field update.
+	if err := wait.PollUntilContextCancel(deleteCtx, 250*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		var tmp corev1.Service
+		getErr := p.k8sClient.Get(ctx, key, &tmp)
+		return apierrors.IsNotFound(getErr), nil
+	}); err != nil {
+		if savedSvc != nil {
+			p.store.registerResourceInGatewayConfig(gatewayNSName, savedSvc)
+		}
+		return fmt.Errorf("timed out waiting for Service deletion for loadBalancerClass change: %w", err)
 	}
 
 	return nil

--- a/internal/controller/provisioner/provisioner_test.go
+++ b/internal/controller/provisioner/provisioner_test.go
@@ -272,42 +272,6 @@ func (f *failingClient) Patch(
 	return f.Client.Patch(ctx, obj, patch, opts...)
 }
 
-// lbClassImmutableClient wraps a client.Client and returns a LoadBalancerClass immutability
-// error on the first Service Update call, simulating the immutable-field behavior of the real
-// Kubernetes API. Subsequent Service Updates are delegated to the underlying client unchanged.
-type lbClassImmutableClient struct {
-	client.Client
-	svcUpdateAttempts int
-}
-
-func (c *lbClassImmutableClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if _, ok := obj.(*corev1.Service); ok {
-		c.svcUpdateAttempts++
-		if c.svcUpdateAttempts == 1 {
-			return apierrors.NewInvalid(
-				schema.GroupKind{Group: "", Kind: "Service"},
-				obj.GetName(),
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec").Child("loadBalancerClass"),
-						"gateway.nginx.org/nginx-gateway-controller",
-						"may not change once set",
-					),
-				},
-			)
-		}
-	}
-	return c.Client.Update(ctx, obj, opts...)
-}
-
-// Delete delegates to the underlying client and clears the ResourceVersion on obj so that
-// a subsequent CreateOrUpdate can Create the object fresh without a stale ResourceVersion.
-func (c *lbClassImmutableClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	err := c.Client.Delete(ctx, obj, opts...)
-	obj.SetResourceVersion("")
-	return err
-}
-
 func TestNewNginxProvisioner(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
@@ -772,9 +736,11 @@ func TestNonLeaderProvisioner(t *testing.T) {
 	g.Expect(deploymentStore.RemoveCallCount()).To(Equal(1))
 }
 
-func TestProvisionNginxOnLBClassImmutabilityError(t *testing.T) {
+func TestProvisionNginxDeletesServiceOnLBClassChange(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
+
+	gatewayNSName := types.NamespacedName{Name: "gw", Namespace: "default"}
 
 	// Simulate a Service that was previously provisioned without LoadBalancerClass.
 	existingSvc := &corev1.Service{
@@ -787,18 +753,19 @@ func TestProvisionNginxOnLBClassImmutabilityError(t *testing.T) {
 		WithObjects(existingSvc).
 		Build()
 
-	// Wrap the client so the first Service Update returns an LBClass immutability error.
-	wrappedClient := &lbClassImmutableClient{Client: fakeClient}
+	st := newStore(nil, "", "", "", "", "")
+	// Register the Service in the store so we can verify it gets cleared.
+	st.registerResourceInGatewayConfig(gatewayNSName, existingSvc)
 
 	provisioner := &NginxProvisioner{
 		leader: true,
-		store:  newStore(nil, "", "", "", "", ""),
+		store:  st,
 		cfg: Config{
 			Logger:           logr.Discard(),
 			EventRecorder:    &k8sEvents.FakeRecorder{},
 			GatewayPodConfig: &config.GatewayPodConfig{},
 		},
-		k8sClient: wrappedClient,
+		k8sClient: fakeClient,
 	}
 
 	lbClass := "gateway.nginx.org/nginx-gateway-controller"
@@ -810,15 +777,148 @@ func TestProvisionNginxOnLBClassImmutabilityError(t *testing.T) {
 		},
 	}
 
-	// Gateway has no addresses so patchServiceStatus is not triggered.
 	gateway := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
 	}
 
+	// The store should have the Service registered before provisioning.
+	nginxRes := st.getNginxResourcesForGateway(gatewayNSName)
+	g.Expect(nginxRes).ToNot(BeNil())
+	g.Expect(nginxRes.Service.Name).To(Equal("gw-nginx"))
+
 	err := provisioner.provisionNginx(t.Context(), "gw-nginx", gateway, []client.Object{desiredSvc})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify the Service was recreated with the desired LoadBalancerClass.
+	got := &corev1.Service{}
+	g.Expect(fakeClient.Get(
+		t.Context(),
+		types.NamespacedName{Name: "gw-nginx", Namespace: "default"},
+		got,
+	)).To(Succeed())
+	g.Expect(got.Spec.LoadBalancerClass).ToNot(BeNil())
+	g.Expect(*got.Spec.LoadBalancerClass).To(Equal(lbClass))
+}
+
+func TestDeleteServiceForLBClassChangeRestoresStoreOnFailure(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	gatewayNSName := types.NamespacedName{Name: "gw", Namespace: "default"}
+
+	existingSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-nginx", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(createScheme()).
+		WithObjects(existingSvc).
+		Build()
+
+	st := newStore(nil, "", "", "", "", "")
+	st.registerResourceInGatewayConfig(gatewayNSName, existingSvc)
+
+	deleteErr := errors.New("connection refused")
+	provisioner := &NginxProvisioner{
+		leader: true,
+		store:  st,
+		cfg: Config{
+			Logger:           logr.Discard(),
+			EventRecorder:    &k8sEvents.FakeRecorder{},
+			GatewayPodConfig: &config.GatewayPodConfig{},
+		},
+		k8sClient: &deleteFailingClient{Client: fakeClient, err: deleteErr},
+	}
+
+	lbClass := "gateway.nginx.org/nginx-gateway-controller"
+	desiredSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-nginx", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+	}
+
+	err := provisioner.deleteServiceForLBClassChange(t.Context(), gateway, []client.Object{desiredSvc})
 	g.Expect(err).To(HaveOccurred())
-	// Should not retry when its a LBClass immutability error
-	g.Expect(wrappedClient.svcUpdateAttempts).To(Equal(1))
+	g.Expect(err.Error()).To(ContainSubstring("connection refused"))
+
+	// The store entry should be restored so the next reconcile can retry deletion.
+	nginxRes := st.getNginxResourcesForGateway(gatewayNSName)
+	g.Expect(nginxRes).ToNot(BeNil())
+	g.Expect(nginxRes.Service.Name).To(Equal("gw-nginx"))
+	g.Expect(nginxRes.ServiceLBClass).To(BeNil())
+}
+
+func TestDeleteServiceForLBClassChangeFallsBackToLiveGet(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	// Service exists in the cluster with no LoadBalancerClass, but the store is empty
+	// (simulating a controller restart before the informer delivers the event).
+	existingSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-nginx", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(createScheme()).
+		WithObjects(existingSvc).
+		Build()
+
+	st := newStore(nil, "", "", "", "", "")
+	// Intentionally do NOT register the Service in the store.
+
+	provisioner := &NginxProvisioner{
+		leader: true,
+		store:  st,
+		cfg: Config{
+			Logger:           logr.Discard(),
+			EventRecorder:    &k8sEvents.FakeRecorder{},
+			GatewayPodConfig: &config.GatewayPodConfig{},
+		},
+		k8sClient: fakeClient,
+	}
+
+	lbClass := "gateway.nginx.org/nginx-gateway-controller"
+	desiredSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-nginx", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+	}
+
+	err := provisioner.deleteServiceForLBClassChange(t.Context(), gateway, []client.Object{desiredSvc})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The old Service should have been deleted via the fallback GET path.
+	got := &corev1.Service{}
+	err = fakeClient.Get(
+		t.Context(),
+		types.NamespacedName{Name: "gw-nginx", Namespace: "default"},
+		got,
+	)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+// deleteFailingClient wraps a client.Client and fails all Delete calls with the configured error.
+type deleteFailingClient struct {
+	client.Client
+	err error
+}
+
+func (d *deleteFailingClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+	return d.err
 }
 
 func TestProvisionerRestartsDeployment(t *testing.T) {
@@ -1653,65 +1753,40 @@ func TestPatchServiceStatus(t *testing.T) {
 	}
 }
 
-func TestIsLoadBalancerClassImmutabilityErr(t *testing.T) {
+func TestNeedToDeleteServiceForLBClassChange(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		err    error
-		name   string
-		expect bool
+		existing *string
+		desired  *string
+		name     string
+		expect   bool
 	}{
 		{
-			name:   "nil error",
-			err:    nil,
+			name:   "both nil",
 			expect: false,
 		},
 		{
-			name:   "non-invalid API error has no loadBalancerClass cause",
-			err:    apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, "test-svc"),
-			expect: false,
+			name:     "both equal",
+			existing: helpers.GetPointer("my-class"),
+			desired:  helpers.GetPointer("my-class"),
+			expect:   false,
 		},
 		{
-			name: "invalid error for a different field",
-			err: apierrors.NewInvalid(
-				schema.GroupKind{Group: "", Kind: "Service"},
-				"test-svc",
-				field.ErrorList{
-					field.Invalid(field.NewPath("spec").Child("type"), "ClusterIP", "cannot change type"),
-				},
-			),
-			expect: false,
+			name:    "existing nil, desired set",
+			desired: helpers.GetPointer("my-class"),
+			expect:  true,
 		},
 		{
-			name: "invalid error for spec.loadBalancerClass",
-			err: apierrors.NewInvalid(
-				schema.GroupKind{Group: "", Kind: "Service"},
-				"test-svc",
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec").Child("loadBalancerClass"),
-						"gateway.nginx.org/nginx-gateway-controller",
-						"may not change once set",
-					),
-				},
-			),
-			expect: true,
+			name:     "existing set, desired nil",
+			existing: helpers.GetPointer("my-class"),
+			expect:   true,
 		},
 		{
-			name: "invalid error with multiple causes including spec.loadBalancerClass",
-			err: apierrors.NewInvalid(
-				schema.GroupKind{Group: "", Kind: "Service"},
-				"test-svc",
-				field.ErrorList{
-					field.Invalid(field.NewPath("spec").Child("type"), "ClusterIP", "cannot change type"),
-					field.Invalid(
-						field.NewPath("spec").Child("loadBalancerClass"),
-						"gateway.nginx.org/nginx-gateway-controller",
-						"may not change once set",
-					),
-				},
-			),
-			expect: true,
+			name:     "both set but different",
+			existing: helpers.GetPointer("old-class"),
+			desired:  helpers.GetPointer("new-class"),
+			expect:   true,
 		},
 	}
 
@@ -1719,7 +1794,7 @@ func TestIsLoadBalancerClassImmutabilityErr(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			g.Expect(isLoadBalancerClassImmutabilityErr(test.err)).To(Equal(test.expect))
+			g.Expect(needToDeleteServiceForLBClassChange(test.existing, test.desired)).To(Equal(test.expect))
 		})
 	}
 }

--- a/internal/controller/provisioner/setter.go
+++ b/internal/controller/provisioner/setter.go
@@ -149,7 +149,22 @@ func serviceSpecSetter(
 		service.OwnerReferences = objectMeta.OwnerReferences
 		service.Annotations = mergeAnnotations(existingAnnotations, objectMeta.Annotations)
 
+		// Preserve server-assigned immutable fields from the existing Service.
+		// clusterIP and clusterIPs are assigned by the API server on creation and
+		// cannot be changed. When we overwrite the entire Spec we must carry them
+		// forward, otherwise the update is rejected.
+		existingClusterIP := service.Spec.ClusterIP
+		existingClusterIPs := service.Spec.ClusterIPs
+
 		service.Spec = spec
+
+		if existingClusterIP != "" {
+			service.Spec.ClusterIP = existingClusterIP
+		}
+		if len(existingClusterIPs) > 0 {
+			service.Spec.ClusterIPs = existingClusterIPs
+		}
+
 		return nil
 	}
 }

--- a/internal/controller/provisioner/setter_test.go
+++ b/internal/controller/provisioner/setter_test.go
@@ -161,6 +161,77 @@ func TestServiceSpecSetter_PreservesExternalAnnotations(t *testing.T) {
 	}
 }
 
+func TestServiceSpecSetter_PreservesClusterIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		existingClusterIP  string
+		existingClusterIPs []string
+		expectedClusterIP  string
+		expectedClusterIPs []string
+	}{
+		{
+			name:               "preserves existing clusterIP and clusterIPs",
+			existingClusterIP:  "10.96.0.1",
+			existingClusterIPs: []string{"10.96.0.1"},
+			expectedClusterIP:  "10.96.0.1",
+			expectedClusterIPs: []string{"10.96.0.1"},
+		},
+		{
+			name:               "preserves dual-stack clusterIPs",
+			existingClusterIP:  "10.96.0.1",
+			existingClusterIPs: []string{"10.96.0.1", "fd00::1"},
+			expectedClusterIP:  "10.96.0.1",
+			expectedClusterIPs: []string{"10.96.0.1", "fd00::1"},
+		},
+		{
+			name:               "no-op when existing clusterIP is empty",
+			existingClusterIP:  "",
+			existingClusterIPs: nil,
+			expectedClusterIP:  "",
+			expectedClusterIPs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			existingService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP:  tt.existingClusterIP,
+					ClusterIPs: tt.existingClusterIPs,
+				},
+			}
+
+			desiredMeta := metav1.ObjectMeta{
+				Labels: map[string]string{"app": "nginx-gateway"},
+			}
+
+			desiredSpec := corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			}
+
+			err := serviceSpecSetter(existingService, desiredSpec, desiredMeta)()
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(existingService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+			g.Expect(existingService.Spec.Ports).To(Equal(desiredSpec.Ports))
+			g.Expect(existingService.Spec.ClusterIP).To(Equal(tt.expectedClusterIP))
+			g.Expect(existingService.Spec.ClusterIPs).To(Equal(tt.expectedClusterIPs))
+		})
+	}
+}
+
 func int32Ptr(i int32) *int32 { return &i }
 
 func TestDeploymentAndDaemonSetSpecSetter(t *testing.T) {

--- a/internal/controller/provisioner/store.go
+++ b/internal/controller/provisioner/store.go
@@ -26,6 +26,7 @@ type NginxResources struct {
 	PDB                 metav1.ObjectMeta
 	DaemonSet           metav1.ObjectMeta
 	Service             metav1.ObjectMeta
+	ServiceLBClass      *string
 	ServiceAccount      metav1.ObjectMeta
 	Role                metav1.ObjectMeta
 	RoleBinding         metav1.ObjectMeta
@@ -146,7 +147,9 @@ func (s *store) registerResourceInGatewayConfig(gatewayNSName types.NamespacedNa
 	case *appsv1.DaemonSet:
 		s.getOrCreateNginxResources(gatewayNSName).DaemonSet = obj.ObjectMeta
 	case *corev1.Service:
-		s.getOrCreateNginxResources(gatewayNSName).Service = obj.ObjectMeta
+		res := s.getOrCreateNginxResources(gatewayNSName)
+		res.Service = obj.ObjectMeta
+		res.ServiceLBClass = obj.Spec.LoadBalancerClass
 	case *corev1.ServiceAccount:
 		s.getOrCreateNginxResources(gatewayNSName).ServiceAccount = obj.ObjectMeta
 	case *rbacv1.Role:
@@ -327,6 +330,19 @@ func (s *store) deleteResourcesForGateway(nsName types.NamespacedName) {
 	defer s.lock.Unlock()
 
 	delete(s.nginxResources, nsName)
+}
+
+// clearServiceForGateway removes the Service entry from the NginxResources tracked for the
+// given Gateway. This prevents the delete-event handler from treating a subsequent intentional
+// Service deletion as an unexpected removal that needs reprovisioning.
+func (s *store) clearServiceForGateway(gatewayNSName types.NamespacedName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if cfg, ok := s.nginxResources[gatewayNSName]; ok {
+		cfg.Service = metav1.ObjectMeta{}
+		cfg.ServiceLBClass = nil
+	}
 }
 
 func (s *store) gatewayExistsForResource(object client.Object, nsName types.NamespacedName) *graph.Gateway {

--- a/internal/controller/provisioner/store.go
+++ b/internal/controller/provisioner/store.go
@@ -503,6 +503,13 @@ func (s *store) markGatewayDeleting(nsName types.NamespacedName) {
 	s.deletingGateways.Store(nsName, struct{}{})
 }
 
+// clearGatewayDeleting removes the deleting mark for a Gateway.
+// This must be called when a Gateway with the same name is re-created
+// so that reprovisionResources is not blocked for the new Gateway's managed resources.
+func (s *store) clearGatewayDeleting(nsName types.NamespacedName) {
+	s.deletingGateways.Delete(nsName)
+}
+
 // isGatewayDeleting checks if a Gateway is marked as being deleted.
 func (s *store) isGatewayDeleting(nsName types.NamespacedName) bool {
 	_, exists := s.deletingGateways.Load(nsName)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,7 +57,7 @@ deploy-metallb: ## Deploy MetalLB to the cluster (required for LoadBalancer serv
 	kubectl apply -f conformance/metallb-pool.yaml
 
 .PHONY: run-conformance-tests
-run-conformance-tests: ## Run conformance tests
+run-conformance-tests: deploy-metallb ## Run conformance tests
 	kind load docker-image $(CONFORMANCE_PREFIX):$(CONFORMANCE_TAG) --name $(CLUSTER_NAME)
 	kubectl apply -f conformance/conformance-rbac.yaml
 	kubectl run -i conformance \
@@ -127,6 +127,8 @@ cleanup-conformance-tests: ## Clean up conformance tests fixtures
 	kubectl delete pod conformance --ignore-not-found
 	kubectl delete pod conformance-inference --ignore-not-found
 	kubectl delete -f conformance/conformance-rbac.yaml --ignore-not-found
+	kubectl delete -f conformance/metallb-pool.yaml --ignore-not-found || true
+	kubectl delete -f https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml --ignore-not-found || true
 
 .PHONY: reset-go-modules
 reset-go-modules: ## Reset the go modules changes

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,14 +21,12 @@ This directory contains the tests for NGINX Gateway Fabric. The tests are divide
     - [Option 1 - Build and install NGINX Gateway Fabric from local to configured kind cluster](#option-1---build-and-install-nginx-gateway-fabric-from-local-to-configured-kind-cluster)
     - [Option 2 - Install NGINX Gateway Fabric from local already built image to configured kind cluster](#option-2---install-nginx-gateway-fabric-from-local-already-built-image-to-configured-kind-cluster)
   - [Step 2 - Build conformance test runner image](#step-2---build-conformance-test-runner-image)
-  - [Step 3 - Deploy MetalLB to the kind cluster](#step-3---deploy-metallb-to-the-kind-cluster)
-    - [To deploy MetalLB to the kind cluster](#to-deploy-metallb-to-the-kind-cluster)
-  - [Step 4 - Run Conformance tests](#step-4---run-conformance-tests)
+  - [Step 3 - Run Conformance tests](#step-3---run-conformance-tests)
     - [To run Gateway conformance tests](#to-run-gateway-conformance-tests)
     - [To run Inference conformance tests](#to-run-inference-conformance-tests)
-  - [Step 5 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric](#step-5---cleanup-the-conformance-test-fixtures-and-uninstall-nginx-gateway-fabric)
-  - [Step 6 - Revert changes to Go modules](#step-6---revert-changes-to-go-modules)
-  - [Step 7 - Delete kind cluster](#step-7---delete-kind-cluster)
+  - [Step 4 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric](#step-4---cleanup-the-conformance-test-fixtures-and-uninstall-nginx-gateway-fabric)
+  - [Step 5 - Revert changes to Go modules](#step-5---revert-changes-to-go-modules)
+  - [Step 6 - Delete kind cluster](#step-6---delete-kind-cluster)
 - [System Testing](#system-testing)
   - [Logging in tests](#logging-in-tests)
   - [Step 1 - Run the tests](#step-1---run-the-tests)
@@ -213,20 +211,11 @@ go mod tidy
 make build-test-runner-image
 ```
 
-### Step 3 - Deploy MetalLB to the kind cluster
-
-#### To deploy MetalLB to the kind cluster
-
-> This is needed to assign external IPs to the Loadbalancer Services spun up in the conformance test.
-> If your cluster can already do this, it is okay to skip.
-
-```makefile
-make deploy-metallb
-```
-
-### Step 4 - Run Conformance tests
+### Step 3 - Run Conformance tests
 
 #### To run Gateway conformance tests
+
+This will also pre-install MetalLB to assign external IPs to the LoadBalancer Services.
 
 ```makefile
 make run-conformance-tests
@@ -238,7 +227,7 @@ make run-conformance-tests
 make run-inference-conformance-tests
 ```
 
-### Step 5 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric
+### Step 4 - Cleanup the conformance test fixtures and uninstall NGINX Gateway Fabric
 
 ```makefile
 make cleanup-conformance-tests
@@ -248,7 +237,7 @@ make cleanup-conformance-tests
 make uninstall-ngf
 ```
 
-### Step 6 - Revert changes to Go modules
+### Step 5 - Revert changes to Go modules
 
 **Optional** Not required if you aren't running the `main` Gateway API tests.
 
@@ -256,7 +245,7 @@ make uninstall-ngf
 make reset-go-modules
 ```
 
-### Step 7 - Delete kind cluster
+### Step 6 - Delete kind cluster
 
 ```makefile
 make delete-kind-cluster

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -225,10 +225,6 @@ var _ = Describe("Graceful Recovery: abrupt node restart",
 		})
 
 		It("recovers when node is restarted abruptly", func() {
-			if *plusEnabled {
-				Skip("Skipping test when using NGINX Plus due to known issue:" +
-					" https://github.com/nginx/nginx-gateway-fabric/issues/3248")
-			}
 			runRestartNodeTest(
 				gracefulRecoveryFiles, &ns,
 				&activeNGFPodName, &activeNginxPodName,


### PR DESCRIPTION
Problem: The GatewayStaticAddress conformance test intermittently fails due to two issues:

1. When a Gateway gains IP addresses, the provisioner sets spec.loadBalancerClass on the Service. Kubernetes marks this field as immutable, so the subsequent CreateOrUpdate fails with an Invalid error that retries indefinitely.

2. After commit 77865be ("Stop using deprecated externalIPs service field"), Gateway addresses are populated from Service.Status.LoadBalancer.Ingress instead of directly from Gateway.Spec.Addresses. Since RegisterGateway (which patches the Service status) runs in a goroutine while status updates are enqueued synchronously, the status handler can read the Service before the patch completes, resulting in empty Gateway addresses.

3. This work also uncovered a bug where Gateways that got deleted weren't removed from an internal tracking store, which could cause issues with re-provisioning nginx resources if the Gateways were ever re-created with the same name.

Solution:

For (1), before running CreateOrUpdate, proactively compare the desired loadBalancerClass against the value tracked in the in-memory store. If they differ, clear the Service from the store and delete it. The normal CreateOrUpdate then creates a fresh Service with the correct loadBalancerClass. Also preserve clusterIP and clusterIPs across Service spec updates in the setter, since these are server-assigned immutable fields that would otherwise be wiped by the full spec overwrite.

For (2), collect status queue objects during the gateway loop and defer their enqueue until all RegisterGateway goroutines have finished via sync.WaitGroup, ensuring the Service status is fully patched before the status handler reads it.

For (3), remove Gateways from the internal store when deleted.

Additionally, make deploy-metallb a prerequisite of run-conformance-tests and clean it up in cleanup-conformance-tests, removing a manual step from the conformance test workflow. Removed a skip from a graceful recovery test for NGINX Plus that appears to be passing now.

Testing: All tests now pass.

Closes #5437 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix a bug that could prevent nginx resources from being provisioned properly if a Gateway is deleted and then re-created.
```
