### PR TITLE
Update min k8s version to 1.32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           K8S_KIND_VERSION=v1.36.1 # renovate: datasource=docker depName=kindest/node
           echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
-          echo "min_k8s_version=v1.31.14" >> $GITHUB_OUTPUT
+          echo "min_k8s_version=v1.32.13" >> $GITHUB_OUTPUT
           echo "k8s_latest=${K8S_KIND_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check if go.mod and go.sum are up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           K8S_KIND_VERSION=v1.36.1 # renovate: datasource=docker depName=kindest/node
           echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
-          echo "min_k8s_version=v1.32.13" >> $GITHUB_OUTPUT
+          echo "min_k8s_version=v1.32.11" >> $GITHUB_OUTPUT
           echo "k8s_latest=${K8S_KIND_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check if go.mod and go.sum are up to date

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following table lists the software versions NGINX Gateway Fabric supports. O
 
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent | F5 WAF for NGINX |
 |----------------------|-------------|------------|-----------|------------|-------------|------------------|
-| Edge                 | 1.6.1       | 1.31+      | 1.31.3    | R37.0      | v3.11.2     | 5.13.2           |
+| Edge                 | 1.6.1       | 1.32+      | 1.31.3    | R37.0      | v3.11.2     | 5.13.2           |
 | 2.6.7                | 1.5.1       | 1.31+      | 1.31.3    | R37.0      | v3.11.2     | 5.13.2           |
 | 2.5.1                | 1.5.1       | 1.31+      | 1.29.7    | R36        | v3.8.0      | ---              |
 | 2.4.2                | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.1      | ---              |

--- a/charts/nginx-gateway-fabric/Chart.yaml
+++ b/charts/nginx-gateway-fabric/Chart.yaml
@@ -4,7 +4,7 @@ description: NGINX Gateway Fabric
 type: application
 version: 2.6.7
 appVersion: "edge"
-kubeVersion: ">= 1.31.0-0"
+kubeVersion: ">= 1.32.0-0"
 home: https://github.com/nginx/nginx-gateway-fabric
 icon: https://raw.githubusercontent.com/nginx/nginx-gateway-fabric/main/charts/nginx-gateway-fabric/chart-icon.png
 sources:

--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -48,7 +48,7 @@ kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gatew
 
 ## Requirements
 
-Kubernetes: `>= 1.31.0-0`
+Kubernetes: `>= 1.32.0-0`
 
 ## Installing the Chart
 

--- a/operators/config/manifests/bases/nginx-gateway-fabric.clusterserviceversion.yaml
+++ b/operators/config/manifests/bases/nginx-gateway-fabric.clusterserviceversion.yaml
@@ -40,7 +40,7 @@ spec:
   - email: kubernetes@nginx.com
     name: F5NGINX
   maturity: alpha
-  minKubeVersion: 1.31.0
+  minKubeVersion: 1.32.0
   provider:
     name: F5 NGINX
     url: https://www.f5.com/go/product/welcome-to-nginx


### PR DESCRIPTION
With the recent Gateway API release, some CRD changes require k8s v1.32 or higher. Bumping our supported minimum from 1.31 to 1.32.

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Minimum supported k8s version bumped to 1.32
```
