### PR TITLE
Fix route and policy attachment edge cases

### DIFF
--- a/internal/controller/state/graph/authentication_filter.go
+++ b/internal/controller/state/graph/authentication_filter.go
@@ -589,17 +589,16 @@ func propagateInvalidOIDCFiltersToRouteRules(filterRefs map[*AuthenticationFilte
 		nonHTTPSMsg = "OIDC authentication requires an HTTPS listener"
 	)
 
-	invalidatedRoutes := make(map[*L7Route]struct{})
+	globallyInvalidRoutes := make(map[*L7Route]struct{})
 	for af, refs := range filterRefs {
 		for _, ref := range refs {
 			if !af.Valid {
 				ref.route.Spec.Rules[ref.ruleIdx].Filters.Filters[ref.filterIdx].ResolvedExtensionRef.Valid = false
 				ref.route.Spec.Rules[ref.ruleIdx].Filters.Valid = false
-				invalidatedRoutes[ref.route] = struct{}{}
+				globallyInvalidRoutes[ref.route] = struct{}{}
 			} else if ref.nonHTTPS {
 				ref.route.Spec.Rules[ref.ruleIdx].Filters.Filters[ref.filterIdx].ResolvedExtensionRef.Valid = false
 				ref.route.Spec.Rules[ref.ruleIdx].Filters.Valid = false
-				invalidatedRoutes[ref.route] = struct{}{}
 				mergeOrAppendRouteCondition(
 					ref.route,
 					conditions.NewRouteResolvedRefsInvalidFilter(nonHTTPSMsg),
@@ -608,7 +607,7 @@ func propagateInvalidOIDCFiltersToRouteRules(filterRefs map[*AuthenticationFilte
 		}
 	}
 
-	for route := range invalidatedRoutes {
+	for route := range globallyInvalidRoutes {
 		mergeOrAppendRouteCondition(route, conditions.NewRouteResolvedRefsInvalidFilter(invalidMsg))
 	}
 }

--- a/internal/controller/state/graph/authentication_filter.go
+++ b/internal/controller/state/graph/authentication_filter.go
@@ -30,6 +30,8 @@ type oidcRuleRef struct {
 	route     *L7Route
 	ruleIdx   int
 	filterIdx int
+	// nonHTTPS is true when this route-rule reference is attached via a non-HTTPS listener.
+	nonHTTPS bool
 }
 
 // AuthenticationFilter represents a ngfAPI.AuthenticationFilter.
@@ -480,7 +482,7 @@ func validateOIDCLogoutURIs(
 }
 
 // validateOIDCFilters performs all post-binding OIDC validations in a single pass over routes and rules:
-//   - filters attached to non-HTTPS listeners are marked invalid immediately
+//   - filters referenced via non-HTTPS listeners are recorded per-route-rule
 //   - the remaining valid filters are collected for URI conflict detection across shared hostnames
 func validateOIDCFilters(routes map[RouteKey]*L7Route, gws map[types.NamespacedName]*Gateway) {
 	listenerProtocols := buildListenerProtocolMap(gws)
@@ -529,9 +531,9 @@ func hasNonHTTPSAttachment(parentRefs []ParentRef, listenerProtocols map[string]
 
 // collectOIDCFilterInfo performs a single pass over all valid routes and rules.
 // For each OIDC filter encountered:
-//   - if its route has a non-HTTPS listener attachment and the filter is still valid, it is marked invalid
-//   - all filters (valid or not) are registered in filterRefs for propagation
-//   - only valid filters are registered in hostnameToFilters for URI conflict detection
+//   - if its route has a non-HTTPS listener attachment, the oidcRuleRef is flagged
+//   - all filters are registered in filterRefs for propagation
+//   - only valid filters on HTTPS routes are registered in hostnameToFilters for URI conflict detection
 func collectOIDCFilterInfo(
 	routes map[RouteKey]*L7Route,
 	listenerProtocols map[string]v1.ProtocolType,
@@ -560,14 +562,9 @@ func collectOIDCFilterInfo(
 				if af == nil {
 					continue
 				}
-				if nonHTTPS && af.Valid {
-					af.Conditions = append(af.Conditions,
-						conditions.NewAuthenticationFilterInvalid("OIDC authentication requires an HTTPS listener"),
-					)
-					af.Valid = false
-				}
-				filterRefs[af] = append(filterRefs[af], oidcRuleRef{route: route, ruleIdx: i, filterIdx: j})
-				if af.Valid {
+				ref := oidcRuleRef{route: route, ruleIdx: i, filterIdx: j, nonHTTPS: nonHTTPS}
+				filterRefs[af] = append(filterRefs[af], ref)
+				if af.Valid && !nonHTTPS {
 					nsname := types.NamespacedName{Namespace: af.Source.Namespace, Name: af.Source.Name}
 					for _, hostname := range acceptedHostnames {
 						if hostnameToFilters[hostname] == nil {
@@ -583,21 +580,31 @@ func collectOIDCFilterInfo(
 	return hostnameToFilters, filterRefs
 }
 
-// propagateInvalidOIDCFiltersToRouteRules marks route rules as having an invalid filter when their referenced
-// OIDC filter was invalidated by URI conflict detection. This ensures the dataplane treats those rules as
-// invalid rather than silently skipping authentication.
+// propagateInvalidOIDCFiltersToRouteRules marks route rules as having an invalid filter when:
+//   - the filter is globally invalid (e.g. URI conflict), or
+//   - the route-rule reference is attached via a non-HTTPS listener.
 func propagateInvalidOIDCFiltersToRouteRules(filterRefs map[*AuthenticationFilter][]oidcRuleRef) {
-	const invalidMsg = "OIDC filter is invalid; see filter status for details"
+	const (
+		invalidMsg  = "OIDC filter is invalid; see filter status for details"
+		nonHTTPSMsg = "OIDC authentication requires an HTTPS listener"
+	)
 
 	invalidatedRoutes := make(map[*L7Route]struct{})
 	for af, refs := range filterRefs {
-		if af.Valid {
-			continue
-		}
 		for _, ref := range refs {
-			ref.route.Spec.Rules[ref.ruleIdx].Filters.Filters[ref.filterIdx].ResolvedExtensionRef.Valid = false
-			ref.route.Spec.Rules[ref.ruleIdx].Filters.Valid = false
-			invalidatedRoutes[ref.route] = struct{}{}
+			if !af.Valid {
+				ref.route.Spec.Rules[ref.ruleIdx].Filters.Filters[ref.filterIdx].ResolvedExtensionRef.Valid = false
+				ref.route.Spec.Rules[ref.ruleIdx].Filters.Valid = false
+				invalidatedRoutes[ref.route] = struct{}{}
+			} else if ref.nonHTTPS {
+				ref.route.Spec.Rules[ref.ruleIdx].Filters.Filters[ref.filterIdx].ResolvedExtensionRef.Valid = false
+				ref.route.Spec.Rules[ref.ruleIdx].Filters.Valid = false
+				invalidatedRoutes[ref.route] = struct{}{}
+				mergeOrAppendRouteCondition(
+					ref.route,
+					conditions.NewRouteResolvedRefsInvalidFilter(nonHTTPSMsg),
+				)
+			}
 		}
 	}
 

--- a/internal/controller/state/graph/authentication_filter_test.go
+++ b/internal/controller/state/graph/authentication_filter_test.go
@@ -1510,7 +1510,7 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 			expFilterValid: true,
 		},
 		{
-			name: "OIDC filter on route attached to HTTP listener - filter marked invalid with HTTPS required condition",
+			name: "OIDC filter on route attached to HTTP listener - filter stays valid, route rules invalidated",
 			buildRouteAndGateway: func() (map[RouteKey]*L7Route, map[types.NamespacedName]*Gateway) {
 				af := createAuthenticationFilterWithOIDC(filterNsName, &ngfAPI.OIDCAuth{}, true)
 				gw := makeGateway(gwNSName, v1.HTTPProtocolType)
@@ -1520,10 +1520,7 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 					},
 					map[types.NamespacedName]*Gateway{gwNSName: gw}
 			},
-			expFilterValid: false,
-			expConditions: []conditions.Condition{
-				conditions.NewAuthenticationFilterInvalid("OIDC authentication requires an HTTPS listener"),
-			},
+			expFilterValid: true,
 		},
 		{
 			name: "OIDC filter already invalid before HTTPS check - not double-processed, stays invalid",
@@ -1557,8 +1554,8 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 			expFilterValid: true,
 		},
 		{
-			name: "shared OIDC filter referenced by a route on HTTP listener and another route on HTTPS listener " +
-				"filter is marked invalid due to HTTP attachment and both routes rules are marked invalid via propagation",
+			name: "shared OIDC filter referenced by HTTP and HTTPS routes - " +
+				"filter stays valid, only HTTP route rules invalidated",
 			buildRouteAndGateway: func() (map[RouteKey]*L7Route, map[types.NamespacedName]*Gateway) {
 				af := createAuthenticationFilterWithOIDC(filterNsName, &ngfAPI.OIDCAuth{}, true)
 				httpGWNSName := types.NamespacedName{Namespace: "default", Name: "http-gw"}
@@ -1577,10 +1574,7 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 					},
 					map[types.NamespacedName]*Gateway{httpGWNSName: httpGW, httpsGWNSName: httpsGW}
 			},
-			expFilterValid: false,
-			expConditions: []conditions.Condition{
-				conditions.NewAuthenticationFilterInvalid("OIDC authentication requires an HTTPS listener"),
-			},
+			expFilterValid: true,
 		},
 		{
 			name: "OIDC filter on route attached to HTTPS ListenerSet listener - valid, no condition added",
@@ -1598,7 +1592,7 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 		},
 		{
 			name: "OIDC filter on route attached to HTTP ListenerSet listener - " +
-				"filter marked invalid with HTTPS required condition",
+				"filter stays valid, route rules invalidated",
 			buildRouteAndGateway: func() (map[RouteKey]*L7Route, map[types.NamespacedName]*Gateway) {
 				af := createAuthenticationFilterWithOIDC(filterNsName, &ngfAPI.OIDCAuth{}, true)
 				listenerSetNsName := types.NamespacedName{Namespace: "test", Name: "listener-set"}
@@ -1609,10 +1603,7 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 					},
 					map[types.NamespacedName]*Gateway{gwNSName: gw}
 			},
-			expFilterValid: false,
-			expConditions: []conditions.Condition{
-				conditions.NewAuthenticationFilterInvalid("OIDC authentication requires an HTTPS listener"),
-			},
+			expFilterValid: true,
 		},
 	}
 
@@ -1641,6 +1632,96 @@ func TestValidateOIDCHTTPSListeners(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOIDCSharedFilterHTTPAndHTTPS(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	makeGW := func(nsname types.NamespacedName, protocol v1.ProtocolType) *Gateway {
+		return &Gateway{
+			Source: &v1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}},
+			Listeners: []*Listener{{
+				GatewayName: nsname,
+				Name:        "listener",
+				Source:      v1.Listener{Protocol: protocol},
+			}},
+		}
+	}
+
+	makeRoute := func(af *AuthenticationFilter, gwNSName types.NamespacedName) *L7Route {
+		listenerKey := CreateParentRefListenerKey(gwNSName, "listener")
+		return &L7Route{
+			Valid: true,
+			Spec: L7RouteSpec{
+				Rules: []RouteRule{{
+					ValidMatches: true,
+					Filters: RouteRuleFilters{
+						Filters: []Filter{{
+							FilterType:           FilterExtensionRef,
+							ResolvedExtensionRef: &ExtensionRefFilter{AuthenticationFilter: af, Valid: af.Valid},
+						}},
+						Valid: true,
+					},
+				}},
+			},
+			ParentRefs: []ParentRef{{
+				Kind:           kinds.Gateway,
+				NamespacedName: gwNSName,
+				Attachment: &ParentRefAttachmentStatus{
+					AcceptedHostnames: map[string][]string{listenerKey: {"cafe.example.com"}},
+					Attached:          true,
+				},
+			}},
+		}
+	}
+
+	filterNsName := types.NamespacedName{Namespace: "ns", Name: "oidc-filter"}
+	af := createAuthenticationFilterWithOIDC(filterNsName, &ngfAPI.OIDCAuth{}, true)
+
+	httpGWNSName := types.NamespacedName{Namespace: "default", Name: "http-gw"}
+	httpsGWNSName := types.NamespacedName{Namespace: "default", Name: "https-gw"}
+	httpGW := makeGW(httpGWNSName, v1.HTTPProtocolType)
+	httpsGW := makeGW(httpsGWNSName, v1.HTTPSProtocolType)
+
+	httpRoute := makeRoute(af, httpGWNSName)
+	httpsRoute := makeRoute(af, httpsGWNSName)
+
+	routes := map[RouteKey]*L7Route{
+		{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "http-route"}, RouteType: RouteTypeHTTP}:  httpRoute,
+		{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "https-route"}, RouteType: RouteTypeHTTP}: httpsRoute,
+	}
+	gws := map[types.NamespacedName]*Gateway{httpGWNSName: httpGW, httpsGWNSName: httpsGW}
+
+	validateOIDCFilters(routes, gws)
+
+	// The shared filter must remain valid.
+	g.Expect(af.Valid).To(BeTrue(), "shared filter should not be mutated to invalid")
+	g.Expect(af.Conditions).To(BeEmpty(), "shared filter should not have conditions appended")
+
+	// The HTTP route's rules should be invalidated.
+	for _, rule := range httpRoute.Spec.Rules {
+		g.Expect(rule.Filters.Valid).To(BeFalse(), "HTTP route rule filters should be invalid")
+		for _, f := range rule.Filters.Filters {
+			if f.ResolvedExtensionRef != nil {
+				g.Expect(f.ResolvedExtensionRef.Valid).To(BeFalse(),
+					"HTTP route resolved extension ref should be invalid")
+			}
+		}
+	}
+	g.Expect(httpRoute.Conditions).ToNot(BeEmpty(), "HTTP route should have a condition")
+
+	// The HTTPS route's rules should remain valid.
+	for _, rule := range httpsRoute.Spec.Rules {
+		g.Expect(rule.Filters.Valid).To(BeTrue(), "HTTPS route rule filters should remain valid")
+		for _, f := range rule.Filters.Filters {
+			if f.ResolvedExtensionRef != nil {
+				g.Expect(f.ResolvedExtensionRef.Valid).To(BeTrue(),
+					"HTTPS route resolved extension ref should remain valid")
+			}
+		}
+	}
+	g.Expect(httpsRoute.Conditions).To(BeEmpty(), "HTTPS route should not have conditions")
 }
 
 func TestValidateOIDCURIConflictsPerHostname(t *testing.T) {

--- a/internal/controller/state/graph/backend_refs.go
+++ b/internal/controller/state/graph/backend_refs.go
@@ -444,6 +444,17 @@ func validateBackendTLSPolicyMatchingAllBackends(backendRefs []BackendRef) *cond
 	return nil
 }
 
+// btpTargetsService reports whether the given targetRef targets a Service with the specified name and namespace.
+func btpTargetsService(
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	btpNs, refName, refNs string,
+) bool {
+	return string(targetRef.Name) == refName &&
+		btpNs == refNs &&
+		targetRef.Kind == kinds.Service &&
+		(targetRef.Group == "" || targetRef.Group == "core")
+}
+
 func findBackendTLSPolicyForService(
 	backendTLSPolicies map[types.NamespacedName]*BackendTLSPolicy,
 	refNamespace *gatewayv1.Namespace,
@@ -464,29 +475,30 @@ func findBackendTLSPolicyForService(
 	for _, btp := range backendTLSPolicies {
 		btpNs := btp.Source.Namespace
 		for _, targetRef := range btp.Source.Spec.TargetRefs {
-			if string(targetRef.Name) == refName && btpNs == refNs {
-				// Check if this policy applies to the specific port we're interested in
-				if targetRef.SectionName != nil {
-					// Policy targets a specific port by name
-					if servicePort.Name != string(*targetRef.SectionName) {
-						// This policy targets a different port, skip it
-						continue
-					}
+			if !btpTargetsService(targetRef, btpNs, refName, refNs) {
+				continue
+			}
+			// Check if this policy applies to the specific port we're interested in
+			if targetRef.SectionName != nil {
+				// Policy targets a specific port by name
+				if servicePort.Name != string(*targetRef.SectionName) {
+					// This policy targets a different port, skip it
+					continue
 				}
-				// Policy applies to all ports (no sectionName) or matches our port
+			}
+			// Policy applies to all ports (no sectionName) or matches our port
 
-				if beTLSPolicy == nil {
+			if beTLSPolicy == nil {
+				beTLSPolicy = btp
+			} else {
+				// Found a conflict - determine which policy wins
+				if sort.LessClientObject(btp.Source, beTLSPolicy.Source) {
+					// btp wins, beTLSPolicy loses
+					conflictingPolicies = append(conflictingPolicies, beTLSPolicy)
 					beTLSPolicy = btp
 				} else {
-					// Found a conflict - determine which policy wins
-					if sort.LessClientObject(btp.Source, beTLSPolicy.Source) {
-						// btp wins, beTLSPolicy loses
-						conflictingPolicies = append(conflictingPolicies, beTLSPolicy)
-						beTLSPolicy = btp
-					} else {
-						// beTLSPolicy wins, btp loses
-						conflictingPolicies = append(conflictingPolicies, btp)
-					}
+					// beTLSPolicy wins, btp loses
+					conflictingPolicies = append(conflictingPolicies, btp)
 				}
 			}
 		}

--- a/internal/controller/state/graph/backend_refs_test.go
+++ b/internal/controller/state/graph/backend_refs_test.go
@@ -2020,6 +2020,49 @@ func TestFindBackendTLSPolicyForService(t *testing.T) {
 	}
 }
 
+func TestFindBackendTLSPolicyForService_IgnoresNonServiceKind(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	// BackendTLSPolicy targeting a non-Service Kind (e.g. ConfigMap) with the same name
+	// should not match when looking up policies for a Service.
+	btp := &BackendTLSPolicy{
+		Valid: true,
+		Source: &gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "btp",
+				Namespace: "test",
+			},
+			Spec: gatewayv1.BackendTLSPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: "",
+							Kind:  "ConfigMap",
+							Name:  "svc1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	backendTLSPolicies := map[types.NamespacedName]*BackendTLSPolicy{
+		{Namespace: "test", Name: "btp"}: btp,
+	}
+
+	result, err := findBackendTLSPolicyForService(
+		backendTLSPolicies,
+		helpers.GetPointer[gatewayv1.Namespace]("test"),
+		"svc1",
+		"test",
+		v1.ServicePort{Name: "https", Port: 443},
+	)
+
+	g.Expect(result).To(BeNil(), "policy targeting ConfigMap kind should not match a Service lookup")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 func TestGetRefGrantFromResourceForRoute(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/controller/state/graph/grpcroute.go
+++ b/internal/controller/state/graph/grpcroute.go
@@ -339,10 +339,10 @@ func processGRPCRouteRules(
 
 // ConvertGRPCMatches converts a GRPCMatch list to an HTTPRouteMatch list.
 func ConvertGRPCMatches(grpcMatches []v1.GRPCRouteMatch) []v1.HTTPRouteMatch {
-	pathValue := "/"
-	pathType := v1.PathMatchType("PathPrefix")
 	// If no matches are specified, the implementation MUST match every gRPC request.
 	if len(grpcMatches) == 0 {
+		pathType := v1.PathMatchType("PathPrefix")
+		pathValue := "/"
 		return []v1.HTTPRouteMatch{
 			{
 				Path: &v1.HTTPPathMatch{
@@ -356,6 +356,8 @@ func ConvertGRPCMatches(grpcMatches []v1.GRPCRouteMatch) []v1.HTTPRouteMatch {
 	hms := make([]v1.HTTPRouteMatch, 0, len(grpcMatches))
 
 	for _, gm := range grpcMatches {
+		pathValue := "/"
+		pathType := v1.PathMatchType("PathPrefix")
 		var hm v1.HTTPRouteMatch
 		hmHeaders := make([]v1.HTTPHeaderMatch, 0, len(gm.Headers))
 		for _, head := range gm.Headers {

--- a/internal/controller/state/graph/grpcroute_test.go
+++ b/internal/controller/state/graph/grpcroute_test.go
@@ -2409,14 +2409,14 @@ func TestConvertGRPCMatches(t *testing.T) {
 				{
 					Path: &v1.HTTPPathMatch{
 						Type:  helpers.GetPointer(v1.PathMatchExact),
-						Value: new("/myService/myMethod"),
+						Value: helpers.GetPointer("/myService/myMethod"),
 					},
 					Headers: []v1.HTTPHeaderMatch{},
 				},
 				{
 					Path: &v1.HTTPPathMatch{
 						Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
-						Value: new("/"),
+						Value: helpers.GetPointer("/"),
 					},
 					Headers: []v1.HTTPHeaderMatch{
 						{

--- a/internal/controller/state/graph/grpcroute_test.go
+++ b/internal/controller/state/graph/grpcroute_test.go
@@ -2399,6 +2399,35 @@ func TestConvertGRPCMatches(t *testing.T) {
 			methodMatches: []v1.GRPCRouteMatch{},
 			expected:      expectedEmptyMatches,
 		},
+		{
+			name: "method match followed by headers-only match resets path per iteration",
+			methodMatches: append(
+				methodMatch,
+				headersMatch...,
+			),
+			expected: []v1.HTTPRouteMatch{
+				{
+					Path: &v1.HTTPPathMatch{
+						Type:  helpers.GetPointer(v1.PathMatchExact),
+						Value: new("/myService/myMethod"),
+					},
+					Headers: []v1.HTTPHeaderMatch{},
+				},
+				{
+					Path: &v1.HTTPPathMatch{
+						Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
+						Value: new("/"),
+					},
+					Headers: []v1.HTTPHeaderMatch{
+						{
+							Value: "SomeValue",
+							Name:  v1.HTTPHeaderName("MyHeader"),
+							Type:  helpers.GetPointer(v1.HeaderMatchExact),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/controller/state/graph/route_common.go
+++ b/internal/controller/state/graph/route_common.go
@@ -1337,7 +1337,8 @@ func isRouteNamespaceAllowedByListener(
 
 			ns, exists := namespaces[types.NamespacedName{Name: routeNS}]
 			if !exists {
-				panic(fmt.Errorf("route namespace %q not found in map", routeNS))
+				// Namespace not found; deny attachment.
+				return false
 			}
 			return listener.AllowedRouteLabelSelector.Matches(labels.Set(ns.Labels))
 		}

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -2086,11 +2086,13 @@ func TestAllowedRouteType(t *testing.T) {
 
 func TestIsRouteNamespaceAllowedByListener(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
 	selectorFrom := gatewayv1.NamespacesFromSelector
-	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{"env": "prod"},
 	})
+	g.Expect(err).ToNot(HaveOccurred())
 
 	listener := &Listener{
 		Source: gatewayv1.Listener{

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -2084,6 +2084,72 @@ func TestAllowedRouteType(t *testing.T) {
 	}
 }
 
+func TestIsRouteNamespaceAllowedByListener(t *testing.T) {
+	t.Parallel()
+
+	selectorFrom := gatewayv1.NamespacesFromSelector
+	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "prod"},
+	})
+
+	listener := &Listener{
+		Source: gatewayv1.Listener{
+			AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From: &selectorFrom,
+				},
+			},
+		},
+		AllowedRouteLabelSelector: selector,
+	}
+
+	tests := []struct {
+		namespaces map[types.NamespacedName]*v1.Namespace
+		name       string
+		expected   bool
+	}{
+		{
+			name: "namespace exists and matches selector",
+			namespaces: map[types.NamespacedName]*v1.Namespace{
+				{Name: "route-ns"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "route-ns",
+						Labels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "namespace exists but does not match selector",
+			namespaces: map[types.NamespacedName]*v1.Namespace{
+				{Name: "route-ns"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "route-ns",
+						Labels: map[string]string{"env": "staging"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:       "namespace missing from map returns false instead of panicking",
+			namespaces: map[types.NamespacedName]*v1.Namespace{},
+			expected:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := isRouteNamespaceAllowedByListener(listener, "route-ns", "gw-ns", test.namespaces)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
 func TestBindL4RouteToListeners(t *testing.T) {
 	t.Parallel()
 	// we create a new listener each time because the function under test can modify it

--- a/internal/framework/controller/resource.go
+++ b/internal/framework/controller/resource.go
@@ -34,17 +34,27 @@ func truncateAndHashName(name string, suffix string) string {
 		return full
 	}
 
-	// Always include the suffix, truncate name as needed
 	hash := sha256.Sum256([]byte(full))
 	hashStr := hex.EncodeToString(hash[:])[:hashLen]
-	maxNameLen := max(MaxServiceNameLen-(len(sep)*2)-hashLen-len(suffix), 0)
+
+	// overhead = 2 separators + hash
+	overhead := (len(sep) * 2) + hashLen
+	budget := MaxServiceNameLen - overhead // chars available for name + suffix
+
+	truncSuffix := suffix
+	if len(suffix) >= budget {
+		// Reserve at least 1 char for the name so the result doesn't start with "-".
+		truncSuffix = suffix[:budget-1]
+	}
+
+	maxNameLen := budget - len(truncSuffix)
 	truncName := name
 	if len(name) > maxNameLen {
 		truncName = name[:maxNameLen]
 	}
 
-	// Remove trailing dashes to avoid double-dash when separator is added
+	// Remove trailing dashes to avoid double-dash when separator is added.
 	truncName = strings.TrimRight(truncName, sep)
 
-	return truncName + sep + hashStr + sep + suffix
+	return truncName + sep + hashStr + sep + truncSuffix
 }

--- a/internal/framework/controller/resource.go
+++ b/internal/framework/controller/resource.go
@@ -37,7 +37,7 @@ func truncateAndHashName(name string, suffix string) string {
 	// Always include the suffix, truncate name as needed
 	hash := sha256.Sum256([]byte(full))
 	hashStr := hex.EncodeToString(hash[:])[:hashLen]
-	maxNameLen := MaxServiceNameLen - (len(sep) * 2) - hashLen - len(suffix)
+	maxNameLen := max(MaxServiceNameLen-(len(sep)*2)-hashLen-len(suffix), 0)
 	truncName := name
 	if len(name) > maxNameLen {
 		truncName = name[:maxNameLen]

--- a/internal/framework/controller/resource_test.go
+++ b/internal/framework/controller/resource_test.go
@@ -97,3 +97,16 @@ func TestCreateInferencePoolServiceName(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateNginxResourceName_OversizeSuffixDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	// A suffix longer than 53 chars makes the internal maxNameLen negative.
+	// The function must not panic; the result will exceed MaxServiceNameLen
+	// but that is acceptable for degenerate inputs.
+	g.Expect(func() {
+		name := CreateNginxResourceName("name", strings.Repeat("s", 60))
+		g.Expect(len(name)).To(BeNumerically(">", 0))
+	}).NotTo(Panic())
+}

--- a/internal/framework/controller/resource_test.go
+++ b/internal/framework/controller/resource_test.go
@@ -98,15 +98,14 @@ func TestCreateInferencePoolServiceName(t *testing.T) {
 	}
 }
 
-func TestCreateNginxResourceName_OversizeSuffixDoesNotPanic(t *testing.T) {
+func TestCreateNginxResourceName_OversizeSuffix(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	// A suffix longer than 53 chars makes the internal maxNameLen negative.
-	// The function must not panic; the result will exceed MaxServiceNameLen
-	// but that is acceptable for degenerate inputs.
-	g.Expect(func() {
-		name := CreateNginxResourceName("name", strings.Repeat("s", 60))
-		g.Expect(len(name)).To(BeNumerically(">", 0))
-	}).NotTo(Panic())
+	// A suffix longer than 53 chars would previously make the internal maxNameLen
+	// negative. The function must not panic and must produce a valid <=63-char name.
+	name := CreateNginxResourceName("name", strings.Repeat("s", 60))
+	g.Expect(len(name)).To(BeNumerically("<=", MaxServiceNameLen))
+	g.Expect(name).NotTo(HavePrefix("-"), "name must not start with a dash")
+	g.Expect(name).NotTo(ContainSubstring("--"))
 }


### PR DESCRIPTION
Problem: Several edge cases in the route and policy graph could cause panics, silent misconfigurations, or overly broad invalidation of routes:
- NGF could panic when generating NGINX resource names for gateways or listeners with very long names.
- NGF could panic when processing routes if their target namespace was deleted during reconciliation.
- GRPCRoutes with multiple match rules could produce incorrect NGINX path configuration, causing a headers-only match to route to the wrong backend.
- A BackendTLSPolicy targeting a non-Service resource (e.g. ConfigMap) could be incorrectly applied to a Service with the same name.
- An OIDC filter referenced by routes on both HTTP and HTTPS listeners would reject all routes, including the valid HTTPS ones.

Solution: Harden input validation and boundary checks across route attachment, gRPC match conversion, BackendTLSPolicy resolution, OIDC filter validation, and NGINX resource name generation. unit tests for each case.

Testing: Manually verified each bug.

Closes #5424

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
- Fixed a panic that could occur during NGINX resource name generation when a GatewayClass name exceeds 53 characters.
- Fixed a panic that could occur during route processing when a namespace is deleted while routes referencing it are being reconciled.
- Fixed an issue where a GRPCRoute with multiple matches could produce incorrect NGINX path configuration when a method match is followed by a headers-only match, causing the second match to incorrectly inherit the path of the first.
- Fixed an issue where a BackendTLSPolicy could incorrectly be applied to a Service backend if a non-Service resource (e.g. ConfigMap) with the same name existed as a targetRef in the policy.
- Fixed an issue where an OIDC authentication filter shared by routes on both HTTP and HTTPS listeners would be marked globally invalid, causing the HTTPS routes to be unnecessarily rejected. Only the non-HTTPS routes are now affected.
```
