### PR TITLE
Update GatewayInvalidParametersRef condition; fix UDP weighting

### DIFF
--- a/internal/controller/nginx/config/stream_servers.go
+++ b/internal/controller/nginx/config/stream_servers.go
@@ -224,9 +224,17 @@ func createSplitClientForL4Server(server dataplane.Layer4VirtualServer) *stream.
 		return nil
 	}
 
-	// Calculate total weight
+	weightedUpstreams := make([]dataplane.Layer4Upstream, 0, len(server.Upstreams))
+
+	// Calculate total weight while skipping zero-weight backends. Rendering
+	// 0.00% is invalid in stream split_clients and breaks nginx reloads.
 	totalWeight := int32(0)
 	for _, upstream := range server.Upstreams {
+		if upstream.Weight <= 0 {
+			continue
+		}
+
+		weightedUpstreams = append(weightedUpstreams, upstream)
 		totalWeight += upstream.Weight
 	}
 
@@ -234,12 +242,16 @@ func createSplitClientForL4Server(server dataplane.Layer4VirtualServer) *stream.
 		return nil
 	}
 
-	distributions := make([]stream.SplitClientDistribution, 0, len(server.Upstreams))
+	if len(weightedUpstreams) == 1 {
+		return nil
+	}
+
+	distributions := make([]stream.SplitClientDistribution, 0, len(weightedUpstreams))
 	availablePercentage := float64(100)
 
 	// Process all upstreams except the last one
-	for i := range len(server.Upstreams) - 1 {
-		upstream := server.Upstreams[i]
+	for i := range len(weightedUpstreams) - 1 {
+		upstream := weightedUpstreams[i]
 		percentage := percentOf(upstream.Weight, totalWeight)
 		availablePercentage -= percentage
 
@@ -250,7 +262,7 @@ func createSplitClientForL4Server(server dataplane.Layer4VirtualServer) *stream.
 	}
 
 	// The last upstream gets the remaining percentage
-	lastUpstream := server.Upstreams[len(server.Upstreams)-1]
+	lastUpstream := weightedUpstreams[len(weightedUpstreams)-1]
 	distributions = append(distributions, stream.SplitClientDistribution{
 		Percent: fmt.Sprintf("%.2f", availablePercentage),
 		Value:   lastUpstream.Name,

--- a/internal/controller/nginx/config/stream_servers_test.go
+++ b/internal/controller/nginx/config/stream_servers_test.go
@@ -1093,6 +1093,24 @@ func TestCreateSplitClientForL4Server(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "zero-weight upstreams are excluded from distributions",
+			server: dataplane.Layer4VirtualServer{
+				Port: 5353,
+				Upstreams: []dataplane.Layer4Upstream{
+					{Name: "udp_v1", Weight: 100},
+					{Name: "udp_v2", Weight: 0},
+					{Name: "udp_v3", Weight: 50},
+				},
+			},
+			expected: &stream.SplitClient{
+				VariableName: "backend_5353",
+				Distributions: []stream.SplitClientDistribution{
+					{Percent: "66.66", Value: "udp_v1"},
+					{Percent: "33.34", Value: "udp_v3"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -1209,14 +1209,14 @@ func NewGatewayRefInvalid(msg string) Condition {
 }
 
 // NewGatewayInvalidParameters returns a Condition that indicates that the Gateway has invalid parameters.
-// We are allowing Accepted to still be true to prevent nullifying the entire Gateway config if a parametersRef
-// is updated to something invalid.
+// Per the Gateway API spec, the Gateway is not accepted when the parametersRef is invalid.
+// Note: The Gateway is still kept Valid in the graph to prevent nullifying the data plane config.
 func NewGatewayInvalidParameters(msg string) Condition {
 	return Condition{
 		Type:    string(v1.GatewayConditionAccepted),
-		Status:  metav1.ConditionTrue,
+		Status:  metav1.ConditionFalse,
 		Reason:  string(v1.GatewayReasonInvalidParameters),
-		Message: fmt.Sprintf("The Gateway is accepted, but ParametersRef is ignored due to an error: %s", msg),
+		Message: fmt.Sprintf("The Gateway is not accepted due to an invalid ParametersRef: %s", msg),
 	}
 }
 

--- a/internal/controller/status/prepare_requests_test.go
+++ b/internal/controller/status/prepare_requests_test.go
@@ -1624,11 +1624,11 @@ func TestBuildGatewayStatuses(t *testing.T) {
 						},
 						{
 							Type:               string(v1.GatewayConditionAccepted),
-							Status:             metav1.ConditionTrue,
+							Status:             metav1.ConditionFalse,
 							ObservedGeneration: 2,
 							LastTransitionTime: transitionTime,
 							Reason:             string(v1.GatewayReasonInvalidParameters),
-							Message: "The Gateway is accepted, but ParametersRef is ignored due to an error: " +
+							Message: "The Gateway is not accepted due to an invalid ParametersRef: " +
 								"The ParametersRef not found",
 						},
 						{

--- a/tests/conformance/conformance-rbac.yaml
+++ b/tests/conformance/conformance-rbac.yaml
@@ -47,6 +47,7 @@ rules:
   - tlsroutes
   - backendtlspolicies
   - udproutes
+  - tcproutes
   - listenersets
   verbs:
   - create


### PR DESCRIPTION
Problem: Gateway with invalid parametersRef reports Accepted=True, failing the GatewayInvalidParametersRef conformance test. The Gateway API spec requires Accepted=False with reason InvalidParameters when the parametersRef refers to an unsupported kind or non-existent resource.

Additionally, if a UDP backend had 0.00% weight, this would cause a failure to reload nginx due to invalid stream config.

Solution: Change NewGatewayInvalidParameters to set Accepted=False per the spec. The Gateway remains Valid in the graph so the data plane config is not torn down, but the status now correctly reports the Gateway as not accepted.

Omit 0.00 weights from stream split_clients.

Closes #5570

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
- Fixed Gateway status to report Accepted=False when infrastructure.parametersRef references an unsupported or invalid resource, conforming to the Gateway API specification.
- Omit 0-weighted backends from stream (UDP/TCP) maps to prevent nginx reload failures.
```
