### PR TITLE
Support v1 TCPRoute and UDPRoute

### DIFF
--- a/charts/nginx-gateway-fabric/templates/_helpers.tpl
+++ b/charts/nginx-gateway-fabric/templates/_helpers.tpl
@@ -209,10 +209,8 @@ Create namespaced RBAC rules.
   - backendtlspolicies
   - tlsroutes
   - listenersets
-  {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
   - tcproutes
   - udproutes
-  {{- end }}
   verbs:
   - list
   - watch
@@ -227,10 +225,8 @@ Create namespaced RBAC rules.
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
-  {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
   - tcproutes/status
   - udproutes/status
-  {{- end }}
   verbs:
   - update
 - apiGroups:

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/inference-nginx-plus/deploy.yaml
+++ b/deploy/inference-nginx-plus/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/inference/deploy.yaml
+++ b/deploy/inference/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -196,6 +196,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -210,6 +212,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/snippets-nginx-plus/deploy.yaml
+++ b/deploy/snippets-nginx-plus/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/snippets/deploy.yaml
+++ b/deploy/snippets/deploy.yaml
@@ -187,6 +187,8 @@ rules:
   - backendtlspolicies
   - tlsroutes
   - listenersets
+  - tcproutes
+  - udproutes
   verbs:
   - list
   - watch
@@ -201,6 +203,8 @@ rules:
   - backendtlspolicies/status
   - tlsroutes/status
   - listenersets/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/examples/externalname-service/route.yaml
+++ b/examples/externalname-service/route.yaml
@@ -29,7 +29,7 @@ spec:
     - name: coffee
       port: 80
 # ---
-# apiVersion: gateway.networking.k8s.io/v1alpha2
+# apiVersion: gateway.networking.k8s.io/v1
 # kind: TLSRoute
 # metadata:
 #   name: httpbin-tls-route

--- a/examples/tcp-routing/tcp-routes.yaml
+++ b/examples/tcp-routing/tcp-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-coffee
@@ -11,7 +11,7 @@ spec:
     - name: coffee
       port: 8081
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-tea

--- a/examples/udp-routing/udp-route.yaml
+++ b/examples/udp-routing/udp-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: coredns

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -38,7 +38,6 @@ import (
 	k8spredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 
@@ -95,7 +94,6 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(gatewayv1.Install(scheme))
-	utilruntime.Must(gatewayv1alpha2.Install(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
 	utilruntime.Must(ngfAPIv1alpha1.AddToScheme(scheme))
@@ -717,35 +715,6 @@ func featureFlagControllerCfgs(cfg config.Config) []ctlrCfg {
 		)
 	}
 
-	if cfg.ExperimentalFeatures {
-		cfgs = append(cfgs,
-			ctlrCfg{
-				objectType: &gatewayv1alpha2.TCPRoute{},
-				options: []controller.Option{
-					controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
-				},
-				requireCRDCheck: true,
-				crdGVK: &schema.GroupVersionKind{
-					Group:   "gateway.networking.k8s.io",
-					Version: "v1alpha2",
-					Kind:    "TCPRoute",
-				},
-			},
-			ctlrCfg{
-				objectType: &gatewayv1alpha2.UDPRoute{},
-				options: []controller.Option{
-					controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
-				},
-				requireCRDCheck: true,
-				crdGVK: &schema.GroupVersionKind{
-					Group:   "gateway.networking.k8s.io",
-					Version: "v1alpha2",
-					Kind:    "UDPRoute",
-				},
-			},
-		)
-	}
-
 	if cfg.InferenceExtension {
 		cfgs = append(cfgs,
 			ctlrCfg{
@@ -892,6 +861,66 @@ func registerControllers(
 			},
 		},
 		{
+			objectType: &gatewayv1.TCPRoute{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+			requireCRDCheck: true,
+			crdGVK: &schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "TCPRoute",
+			},
+		},
+		{
+			objectType: &gatewayv1.UDPRoute{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+			requireCRDCheck: true,
+			crdGVK: &schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "UDPRoute",
+			},
+		},
+		{
+			objectType: &gatewayv1.BackendTLSPolicy{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+			requireCRDCheck: true,
+			crdGVK: &schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "BackendTLSPolicy",
+			},
+		},
+		{
+			objectType: &gatewayv1.TLSRoute{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+			requireCRDCheck: true,
+			crdGVK: &schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "TLSRoute",
+			},
+		},
+		{
+			objectType: &gatewayv1.ListenerSet{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+			requireCRDCheck: true,
+			crdGVK: &schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "ListenerSet",
+			},
+		},
+		{
 			objectType: &ngfAPIv1alpha1.ClientSettingsPolicy{},
 			options: []controller.Option{
 				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
@@ -936,46 +965,6 @@ func registerControllers(
 	}
 
 	controllerRegCfgs = append(controllerRegCfgs, featureFlagControllerCfgs(cfg)...)
-
-	// BackendTLSPolicy/TLSRoute v1 - conditionally register if CRD exists
-	controllerRegCfgs = append(controllerRegCfgs,
-		ctlrCfg{
-			objectType: &gatewayv1.BackendTLSPolicy{},
-			options: []controller.Option{
-				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
-			},
-			requireCRDCheck: true,
-			crdGVK: &schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "BackendTLSPolicy",
-			},
-		},
-		ctlrCfg{
-			objectType: &gatewayv1.TLSRoute{},
-			options: []controller.Option{
-				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
-			},
-			requireCRDCheck: true,
-			crdGVK: &schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "TLSRoute",
-			},
-		},
-		ctlrCfg{
-			objectType: &gatewayv1.ListenerSet{},
-			options: []controller.Option{
-				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
-			},
-			requireCRDCheck: true,
-			crdGVK: &schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "ListenerSet",
-			},
-		},
-	)
 
 	if cfg.ConfigName != "" {
 		controllerRegCfgs = append(controllerRegCfgs,
@@ -1333,16 +1322,16 @@ func prepareFirstEventBatchPreparerArgs(
 		objectLists = append(objectLists, &gatewayv1.ListenerSetList{})
 	}
 
-	if cfg.ExperimentalFeatures {
-		if discoveredCRDs["TLSRoute"] {
-			objectLists = append(objectLists, &gatewayv1.TLSRouteList{})
-		}
-		if discoveredCRDs["TCPRoute"] {
-			objectLists = append(objectLists, &gatewayv1alpha2.TCPRouteList{})
-		}
-		if discoveredCRDs["UDPRoute"] {
-			objectLists = append(objectLists, &gatewayv1alpha2.UDPRouteList{})
-		}
+	if discoveredCRDs["TLSRoute"] {
+		objectLists = append(objectLists, &gatewayv1.TLSRouteList{})
+	}
+
+	if discoveredCRDs["TCPRoute"] {
+		objectLists = append(objectLists, &gatewayv1.TCPRouteList{})
+	}
+
+	if discoveredCRDs["UDPRoute"] {
+		objectLists = append(objectLists, &gatewayv1.UDPRouteList{})
 	}
 
 	if cfg.InferenceExtension {

--- a/internal/controller/manager_test.go
+++ b/internal/controller/manager_test.go
@@ -18,7 +18,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
@@ -98,6 +97,8 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				"BackendTLSPolicy": true,
 				"ListenerSet":      true,
 				"ReferenceGrant":   true,
+				"TCPRoute":         true,
+				"UDPRoute":         true,
 			},
 			expectedObjects: []client.Object{
 				&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}},
@@ -109,6 +110,8 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&discoveryV1.EndpointSliceList{},
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1.BackendTLSPolicyList{},
+				&gatewayv1.TCPRouteList{},
+				&gatewayv1.UDPRouteList{},
 				&apiv1.ConfigMapList{},
 				&gatewayv1.GatewayList{},
 				&gatewayv1.ReferenceGrantList{},
@@ -189,8 +192,8 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				partialObjectMetadataList,
 				&gatewayv1.BackendTLSPolicyList{},
 				&gatewayv1.TLSRouteList{},
-				&gatewayv1alpha2.TCPRouteList{},
-				&gatewayv1alpha2.UDPRouteList{},
+				&gatewayv1.TCPRouteList{},
+				&gatewayv1.UDPRouteList{},
 				&gatewayv1.GRPCRouteList{},
 				&ngfAPIv1alpha1.ClientSettingsPolicyList{},
 				&ngfAPIv1alpha2.ObservabilityPolicyList{},
@@ -352,8 +355,8 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&inference.InferencePoolList{},
 				&gatewayv1.BackendTLSPolicyList{},
 				&gatewayv1.TLSRouteList{},
-				&gatewayv1alpha2.TCPRouteList{},
-				&gatewayv1alpha2.UDPRouteList{},
+				&gatewayv1.TCPRouteList{},
+				&gatewayv1.UDPRouteList{},
 				&gatewayv1.GRPCRouteList{},
 				&ngfAPIv1alpha1.ClientSettingsPolicyList{},
 				&ngfAPIv1alpha2.ObservabilityPolicyList{},
@@ -434,8 +437,8 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&inference.InferencePoolList{},
 				&gatewayv1.BackendTLSPolicyList{},
 				&gatewayv1.TLSRouteList{},
-				&gatewayv1alpha2.TCPRouteList{},
-				&gatewayv1alpha2.UDPRouteList{},
+				&gatewayv1.TCPRouteList{},
+				&gatewayv1.UDPRouteList{},
 				&gatewayv1.GRPCRouteList{},
 				&ngfAPIv1alpha1.ClientSettingsPolicyList{},
 				&ngfAPIv1alpha2.ObservabilityPolicyList{},
@@ -886,13 +889,13 @@ func TestFilterControllersByCRDExistence(t *testing.T) {
 
 	tlsRouteGVK := schema.GroupVersionKind{
 		Group:   "gateway.networking.k8s.io",
-		Version: "v1alpha2",
+		Version: "v1",
 		Kind:    "TLSRoute",
 	}
 
 	tcpRouteGVK := schema.GroupVersionKind{
 		Group:   "gateway.networking.k8s.io",
-		Version: "v1alpha2",
+		Version: "v1",
 		Kind:    "TCPRoute",
 	}
 
@@ -1141,7 +1144,7 @@ func (f *fakeManagerForCRDTest) GetConfig() *rest.Config {
 
 // createTypedObject creates a typed object with GVK set for testing.
 func createTypedObject(gvk *schema.GroupVersionKind) ngftypes.ObjectType {
-	obj := &gatewayv1alpha2.TCPRoute{}
+	obj := &gatewayv1.TCPRoute{}
 	obj.SetGroupVersionKind(*gvk)
 	return obj
 }

--- a/internal/controller/state/change_processor.go
+++ b/internal/controller/state/change_processor.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 
@@ -127,8 +126,8 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 		NginxProxies:          make(map[types.NamespacedName]*ngfAPIv1alpha2.NginxProxy),
 		GRPCRoutes:            make(map[types.NamespacedName]*v1.GRPCRoute),
 		TLSRoutes:             make(map[types.NamespacedName]*v1.TLSRoute),
-		TCPRoutes:             make(map[types.NamespacedName]*v1alpha2.TCPRoute),
-		UDPRoutes:             make(map[types.NamespacedName]*v1alpha2.UDPRoute),
+		TCPRoutes:             make(map[types.NamespacedName]*v1.TCPRoute),
+		UDPRoutes:             make(map[types.NamespacedName]*v1.UDPRoute),
 		NGFPolicies:           make(map[graph.PolicyKey]policies.Policy),
 		SnippetsFilters:       make(map[types.NamespacedName]*ngfAPIv1alpha1.SnippetsFilter),
 		AuthenticationFilters: make(map[types.NamespacedName]*ngfAPIv1alpha1.AuthenticationFilter),
@@ -269,12 +268,12 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 			predicate: nil,
 		},
 		{
-			gvk:       cfg.MustExtractGVK(&v1alpha2.TCPRoute{}),
+			gvk:       cfg.MustExtractGVK(&v1.TCPRoute{}),
 			store:     newObjectStoreMapAdapter(clusterStore.TCPRoutes),
 			predicate: nil,
 		},
 		{
-			gvk:       cfg.MustExtractGVK(&v1alpha2.UDPRoute{}),
+			gvk:       cfg.MustExtractGVK(&v1.UDPRoute{}),
 			store:     newObjectStoreMapAdapter(clusterStore.UDPRoutes),
 			predicate: nil,
 		},

--- a/internal/controller/state/change_processor_test.go
+++ b/internal/controller/state/change_processor_test.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
@@ -343,7 +342,6 @@ func createScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
 	utilruntime.Must(v1.Install(scheme))
-	utilruntime.Must(v1alpha2.Install(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
 	utilruntime.Must(apiext.AddToScheme(scheme))

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -515,17 +515,6 @@ func NewRouteHostnameConflict() Condition {
 	}
 }
 
-// NewRouteMultipleRoutesOnListener returns a Condition that indicates that the Route is not
-// accepted because of multiple.L4 Routes attached to the same listener, which is not supported.
-func NewRouteMultipleRoutesOnListener() Condition {
-	return Condition{
-		Type:    string(v1.RouteConditionAccepted),
-		Status:  metav1.ConditionFalse,
-		Reason:  string(RouteReasonMultipleRoutesOnListener),
-		Message: "Multiple L4 Routes are attached to the same listener, which is not supported",
-	}
-}
-
 // NewRouteResolvedRefs returns a Condition that indicates that all the references on the Route are resolved.
 func NewRouteResolvedRefs() Condition {
 	return Condition{

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -317,9 +317,14 @@ func buildTLSDefaultServer(l *graph.Listener, ssl *SSL) *Layer4VirtualServer {
 }
 
 // buildL4Servers builds Layer4 servers (TCP or UDP) from routes attached to listeners.
+// Multiple routes on the same listener (same port) are merged into a single Layer4VirtualServer
+// with combined upstreams so that nginx programs one stream server per port.
 func buildL4Servers(logger logr.Logger, gateway *graph.Gateway, protocol v1.ProtocolType) []Layer4VirtualServer {
-	var servers []Layer4VirtualServer
 	protocolName := string(protocol)
+
+	// Map from listener port to merged server. Multiple routes on the same listener
+	// contribute their backendRefs to a single server entry.
+	serversByPort := make(map[int32]*Layer4VirtualServer)
 
 	for _, l := range gateway.Listeners {
 		if !l.Valid || l.Source.Protocol != protocol {
@@ -363,39 +368,37 @@ func buildL4Servers(logger logr.Logger, gateway *graph.Gateway, protocol v1.Prot
 				continue
 			}
 
-			server := Layer4VirtualServer{
-				Hostname:  "", // Layer4 doesn't use hostnames
-				Upstreams: upstreams,
-				Port:      l.Source.Port,
+			if existing, ok := serversByPort[l.Source.Port]; ok {
+				existing.Upstreams = append(existing.Upstreams, upstreams...)
+			} else {
+				serversByPort[l.Source.Port] = &Layer4VirtualServer{
+					Hostname:  "", // Layer4 doesn't use hostnames
+					Upstreams: upstreams,
+					Port:      l.Source.Port,
+				}
 			}
-
-			servers = append(servers, server)
 		}
 	}
 
-	// L4 routes are iterated from a map, so sort the resulting servers to produce a stable order.
+	if len(serversByPort) == 0 {
+		return nil
+	}
+
+	servers := make([]Layer4VirtualServer, 0, len(serversByPort))
+	for _, s := range serversByPort {
+		// Sort upstreams within each server for deterministic output.
+		sort.Slice(s.Upstreams, func(i, j int) bool {
+			return s.Upstreams[i].Name < s.Upstreams[j].Name
+		})
+		servers = append(servers, *s)
+	}
+
 	// Preserve order so that this doesn't trigger an unnecessary reload.
 	sort.Slice(servers, func(i, j int) bool {
-		if servers[i].Port != servers[j].Port {
-			return servers[i].Port < servers[j].Port
-		}
-		if servers[i].Hostname != servers[j].Hostname {
-			return servers[i].Hostname < servers[j].Hostname
-		}
-		return layer4UpstreamsKey(servers[i].Upstreams) < layer4UpstreamsKey(servers[j].Upstreams)
+		return servers[i].Port < servers[j].Port
 	})
 
 	return servers
-}
-
-// layer4UpstreamsKey builds a stable comparison key from a server's upstreams so that L4 servers
-// sharing the same port and hostname are ordered deterministically.
-func layer4UpstreamsKey(upstreams []Layer4Upstream) string {
-	names := make([]string, 0, len(upstreams))
-	for _, u := range upstreams {
-		names = append(names, u.Name)
-	}
-	return strings.Join(names, ",")
 }
 
 // buildStreamUpstreams builds all stream upstreams.

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -20,6 +20,7 @@ import (
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/ngfsort"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies/upstreamsettings"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/shared"
@@ -317,80 +318,29 @@ func buildTLSDefaultServer(l *graph.Listener, ssl *SSL) *Layer4VirtualServer {
 }
 
 // buildL4Servers builds Layer4 servers (TCP or UDP) from routes attached to listeners.
-// Multiple routes on the same listener (same port) are merged into a single Layer4VirtualServer
-// with combined upstreams so that nginx programs one stream server per port.
+// Per the Gateway API conflict resolution guidelines, when multiple routes target the
+// same listener only the oldest route (by creation timestamp) is programmed.
 func buildL4Servers(logger logr.Logger, gateway *graph.Gateway, protocol v1.ProtocolType) []Layer4VirtualServer {
 	protocolName := string(protocol)
 
-	// Map from listener port to merged server. Multiple routes on the same listener
-	// contribute their backendRefs to a single server entry.
-	serversByPort := make(map[int32]*Layer4VirtualServer)
+	var servers []Layer4VirtualServer
 
 	for _, l := range gateway.Listeners {
 		if !l.Valid || l.Source.Protocol != protocol {
 			continue
 		}
 
-		for _, r := range l.L4Routes {
-			if !r.Valid {
-				continue
-			}
-
-			backendRefs := r.Spec.GetBackendRefs()
-
-			if len(backendRefs) == 0 {
-				logger.V(1).Info("Route has no valid backend references, skipping",
-					"route", r.Source.GetName(),
-					"protocol", protocolName,
-				)
-				continue
-			}
-
-			var upstreams []Layer4Upstream
-			for _, br := range backendRefs {
-				if !br.Valid {
-					continue
-				}
-
-				upstreamName := br.ServicePortReference()
-
-				upstreams = append(upstreams, Layer4Upstream{
-					Name:   upstreamName,
-					Weight: br.Weight,
-				})
-			}
-
-			if len(upstreams) == 0 {
-				logger.V(1).Info("No valid upstreams for route, skipping",
-					"route", r.Source.GetName(),
-					"protocol", protocolName,
-				)
-				continue
-			}
-
-			if existing, ok := serversByPort[l.Source.Port]; ok {
-				existing.Upstreams = append(existing.Upstreams, upstreams...)
-			} else {
-				serversByPort[l.Source.Port] = &Layer4VirtualServer{
-					Hostname:  "", // Layer4 doesn't use hostnames
-					Upstreams: upstreams,
-					Port:      l.Source.Port,
-				}
-			}
+		// Find the oldest valid route with usable backends for this listener.
+		oldest := oldestValidL4Route(l.L4Routes, logger, protocolName)
+		if oldest == nil {
+			continue
 		}
+
+		servers = append(servers, *oldest.withPort(l.Source.Port))
 	}
 
-	if len(serversByPort) == 0 {
+	if len(servers) == 0 {
 		return nil
-	}
-
-	servers := make([]Layer4VirtualServer, 0, len(serversByPort))
-	for _, s := range serversByPort {
-		// Sort upstreams within each server for deterministic output.
-		sort.Slice(s.Upstreams, func(i, j int) bool {
-			return s.Upstreams[i].Name < s.Upstreams[j].Name
-		})
-		servers = append(servers, *s)
 	}
 
 	// Preserve order so that this doesn't trigger an unnecessary reload.
@@ -399,6 +349,83 @@ func buildL4Servers(logger logr.Logger, gateway *graph.Gateway, protocol v1.Prot
 	})
 
 	return servers
+}
+
+// l4RouteUpstreams holds the extracted upstreams for a single L4 route along with
+// the source object for age comparison.
+type l4RouteUpstreams struct {
+	source    client.Object
+	upstreams []Layer4Upstream
+}
+
+func (u *l4RouteUpstreams) withPort(port v1.PortNumber) *Layer4VirtualServer {
+	return &Layer4VirtualServer{
+		Hostname:  "", // Layer4 doesn't use hostnames
+		Upstreams: u.upstreams,
+		Port:      port,
+	}
+}
+
+// oldestValidL4Route returns the oldest route (by creation timestamp) that has
+// at least one valid backend reference, or nil if no such route exists.
+func oldestValidL4Route(
+	routes map[graph.L4RouteKey]*graph.L4Route,
+	logger logr.Logger,
+	protocolName string,
+) *l4RouteUpstreams {
+	var oldest *l4RouteUpstreams
+
+	for _, r := range routes {
+		if !r.Valid {
+			continue
+		}
+
+		backendRefs := r.Spec.GetBackendRefs()
+
+		if len(backendRefs) == 0 {
+			logger.V(1).Info("Route has no valid backend references, skipping",
+				"route", r.Source.GetName(),
+				"protocol", protocolName,
+			)
+			continue
+		}
+
+		var upstreams []Layer4Upstream
+		for _, br := range backendRefs {
+			if !br.Valid {
+				continue
+			}
+
+			upstreams = append(upstreams, Layer4Upstream{
+				Name:   br.ServicePortReference(),
+				Weight: br.Weight,
+			})
+		}
+
+		if len(upstreams) == 0 {
+			logger.V(1).Info("No valid upstreams for route, skipping",
+				"route", r.Source.GetName(),
+				"protocol", protocolName,
+			)
+			continue
+		}
+
+		// Sort upstreams within each route for deterministic output.
+		sort.Slice(upstreams, func(i, j int) bool {
+			return upstreams[i].Name < upstreams[j].Name
+		})
+
+		candidate := &l4RouteUpstreams{
+			source:    r.Source,
+			upstreams: upstreams,
+		}
+
+		if oldest == nil || ngfsort.LessClientObject(candidate.source, oldest.source) {
+			oldest = candidate
+		}
+	}
+
+	return oldest
 }
 
 // buildStreamUpstreams builds all stream upstreams.

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -6211,9 +6211,9 @@ func TestBuildL4Servers(t *testing.T) {
 			expectedServers: nil,
 		},
 		{
-			// L4Routes is a map (randomized iteration order). The route names are chosen so that map
-			// order differs from the expected output, verifying the servers are sorted deterministically.
-			name: "multiple TCP routes on the same listener are sorted by upstream",
+			// L4Routes is a map (randomized iteration order). Multiple routes on the same listener
+			// are merged into a single server, and their upstreams are sorted for deterministic output.
+			name: "multiple TCP routes on the same listener are merged",
 			gateway: &graph.Gateway{
 				Source: &v1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
@@ -6268,10 +6268,16 @@ func TestBuildL4Servers(t *testing.T) {
 			},
 			protocol: v1.TCPProtocolType,
 			expectedServers: []Layer4VirtualServer{
-				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-a_8080", Weight: 1}}},
-				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-b_8080", Weight: 1}}},
-				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-c_8080", Weight: 1}}},
-				{Hostname: "", Port: 8080, Upstreams: []Layer4Upstream{{Name: "default_svc-d_8080", Weight: 1}}},
+				{
+					Hostname: "",
+					Port:     8080,
+					Upstreams: []Layer4Upstream{
+						{Name: "default_svc-a_8080", Weight: 1},
+						{Name: "default_svc-b_8080", Weight: 1},
+						{Name: "default_svc-c_8080", Weight: 1},
+						{Name: "default_svc-d_8080", Weight: 1},
+					},
+				},
 			},
 		},
 	}

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
@@ -5700,13 +5701,37 @@ func TestBuildStreamUpstreams(t *testing.T) {
 func TestBuildL4Servers(t *testing.T) {
 	t.Parallel()
 
+	baseTime := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
 	createL4Route := func(name string, valid bool, backendRefs []graph.BackendRef) *graph.L4Route {
 		return &graph.L4Route{
 			Valid: valid,
 			Source: &v1.TCPRoute{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      name,
+					Namespace:         "default",
+					Name:              name,
+					CreationTimestamp: baseTime,
+				},
+			},
+			Spec: graph.L4RouteSpec{
+				BackendRefs: backendRefs,
+			},
+		}
+	}
+
+	createL4RouteWithTimestamp := func(
+		name string,
+		valid bool,
+		backendRefs []graph.BackendRef,
+		ts metav1.Time,
+	) *graph.L4Route {
+		return &graph.L4Route{
+			Valid: valid,
+			Source: &v1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              name,
+					CreationTimestamp: ts,
 				},
 			},
 			Spec: graph.L4RouteSpec{
@@ -6211,9 +6236,9 @@ func TestBuildL4Servers(t *testing.T) {
 			expectedServers: nil,
 		},
 		{
-			// L4Routes is a map (randomized iteration order). Multiple routes on the same listener
-			// are merged into a single server, and their upstreams are sorted for deterministic output.
-			name: "multiple TCP routes on the same listener are merged",
+			// Per Gateway API conflict resolution, only the oldest route is programmed.
+			// route-older was created first; route-newer (created 1 minute later) is ignored.
+			name: "oldest route wins when multiple TCP routes target same listener",
 			gateway: &graph.Gateway{
 				Source: &v1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
@@ -6230,37 +6255,76 @@ func TestBuildL4Servers(t *testing.T) {
 							Port:     8080,
 						},
 						L4Routes: map[graph.L4RouteKey]*graph.L4Route{
-							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-c"}}: createL4Route(
-								"route-c", true, []graph.BackendRef{{
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-newer"}}: createL4RouteWithTimestamp(
+								"route-newer", true, []graph.BackendRef{{
 									Valid:       true,
-									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-c"},
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-newer"},
 									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
 									Weight:      1,
 								}},
+								metav1.NewTime(baseTime.Add(time.Minute)),
 							),
-							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-a"}}: createL4Route(
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-older"}}: createL4RouteWithTimestamp(
+								"route-older", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-older"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+								baseTime,
+							),
+						},
+					},
+				},
+			},
+			protocol: v1.TCPProtocolType,
+			expectedServers: []Layer4VirtualServer{
+				{
+					Hostname: "",
+					Port:     8080,
+					Upstreams: []Layer4Upstream{
+						{Name: "default_svc-older_8080", Weight: 1},
+					},
+				},
+			},
+		},
+		{
+			// When timestamps are equal, the route with the alphabetically-first
+			// namespace/name wins (Gateway API tie-breaking rule).
+			name: "same timestamp tie broken by name",
+			gateway: &graph.Gateway{
+				Source: &v1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "gateway",
+					},
+				},
+				Listeners: []*graph.Listener{
+					{
+						Name:  "tcp-listener",
+						Valid: true,
+						Source: v1.Listener{
+							Protocol: v1.TCPProtocolType,
+							Port:     8080,
+						},
+						L4Routes: map[graph.L4RouteKey]*graph.L4Route{
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-z"}}: createL4RouteWithTimestamp(
+								"route-z", true, []graph.BackendRef{{
+									Valid:       true,
+									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-z"},
+									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
+									Weight:      1,
+								}},
+								baseTime,
+							),
+							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-a"}}: createL4RouteWithTimestamp(
 								"route-a", true, []graph.BackendRef{{
 									Valid:       true,
 									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-a"},
 									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
 									Weight:      1,
 								}},
-							),
-							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-d"}}: createL4Route(
-								"route-d", true, []graph.BackendRef{{
-									Valid:       true,
-									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-d"},
-									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
-									Weight:      1,
-								}},
-							),
-							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "route-b"}}: createL4Route(
-								"route-b", true, []graph.BackendRef{{
-									Valid:       true,
-									SvcNsName:   types.NamespacedName{Namespace: "default", Name: "svc-b"},
-									ServicePort: apiv1.ServicePort{Name: "tcp", Port: 8080},
-									Weight:      1,
-								}},
+								baseTime,
 							),
 						},
 					},
@@ -6273,9 +6337,6 @@ func TestBuildL4Servers(t *testing.T) {
 					Port:     8080,
 					Upstreams: []Layer4Upstream{
 						{Name: "default_svc-a_8080", Weight: 1},
-						{Name: "default_svc-b_8080", Weight: 1},
-						{Name: "default_svc-c_8080", Weight: 1},
-						{Name: "default_svc-d_8080", Weight: 1},
 					},
 				},
 			},

--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
@@ -5704,7 +5703,7 @@ func TestBuildL4Servers(t *testing.T) {
 	createL4Route := func(name string, valid bool, backendRefs []graph.BackendRef) *graph.L4Route {
 		return &graph.L4Route{
 			Valid: valid,
-			Source: &v1alpha2.TCPRoute{
+			Source: &v1.TCPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      name,
@@ -6184,7 +6183,7 @@ func TestBuildL4Servers(t *testing.T) {
 						L4Routes: map[graph.L4RouteKey]*graph.L4Route{
 							{NamespacedName: types.NamespacedName{Namespace: "default", Name: "udp-route"}}: {
 								Valid: true,
-								Source: &v1alpha2.UDPRoute{
+								Source: &v1.UDPRoute{
 									ObjectMeta: metav1.ObjectMeta{
 										Namespace: "default",
 										Name:      "udp-route",

--- a/internal/controller/state/graph/gatewayclass.go
+++ b/internal/controller/state/graph/gatewayclass.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"slices"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/consts"
-	"sigs.k8s.io/gateway-api/pkg/features"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
@@ -37,8 +35,6 @@ type GatewayClass struct {
 	Conditions []conditions.Condition
 	// Valid shows whether the GatewayClass is valid.
 	Valid bool
-	// ExperimentalSupported indicates whether experimental features are supported.
-	ExperimentalSupported bool
 	// BestEffort indicates whether the Gateway API CRD versions are not supported,
 	// but we are attempting to generate configuration.
 	BestEffort bool
@@ -84,7 +80,6 @@ func buildGatewayClass(
 	gc *v1.GatewayClass,
 	nps map[types.NamespacedName]*NginxProxy,
 	crdVersions map[types.NamespacedName]*metav1.PartialObjectMetadata,
-	experimentalEnabled bool,
 ) *GatewayClass {
 	if gc == nil {
 		return nil
@@ -95,18 +90,14 @@ func buildGatewayClass(
 		np = getNginxProxyForGatewayClass(*gc.Spec.ParametersRef, nps)
 	}
 
-	conds, valid, crdExperimental, bestEffort := validateGatewayClass(gc, np, crdVersions)
-
-	// Experimental features are supported only if both the config flag AND CRD channel are experimental
-	experimental := experimentalEnabled && crdExperimental
+	conds, valid, bestEffort := validateGatewayClass(gc, np, crdVersions)
 
 	return &GatewayClass{
-		Source:                gc,
-		NginxProxy:            np,
-		Valid:                 valid,
-		Conditions:            conds,
-		ExperimentalSupported: experimental,
-		BestEffort:            bestEffort,
+		Source:     gc,
+		NginxProxy: np,
+		Valid:      valid,
+		Conditions: conds,
+		BestEffort: bestEffort,
 	}
 }
 
@@ -152,14 +143,14 @@ func validateGatewayClass(
 	gc *v1.GatewayClass,
 	npCfg *NginxProxy,
 	crdVersions map[types.NamespacedName]*metav1.PartialObjectMetadata,
-) ([]conditions.Condition, bool, bool, bool) {
+) ([]conditions.Condition, bool, bool) {
 	var conds []conditions.Condition
 
-	supportedVersionConds, versionsValid, experimental, bestEffort := validateCRDVersions(crdVersions)
+	supportedVersionConds, versionsValid, bestEffort := validateCRDVersions(crdVersions)
 	conds = append(conds, supportedVersionConds...)
 
 	if gc.Spec.ParametersRef == nil {
-		return conds, versionsValid, experimental, bestEffort
+		return conds, versionsValid, bestEffort
 	}
 
 	path := field.NewPath("spec").Child("parametersRef")
@@ -168,7 +159,7 @@ func validateGatewayClass(
 	// return early since parametersRef isn't valid
 	if len(refConds) > 0 {
 		conds = append(conds, refConds...)
-		return conds, versionsValid, experimental, bestEffort
+		return conds, versionsValid, bestEffort
 	}
 
 	if npCfg == nil {
@@ -179,7 +170,7 @@ func validateGatewayClass(
 				field.NotFound(path.Child("name"), gc.Spec.ParametersRef.Name).Error(),
 			),
 		)
-		return conds, versionsValid, experimental, bestEffort
+		return conds, versionsValid, bestEffort
 	}
 
 	if !npCfg.Valid {
@@ -189,10 +180,10 @@ func validateGatewayClass(
 			conditions.NewGatewayClassRefInvalid(msg),
 			conditions.NewGatewayClassInvalidParameters(msg),
 		)
-		return conds, versionsValid, experimental, bestEffort
+		return conds, versionsValid, bestEffort
 	}
 
-	return append(conds, conditions.NewGatewayClassResolvedRefs()), versionsValid, experimental, bestEffort
+	return append(conds, conditions.NewGatewayClassResolvedRefs()), versionsValid, bestEffort
 }
 
 var supportedParamKinds = map[string]struct{}{
@@ -206,8 +197,8 @@ type apiVersion struct {
 
 func validateCRDVersions(
 	crdMetadata map[types.NamespacedName]*metav1.PartialObjectMetadata,
-) (conds []conditions.Condition, valid bool, experimental bool, bestEffort bool) {
-	installedAPIVersions, channels := getBundleVersions(crdMetadata)
+) (conds []conditions.Condition, valid bool, bestEffort bool) {
+	installedAPIVersions := getBundleVersions(crdMetadata)
 	supportedAPIVersion := parseVersionString(consts.BundleVersion)
 
 	var unsupported bool
@@ -220,20 +211,15 @@ func validateCRDVersions(
 		}
 	}
 
-	// Check if any CRD is using experimental channel
-	if slices.Contains(channels, features.FeatureChannelExperimental) {
-		experimental = true
-	}
-
 	if unsupported {
-		return conditions.NewGatewayClassUnsupportedVersion(consts.BundleVersion), false, experimental, false
+		return conditions.NewGatewayClassUnsupportedVersion(consts.BundleVersion), false, false
 	}
 
 	if bestEffort {
-		return conditions.NewGatewayClassSupportedVersionBestEffort(consts.BundleVersion), true, experimental, bestEffort
+		return conditions.NewGatewayClassSupportedVersionBestEffort(consts.BundleVersion), true, bestEffort
 	}
 
-	return nil, true, experimental, false
+	return nil, true, false
 }
 
 func parseVersionString(version string) apiVersion {
@@ -260,23 +246,15 @@ func parseVersionString(version string) apiVersion {
 
 func getBundleVersions(
 	crdMetadata map[types.NamespacedName]*metav1.PartialObjectMetadata,
-) ([]apiVersion, []features.FeatureChannel) {
+) []apiVersion {
 	versions := make([]apiVersion, 0, len(gatewayCRDs))
-	channels := make([]features.FeatureChannel, 0, len(gatewayCRDs))
 
 	for nsname, md := range crdMetadata {
 		if _, ok := gatewayCRDs[nsname.Name]; ok {
 			bundleVersion := md.Annotations[consts.BundleVersionAnnotation]
 			versions = append(versions, parseVersionString(bundleVersion))
-
-			// Default to standard channel if annotation is missing
-			ch := md.Annotations[consts.ChannelAnnotation]
-			if ch == "" {
-				ch = string(features.FeatureChannelStandard)
-			}
-			channels = append(channels, features.FeatureChannel(ch))
 		}
 	}
 
-	return versions, channels
+	return versions
 }

--- a/internal/controller/state/graph/gatewayclass_test.go
+++ b/internal/controller/state/graph/gatewayclass_test.go
@@ -182,24 +182,12 @@ func TestBuildGatewayClass(t *testing.T) {
 		},
 	}
 
-	experimentalCRDs := map[types.NamespacedName]*metav1.PartialObjectMetadata{
-		{Name: "gateways.gateway.networking.k8s.io"}: {
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					consts.BundleVersionAnnotation: consts.BundleVersion,
-					consts.ChannelAnnotation:       "experimental",
-				},
-			},
-		},
-	}
-
 	tests := []struct {
-		gc                  *v1.GatewayClass
-		nps                 map[types.NamespacedName]*NginxProxy
-		crdMetadata         map[types.NamespacedName]*metav1.PartialObjectMetadata
-		expected            *GatewayClass
-		name                string
-		experimentalEnabled bool
+		gc          *v1.GatewayClass
+		nps         map[types.NamespacedName]*NginxProxy
+		crdMetadata map[types.NamespacedName]*metav1.PartialObjectMetadata
+		expected    *GatewayClass
+		name        string
 	}{
 		{
 			gc:          validGC,
@@ -340,39 +328,6 @@ func TestBuildGatewayClass(t *testing.T) {
 			},
 			name: "invalid gatewayclass; unsupported version",
 		},
-		{
-			gc:                  validGC,
-			crdMetadata:         experimentalCRDs,
-			experimentalEnabled: true,
-			expected: &GatewayClass{
-				Source:                validGC,
-				Valid:                 true,
-				ExperimentalSupported: true,
-			},
-			name: "experimental enabled and CRDs have experimental channel",
-		},
-		{
-			gc:                  validGC,
-			crdMetadata:         validCRDs,
-			experimentalEnabled: true,
-			expected: &GatewayClass{
-				Source:                validGC,
-				Valid:                 true,
-				ExperimentalSupported: false,
-			},
-			name: "experimental enabled but CRDs have standard channel",
-		},
-		{
-			gc:                  validGC,
-			crdMetadata:         experimentalCRDs,
-			experimentalEnabled: false,
-			expected: &GatewayClass{
-				Source:                validGC,
-				Valid:                 true,
-				ExperimentalSupported: false,
-			},
-			name: "experimental disabled but CRDs have experimental channel",
-		},
 	}
 
 	for _, test := range tests {
@@ -380,7 +335,7 @@ func TestBuildGatewayClass(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			result := buildGatewayClass(test.gc, test.nps, test.crdMetadata, test.experimentalEnabled)
+			result := buildGatewayClass(test.gc, test.nps, test.crdMetadata)
 			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())
 		})
 	}
@@ -492,7 +447,7 @@ func TestValidateCRDVersions(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			conds, valid, _, _ := validateCRDVersions(test.crds)
+			conds, valid, _ := validateCRDVersions(test.crds)
 			g.Expect(valid).To(Equal(test.valid))
 			g.Expect(conds).To(Equal(test.expConds))
 		})

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
@@ -36,8 +35,8 @@ type ClusterState struct {
 	Gateways              map[types.NamespacedName]*gatewayv1.Gateway
 	HTTPRoutes            map[types.NamespacedName]*gatewayv1.HTTPRoute
 	TLSRoutes             map[types.NamespacedName]*gatewayv1.TLSRoute
-	TCPRoutes             map[types.NamespacedName]*v1alpha2.TCPRoute
-	UDPRoutes             map[types.NamespacedName]*v1alpha2.UDPRoute
+	TCPRoutes             map[types.NamespacedName]*gatewayv1.TCPRoute
+	UDPRoutes             map[types.NamespacedName]*gatewayv1.UDPRoute
 	Services              map[types.NamespacedName]*v1.Service
 	Namespaces            map[types.NamespacedName]*v1.Namespace
 	ReferenceGrants       map[types.NamespacedName]*gatewayv1.ReferenceGrant
@@ -285,7 +284,6 @@ func BuildGraph(
 		processedGwClasses.Winner,
 		processedNginxProxies,
 		state.CRDMetadata,
-		featureFlags.Experimental,
 	)
 
 	resourceResolver := newResourceResolver(state)

--- a/internal/controller/state/graph/graph_test.go
+++ b/internal/controller/state/graph/graph_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
@@ -157,7 +156,7 @@ func TestBuildGraph(t *testing.T) {
 				},
 				Validation: gatewayv1.BackendTLSPolicyValidation{
 					Hostname: "foo.example.com",
-					CACertificateRefs: []v1alpha2.LocalObjectReference{
+					CACertificateRefs: []gatewayv1.LocalObjectReference{
 						{
 							Kind:  "ConfigMap",
 							Name:  "configmap",
@@ -590,13 +589,13 @@ func TestBuildGraph(t *testing.T) {
 	tr := createRouteTLS("tr", "gateway-1")
 	tr2 := createRouteTLS("tr2", "gateway-1")
 
-	createRouteTCP := func(name string, gatewayName string) *v1alpha2.TCPRoute {
-		return &v1alpha2.TCPRoute{
+	createRouteTCP := func(name string, gatewayName string) *gatewayv1.TCPRoute {
+		return &gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNs,
 				Name:      name,
 			},
-			Spec: v1alpha2.TCPRouteSpec{
+			Spec: gatewayv1.TCPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{
 						{
@@ -605,7 +604,7 @@ func TestBuildGraph(t *testing.T) {
 						},
 					},
 				},
-				Rules: []v1alpha2.TCPRouteRule{
+				Rules: []gatewayv1.TCPRouteRule{
 					{
 						BackendRefs: []gatewayv1.BackendRef{
 							commonTLSBackendRef,
@@ -616,13 +615,13 @@ func TestBuildGraph(t *testing.T) {
 		}
 	}
 
-	createRouteUDP := func(name string, gatewayName string) *v1alpha2.UDPRoute {
-		return &v1alpha2.UDPRoute{
+	createRouteUDP := func(name string, gatewayName string) *gatewayv1.UDPRoute {
+		return &gatewayv1.UDPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNs,
 				Name:      name,
 			},
-			Spec: v1alpha2.UDPRouteSpec{
+			Spec: gatewayv1.UDPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{
 						{
@@ -631,7 +630,7 @@ func TestBuildGraph(t *testing.T) {
 						},
 					},
 				},
-				Rules: []v1alpha2.UDPRouteRule{
+				Rules: []gatewayv1.UDPRouteRule{
 					{
 						BackendRefs: []gatewayv1.BackendRef{
 							commonTLSBackendRef,
@@ -1250,10 +1249,10 @@ func TestBuildGraph(t *testing.T) {
 				client.ObjectKeyFromObject(tr):  tr,
 				client.ObjectKeyFromObject(tr2): tr2,
 			},
-			TCPRoutes: map[types.NamespacedName]*v1alpha2.TCPRoute{
+			TCPRoutes: map[types.NamespacedName]*gatewayv1.TCPRoute{
 				client.ObjectKeyFromObject(tcpr): tcpr,
 			},
-			UDPRoutes: map[types.NamespacedName]*v1alpha2.UDPRoute{
+			UDPRoutes: map[types.NamespacedName]*gatewayv1.UDPRoute{
 				client.ObjectKeyFromObject(udpr): udpr,
 			},
 			GRPCRoutes: map[types.NamespacedName]*gatewayv1.GRPCRoute{

--- a/internal/controller/state/graph/route_common.go
+++ b/internal/controller/state/graph/route_common.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	v1alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/ngfsort"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
@@ -248,9 +247,9 @@ func CreateRouteKeyL4(obj client.Object) L4RouteKey {
 	switch obj.(type) {
 	case *v1.TLSRoute:
 		routeType = RouteTypeTLS
-	case *v1alpha.TCPRoute:
+	case *v1.TCPRoute:
 		routeType = RouteTypeTCP
-	case *v1alpha.UDPRoute:
+	case *v1.UDPRoute:
 		routeType = RouteTypeUDP
 	default:
 		panic(fmt.Sprintf("Unknown type: %T", obj))
@@ -295,8 +294,8 @@ func (e routeRuleErrors) append(newErrors routeRuleErrors) routeRuleErrors {
 
 func buildL4RoutesForGateways(
 	tlsRoutes map[types.NamespacedName]*v1.TLSRoute,
-	tcpRoutes map[types.NamespacedName]*v1alpha.TCPRoute,
-	udpRoutes map[types.NamespacedName]*v1alpha.UDPRoute,
+	tcpRoutes map[types.NamespacedName]*v1.TCPRoute,
+	udpRoutes map[types.NamespacedName]*v1.UDPRoute,
 	services map[types.NamespacedName]*apiv1.Service,
 	backendTLSPolicies map[types.NamespacedName]*BackendTLSPolicy,
 	gws map[types.NamespacedName]*Gateway,
@@ -893,13 +892,12 @@ func tryToAttachL4RouteToListeners(
 	var (
 		attachedToAtLeastOneValidListener  bool
 		allowed, attached, hostnamesUnique bool
-		multipleRoutesOnListener           bool
 	)
 
 	sortListenersByHostname(attachableListeners)
 
 	for _, l := range attachableListeners {
-		routeAllowed, routeAttached, routeHostnamesUnique, routeMultiple := bindToListenerL4(
+		routeAllowed, routeAttached, routeHostnamesUnique := bindToListenerL4(
 			l,
 			route,
 			namespaces,
@@ -911,15 +909,11 @@ func tryToAttachL4RouteToListeners(
 		attached = attached || routeAttached
 		hostnamesUnique = hostnamesUnique || routeHostnamesUnique
 		attachedToAtLeastOneValidListener = attachedToAtLeastOneValidListener || (routeAttached && l.Valid)
-		multipleRoutesOnListener = multipleRoutesOnListener || routeMultiple
 	}
 
 	if !attached {
 		if !allowed {
 			return conditions.NewRouteNotAllowedByListeners(), false
-		}
-		if multipleRoutesOnListener {
-			return conditions.NewRouteMultipleRoutesOnListener(), false
 		}
 		if !hostnamesUnique {
 			return conditions.NewRouteHostnameConflict(), false
@@ -953,9 +947,9 @@ func getL4RouteKind(route *L4Route) v1.Kind {
 	switch route.Source.(type) {
 	case *v1.TLSRoute:
 		return v1.Kind(kinds.TLSRoute)
-	case *v1alpha.TCPRoute:
+	case *v1.TCPRoute:
 		return v1.Kind(kinds.TCPRoute)
-	case *v1alpha.UDPRoute:
+	case *v1.UDPRoute:
 		return v1.Kind(kinds.UDPRoute)
 	default:
 		panic(fmt.Sprintf("Unknown type: %T", route.Source))
@@ -969,38 +963,31 @@ func bindToListenerL4(
 	portHostnamesMap map[string]struct{},
 	refStatus *ParentRefAttachmentStatus,
 	parentRefNamespace string,
-) (allowed, attached, notConflicting, multipleRoutesOnListener bool) {
+) (allowed, attached, notConflicting bool) {
 	if !isRouteNamespaceAllowedByListener(l, route.Source.GetNamespace(), parentRefNamespace, namespaces) {
-		return false, false, false, false
+		return false, false, false
 	}
 
 	routeKind := getL4RouteKind(route)
 	if !isRouteTypeAllowedByListener(l, routeKind) {
-		return false, false, false, false
-	}
-
-	// TCP/UDP protocols have no routing discriminator (no hostname/path/SNI)
-	// so we can only support one route per listener port
-	if routeKind == v1.Kind(kinds.TCPRoute) || routeKind == v1.Kind(kinds.UDPRoute) {
-		currentRouteKey := CreateRouteKeyL4(route.Source)
-		for existingRouteKey := range l.L4Routes {
-			if existingRouteKey != currentRouteKey {
-				// A different TCP/UDP route is already attached to this listener
-				return true, false, true, true
-			}
-		}
+		return false, false, false
 	}
 
 	acceptedListenerHostnames := findAcceptedHostnames(l.Source.Hostname, route.Spec.Hostnames)
 
 	hostnames := make([]string, 0)
-
-	for _, h := range acceptedListenerHostnames {
-		portHostname := fmt.Sprintf("%s:%d:%s", h, l.Source.Port, l.Source.Protocol)
-		_, ok := portHostnamesMap[portHostname]
-		if !ok {
-			portHostnamesMap[portHostname] = struct{}{}
-			hostnames = append(hostnames, h)
+	if routeKind == v1.Kind(kinds.TCPRoute) || routeKind == v1.Kind(kinds.UDPRoute) {
+		// TCP/UDP routes have no hostnames in spec; allow multiple routes on a listener
+		// and avoid using the cross-route hostname conflict map for L4 stream routes.
+		hostnames = append(hostnames, acceptedListenerHostnames...)
+	} else {
+		for _, h := range acceptedListenerHostnames {
+			portHostname := fmt.Sprintf("%s:%d:%s", h, l.Source.Port, l.Source.Protocol)
+			_, ok := portHostnamesMap[portHostname]
+			if !ok {
+				portHostnamesMap[portHostname] = struct{}{}
+				hostnames = append(hostnames, h)
+			}
 		}
 	}
 
@@ -1008,17 +995,17 @@ func bindToListenerL4(
 	// if any hostnames were removed because of conflicts first, and add that condition first. Otherwise, we know that
 	// the hostnames were all removed because they didn't match the listener hostname, so we add that condition.
 	if len(hostnames) == 0 && len(acceptedListenerHostnames) > 0 {
-		return true, false, false, false
+		return true, false, false
 	}
 	if len(hostnames) == 0 {
-		return true, false, true, false
+		return true, false, true
 	}
 
 	refStatus.AcceptedHostnames[CreateParentRefListenerKeyFromListener(l)] = hostnames
 
 	l.L4Routes[CreateRouteKeyL4(route.Source)] = route
 
-	return true, true, true, false
+	return true, true, true
 }
 
 // resolveAttachmentListenerSet returns the ListenerSet NamespacedName that the parentRef targets
@@ -1628,7 +1615,7 @@ type l4RouteConfig struct {
 
 // l4RouteRule represents a rule in TCPRoute or UDPRoute.
 type l4RouteRule struct {
-	backendRefs []v1alpha.BackendRef
+	backendRefs []v1.BackendRef
 }
 
 // buildGenericL4Route is a generic function to build L4Route for both TCP and UDP routes.
@@ -1714,7 +1701,7 @@ func buildGenericL4Route(
 // validate BackendRef for both TCP and UDP routes.
 func validateBackendRefL4RouteMulti(
 	namespace string,
-	ref v1alpha.BackendRef,
+	ref v1.BackendRef,
 	services map[types.NamespacedName]*apiv1.Service,
 	refGrantResolver func(resource toResource) bool,
 	ruleIdx int,

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/validation/validationfakes"
@@ -2750,12 +2749,12 @@ func TestBindL4RouteToListeners(t *testing.T) {
 		},
 		{
 			route: func() *L4Route {
-				tcpRoute := &v1alpha2.TCPRoute{
+				tcpRoute := &gatewayv1.TCPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "tcp-route-2",
 					},
-					Spec: v1alpha2.TCPRouteSpec{
+					Spec: gatewayv1.TCPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{
 								{
@@ -2815,7 +2814,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 								},
 								RouteType: RouteTypeTCP,
 							}: {
-								Source: &v1alpha2.TCPRoute{
+								Source: &gatewayv1.TCPRoute{
 									ObjectMeta: metav1.ObjectMeta{
 										Namespace: "test",
 										Name:      "tcp-route-1",
@@ -2833,9 +2832,13 @@ func TestBindL4RouteToListeners(t *testing.T) {
 					Idx:            0,
 					SectionName:    helpers.GetPointer[gatewayv1.SectionName]("tcp-listener"),
 					Attachment: &ParentRefAttachmentStatus{
-						Attached:          false,
-						AcceptedHostnames: map[string][]string{},
-						FailedConditions:  []conditions.Condition{conditions.NewRouteMultipleRoutesOnListener()},
+						Attached: true,
+						AcceptedHostnames: map[string][]string{
+							CreateParentRefListenerKey(
+								client.ObjectKeyFromObject(gw),
+								"tcp-listener",
+							): {"~^"},
+						},
 					},
 				},
 			},
@@ -2858,7 +2861,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 					Attachable: true,
 					Routes:     map[RouteKey]*L7Route{},
 					L4Routes: map[L4RouteKey]*L4Route{
-						// Should still have only the original route
+						// Should include both routes when multiple L4 routes attach to one listener.
 						{
 							NamespacedName: types.NamespacedName{
 								Namespace: "test",
@@ -2866,13 +2869,58 @@ func TestBindL4RouteToListeners(t *testing.T) {
 							},
 							RouteType: RouteTypeTCP,
 						}: {
-							Source: &v1alpha2.TCPRoute{
+							Source: &gatewayv1.TCPRoute{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "test",
 									Name:      "tcp-route-1",
 								},
 							},
 							Valid: true,
+						},
+						{
+							NamespacedName: types.NamespacedName{
+								Namespace: "test",
+								Name:      "tcp-route-2",
+							},
+							RouteType: RouteTypeTCP,
+						}: {
+							Source: &gatewayv1.TCPRoute{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "test",
+									Name:      "tcp-route-2",
+								},
+								Spec: gatewayv1.TCPRouteSpec{
+									CommonRouteSpec: gatewayv1.CommonRouteSpec{
+										ParentRefs: []gatewayv1.ParentReference{
+											{
+												Name:        gatewayv1.ObjectName(gw.Name),
+												SectionName: helpers.GetPointer[gatewayv1.SectionName]("tcp-listener"),
+											},
+										},
+									},
+								},
+							},
+							Valid:      true,
+							Attachable: true,
+							Spec: L4RouteSpec{
+								Hostnames: []gatewayv1.Hostname{},
+							},
+							ParentRefs: []ParentRef{
+								{
+									NamespacedName: client.ObjectKeyFromObject(gw),
+									Idx:            0,
+									SectionName:    helpers.GetPointer[gatewayv1.SectionName]("tcp-listener"),
+									Attachment: &ParentRefAttachmentStatus{
+										Attached: true,
+										AcceptedHostnames: map[string][]string{
+											CreateParentRefListenerKey(
+												client.ObjectKeyFromObject(gw),
+												"tcp-listener",
+											): {"~^"},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -2881,7 +2929,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 		},
 		{
 			route: &L4Route{
-				Source: &v1alpha2.TCPRoute{
+				Source: &gatewayv1.TCPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "tcp-route-listenerset",
@@ -2889,7 +2937,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 					TypeMeta: metav1.TypeMeta{
 						Kind: "TCPRoute",
 					},
-					Spec: v1alpha2.TCPRouteSpec{
+					Spec: gatewayv1.TCPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{
 								{
@@ -2987,7 +3035,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 		},
 		{
 			route: &L4Route{
-				Source: &v1alpha2.TCPRoute{
+				Source: &gatewayv1.TCPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "tcp-route-invalid-listenerset",
@@ -2995,7 +3043,7 @@ func TestBindL4RouteToListeners(t *testing.T) {
 					TypeMeta: metav1.TypeMeta{
 						Kind: "TCPRoute",
 					},
-					Spec: v1alpha2.TCPRouteSpec{
+					Spec: gatewayv1.TCPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{
 								{
@@ -3173,9 +3221,9 @@ func TestBindL4RouteToListeners_TCPAndUDPSamePortNoConflict(t *testing.T) {
 	}
 
 	tcpRoute := &L4Route{
-		Source: &v1alpha2.TCPRoute{
+		Source: &gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "tcp-dns"},
-			Spec: v1alpha2.TCPRouteSpec{
+			Spec: gatewayv1.TCPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{
 						{
@@ -3199,9 +3247,9 @@ func TestBindL4RouteToListeners_TCPAndUDPSamePortNoConflict(t *testing.T) {
 	}
 
 	udpRoute := &L4Route{
-		Source: &v1alpha2.UDPRoute{
+		Source: &gatewayv1.UDPRoute{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "udp-dns"},
-			Spec: v1alpha2.UDPRouteSpec{
+			Spec: gatewayv1.UDPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{
 						{
@@ -3281,13 +3329,13 @@ func createTestL4Listener(
 	}
 }
 
-func createTestTCPRoute(name string, serviceName string, port gatewayv1.PortNumber) *v1alpha2.TCPRoute {
-	return &v1alpha2.TCPRoute{
+func createTestTCPRoute(name string, serviceName string, port gatewayv1.PortNumber) *gatewayv1.TCPRoute {
+	return &gatewayv1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNs,
 			Name:      name,
 		},
-		Spec: v1alpha2.TCPRouteSpec{
+		Spec: gatewayv1.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{
 					{
@@ -3295,7 +3343,7 @@ func createTestTCPRoute(name string, serviceName string, port gatewayv1.PortNumb
 					},
 				},
 			},
-			Rules: []v1alpha2.TCPRouteRule{
+			Rules: []gatewayv1.TCPRouteRule{
 				{
 					BackendRefs: []gatewayv1.BackendRef{
 						{
@@ -3311,13 +3359,13 @@ func createTestTCPRoute(name string, serviceName string, port gatewayv1.PortNumb
 	}
 }
 
-func createTestUDPRoute(name string, serviceName string, port gatewayv1.PortNumber) *v1alpha2.UDPRoute {
-	return &v1alpha2.UDPRoute{
+func createTestUDPRoute(name string, serviceName string, port gatewayv1.PortNumber) *gatewayv1.UDPRoute {
+	return &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNs,
 			Name:      name,
 		},
-		Spec: v1alpha2.UDPRouteSpec{
+		Spec: gatewayv1.UDPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{
 					{
@@ -3325,7 +3373,7 @@ func createTestUDPRoute(name string, serviceName string, port gatewayv1.PortNumb
 					},
 				},
 			},
-			Rules: []v1alpha2.UDPRouteRule{
+			Rules: []gatewayv1.UDPRouteRule{
 				{
 					BackendRefs: []gatewayv1.BackendRef{
 						{
@@ -3420,8 +3468,8 @@ func TestBuildL4RoutesForGatewaysTCPAndUDP(t *testing.T) {
 
 	tests := []struct {
 		tlsRoutes     map[types.NamespacedName]*gatewayv1.TLSRoute
-		tcpRoutes     map[types.NamespacedName]*v1alpha2.TCPRoute
-		udpRoutes     map[types.NamespacedName]*v1alpha2.UDPRoute
+		tcpRoutes     map[types.NamespacedName]*gatewayv1.TCPRoute
+		udpRoutes     map[types.NamespacedName]*gatewayv1.UDPRoute
 		name          string
 		listeners     []*Listener
 		expectedCount int
@@ -3432,10 +3480,10 @@ func TestBuildL4RoutesForGatewaysTCPAndUDP(t *testing.T) {
 				createTestL4Listener("tcp-listener", 8080, gatewayv1.TCPProtocolType, kinds.TCPRoute),
 				createTestL4Listener("udp-listener", 5353, gatewayv1.UDPProtocolType, kinds.UDPRoute),
 			},
-			tcpRoutes: map[types.NamespacedName]*v1alpha2.TCPRoute{
+			tcpRoutes: map[types.NamespacedName]*gatewayv1.TCPRoute{
 				{Namespace: testNs, Name: "tcp-route"}: createTestTCPRoute("tcp-route", "service", 8080),
 			},
-			udpRoutes: map[types.NamespacedName]*v1alpha2.UDPRoute{
+			udpRoutes: map[types.NamespacedName]*gatewayv1.UDPRoute{
 				{Namespace: testNs, Name: "udp-route"}: createTestUDPRoute("udp-route", "service", 5353),
 			},
 			expectedCount: 2,
@@ -3450,10 +3498,10 @@ func TestBuildL4RoutesForGatewaysTCPAndUDP(t *testing.T) {
 			tlsRoutes: map[types.NamespacedName]*gatewayv1.TLSRoute{
 				{Namespace: testNs, Name: "tls-route"}: createTestTLSRoute("tls-route", "app.example.com"),
 			},
-			tcpRoutes: map[types.NamespacedName]*v1alpha2.TCPRoute{
+			tcpRoutes: map[types.NamespacedName]*gatewayv1.TCPRoute{
 				{Namespace: testNs, Name: "tcp-route"}: createTestTCPRoute("tcp-route", "service", 8080),
 			},
-			udpRoutes: map[types.NamespacedName]*v1alpha2.UDPRoute{
+			udpRoutes: map[types.NamespacedName]*gatewayv1.UDPRoute{
 				{Namespace: testNs, Name: "udp-route"}: createTestUDPRoute("udp-route", "service", 5353),
 			},
 			expectedCount: 3,
@@ -3463,7 +3511,7 @@ func TestBuildL4RoutesForGatewaysTCPAndUDP(t *testing.T) {
 			listeners: []*Listener{
 				createTestL4Listener("tcp-listener", 8080, gatewayv1.TCPProtocolType, kinds.TCPRoute),
 			},
-			tcpRoutes: map[types.NamespacedName]*v1alpha2.TCPRoute{
+			tcpRoutes: map[types.NamespacedName]*gatewayv1.TCPRoute{
 				{Namespace: testNs, Name: "tcp-route"}: createTestTCPRoute("tcp-route", "service", 8080),
 			},
 			expectedCount: 1,
@@ -3473,7 +3521,7 @@ func TestBuildL4RoutesForGatewaysTCPAndUDP(t *testing.T) {
 			listeners: []*Listener{
 				createTestL4Listener("udp-listener", 5353, gatewayv1.UDPProtocolType, kinds.UDPRoute),
 			},
-			udpRoutes: map[types.NamespacedName]*v1alpha2.UDPRoute{
+			udpRoutes: map[types.NamespacedName]*gatewayv1.UDPRoute{
 				{Namespace: testNs, Name: "udp-route"}: createTestUDPRoute("udp-route", "service", 5353),
 			},
 			expectedCount: 1,
@@ -3573,7 +3621,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 		expectedAllowed        bool
 		expectedAttached       bool
 		expectedNotConflicting bool
-		expectedMultipleRoutes bool
 	}{
 		{
 			name:                   "TCP route - first route attaches successfully",
@@ -3583,7 +3630,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			expectedAllowed:        true,
 			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: false,
 		},
 		{
 			name:      "TCP route - same route attaches again (idempotent)",
@@ -3601,7 +3647,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			expectedAllowed:        true,
 			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: false,
 		},
 		{
 			name:      "TCP route - different route conflicts",
@@ -3617,9 +3662,8 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			},
 			currentRouteName:       "tcp-route-2",
 			expectedAllowed:        true,
-			expectedAttached:       false,
+			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: true,
 		},
 		{
 			name:                   "UDP route - first route attaches successfully",
@@ -3629,7 +3673,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			expectedAllowed:        true,
 			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: false,
 		},
 		{
 			name:      "UDP route - same route attaches again (idempotent)",
@@ -3647,7 +3690,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			expectedAllowed:        true,
 			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: false,
 		},
 		{
 			name:      "UDP route - different route conflicts",
@@ -3663,9 +3705,8 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			},
 			currentRouteName:       "udp-route-2",
 			expectedAllowed:        true,
-			expectedAttached:       false,
+			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: true,
 		},
 		{
 			name:      "TLS route - multiple routes can attach (has hostname discriminator)",
@@ -3683,7 +3724,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			expectedAllowed:        true,
 			expectedAttached:       true,
 			expectedNotConflicting: true,
-			expectedMultipleRoutes: false,
 		},
 	}
 
@@ -3762,7 +3802,7 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 				AcceptedHostnames: make(map[string][]string),
 			}
 
-			allowed, attached, notConflicting, multipleRoutes := bindToListenerL4(
+			allowed, attached, notConflicting := bindToListenerL4(
 				listener,
 				route,
 				map[types.NamespacedName]*v1.Namespace{
@@ -3776,7 +3816,6 @@ func TestBindToListenerL4TCPUDPConflicts(t *testing.T) {
 			g.Expect(allowed).To(Equal(test.expectedAllowed), "allowed mismatch")
 			g.Expect(attached).To(Equal(test.expectedAttached), "attached mismatch")
 			g.Expect(notConflicting).To(Equal(test.expectedNotConflicting), "notConflicting mismatch")
-			g.Expect(multipleRoutes).To(Equal(test.expectedMultipleRoutes), "multipleRoutes mismatch")
 		})
 	}
 }

--- a/internal/controller/state/graph/tcproute.go
+++ b/internal/controller/state/graph/tcproute.go
@@ -3,11 +3,11 @@ package graph
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func buildTCPRoute(
-	tcpRoute *v1alpha2.TCPRoute,
+	tcpRoute *gatewayv1.TCPRoute,
 	gws map[types.NamespacedName]*Gateway,
 	services map[types.NamespacedName]*apiv1.Service,
 	refGrantResolver func(resource toResource) bool,

--- a/internal/controller/state/graph/tcproute_test.go
+++ b/internal/controller/state/graph/tcproute_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
@@ -16,15 +15,15 @@ import (
 )
 
 func createTCPRoute(
-	rules []v1alpha2.TCPRouteRule,
+	rules []gatewayv1.TCPRouteRule,
 	parentRefs []gatewayv1.ParentReference,
-) *v1alpha2.TCPRoute {
-	return &v1alpha2.TCPRoute{
+) *gatewayv1.TCPRoute {
+	return &gatewayv1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "tcpr",
 		},
-		Spec: v1alpha2.TCPRouteSpec{
+		Spec: gatewayv1.TCPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: parentRefs,
 			},
@@ -118,7 +117,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	)
 
 	backendRefDNETCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -136,7 +135,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	)
 
 	wrongBackendRefGroupTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -155,7 +154,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	)
 
 	wrongBackendRefKindTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -174,7 +173,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	)
 
 	diffNsBackendRefTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -193,7 +192,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	)
 
 	portNilBackendRefTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -211,7 +210,7 @@ func TestBuildTCPRoute(t *testing.T) {
 
 	// Valid TCPRoute with single backend
 	validSingleBackendTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -230,7 +229,7 @@ func TestBuildTCPRoute(t *testing.T) {
 
 	// Valid TCPRoute with multiple backends (weighted)
 	validMultiBackendTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -257,7 +256,7 @@ func TestBuildTCPRoute(t *testing.T) {
 
 	// TCPRoute with multiple rules
 	multiRuleTCPR := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -286,7 +285,7 @@ func TestBuildTCPRoute(t *testing.T) {
 
 	// Valid TCPRoute with ListenerSet parent ref
 	validTCPRWithListenerSetParentRef := createTCPRoute(
-		[]v1alpha2.TCPRouteRule{
+		[]gatewayv1.TCPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -327,7 +326,7 @@ func TestBuildTCPRoute(t *testing.T) {
 	tests := []struct {
 		gateways map[types.NamespacedName]*Gateway
 		services map[types.NamespacedName]*apiv1.Service
-		route    *v1alpha2.TCPRoute
+		route    *gatewayv1.TCPRoute
 		expected *L4Route
 		name     string
 	}{

--- a/internal/controller/state/graph/udproute.go
+++ b/internal/controller/state/graph/udproute.go
@@ -3,11 +3,11 @@ package graph
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func buildUDPRoute(
-	udpRoute *v1alpha2.UDPRoute,
+	udpRoute *gatewayv1.UDPRoute,
 	gws map[types.NamespacedName]*Gateway,
 	services map[types.NamespacedName]*apiv1.Service,
 	refGrantResolver func(resource toResource) bool,

--- a/internal/controller/state/graph/udproute_test.go
+++ b/internal/controller/state/graph/udproute_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
@@ -16,15 +15,15 @@ import (
 )
 
 func createUDPRoute(
-	rules []v1alpha2.UDPRouteRule,
+	rules []gatewayv1.UDPRouteRule,
 	parentRefs []gatewayv1.ParentReference,
-) *v1alpha2.UDPRoute {
-	return &v1alpha2.UDPRoute{
+) *gatewayv1.UDPRoute {
+	return &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "udpr",
 		},
-		Spec: v1alpha2.UDPRouteSpec{
+		Spec: gatewayv1.UDPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: parentRefs,
 			},
@@ -118,7 +117,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	)
 
 	backendRefDNEUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -136,7 +135,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	)
 
 	wrongBackendRefGroupUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -155,7 +154,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	)
 
 	wrongBackendRefKindUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -174,7 +173,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	)
 
 	diffNsBackendRefUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -193,7 +192,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	)
 
 	portNilBackendRefUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -211,7 +210,7 @@ func TestBuildUDPRoute(t *testing.T) {
 
 	// Valid UDPRoute with single backend
 	validSingleBackendUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -230,7 +229,7 @@ func TestBuildUDPRoute(t *testing.T) {
 
 	// Valid UDPRoute with multiple backends (weighted)
 	validMultiBackendUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -257,7 +256,7 @@ func TestBuildUDPRoute(t *testing.T) {
 
 	// UDPRoute with multiple rules
 	multiRuleUDPR := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -286,7 +285,7 @@ func TestBuildUDPRoute(t *testing.T) {
 
 	// Valid UDPRoute with ListenerSet parent ref
 	validUDPRWithListenerSetParentRef := createUDPRoute(
-		[]v1alpha2.UDPRouteRule{
+		[]gatewayv1.UDPRouteRule{
 			{
 				BackendRefs: []gatewayv1.BackendRef{
 					{
@@ -327,7 +326,7 @@ func TestBuildUDPRoute(t *testing.T) {
 	tests := []struct {
 		gateways map[types.NamespacedName]*Gateway
 		services map[types.NamespacedName]*apiv1.Service
-		route    *v1alpha2.UDPRoute
+		route    *gatewayv1.UDPRoute
 		expected *L4Route
 		name     string
 	}{

--- a/internal/controller/status/gatewayclass.go
+++ b/internal/controller/status/gatewayclass.go
@@ -9,8 +9,7 @@ import (
 
 // supportedFeatures returns the list of features supported by NGINX Gateway Fabric.
 // The list must be sorted in ascending alphabetical order.
-// If experimental is true, experimental features like TLSRoute will be included.
-func supportedFeatures(experimental bool) []gatewayv1.SupportedFeature {
+func supportedFeatures() []gatewayv1.SupportedFeature {
 	featureNames := []features.FeatureName{
 		// Core features
 		features.SupportGateway,
@@ -58,15 +57,12 @@ func supportedFeatures(experimental bool) []gatewayv1.SupportedFeature {
 		features.SupportHTTPRoute307RedirectStatusCode,
 		features.SupportHTTPRoute308RedirectStatusCode,
 		features.SupportHTTPRouteCORS,
-	}
 
-	// Add experimental features if enabled
-	if experimental {
-		featureNames = append(
-			featureNames,
-			features.SupportUDPRoute,
-			features.FeatureName("TCPRoute"),
-		)
+		// TCPRoute
+		features.SupportTCPRoute,
+
+		// UDPRoute
+		features.SupportUDPRoute,
 	}
 
 	// Sort alphabetically by feature name

--- a/internal/controller/status/gatewayclass_test.go
+++ b/internal/controller/status/gatewayclass_test.go
@@ -50,31 +50,18 @@ func TestSupportedFeatures(t *testing.T) {
 		gatewayv1.FeatureName(features.SupportGatewayFrontendClientCertificateValidation),
 		gatewayv1.FeatureName(features.SupportGatewayFrontendClientCertificateValidationInsecureFallback),
 		gatewayv1.FeatureName(features.SupportListenerSet),
-	}
-
-	experimentalFeatures := []gatewayv1.FeatureName{
+		gatewayv1.FeatureName(features.SupportTCPRoute),
 		gatewayv1.FeatureName(features.SupportUDPRoute),
-		gatewayv1.FeatureName("TCPRoute"),
 	}
-
-	allFeatures := append(slices.Clone(standardFeatures), experimentalFeatures...)
 
 	tests := []struct {
 		name               string
 		expectedFeatures   []gatewayv1.FeatureName
 		unexpectedFeatures []gatewayv1.FeatureName
-		experimental       bool
 	}{
 		{
-			name:               "standard features only",
-			experimental:       false,
+			name:               "standard features",
 			expectedFeatures:   standardFeatures,
-			unexpectedFeatures: experimentalFeatures,
-		},
-		{
-			name:               "standard and experimental features",
-			experimental:       true,
-			expectedFeatures:   allFeatures,
 			unexpectedFeatures: []gatewayv1.FeatureName{},
 		},
 	}
@@ -84,7 +71,7 @@ func TestSupportedFeatures(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			features := supportedFeatures(tc.experimental)
+			features := supportedFeatures()
 
 			g.Expect(features).To(HaveLen(len(tc.expectedFeatures)))
 

--- a/internal/controller/status/prepare_requests.go
+++ b/internal/controller/status/prepare_requests.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPI "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
@@ -54,24 +53,24 @@ func PrepareRouteRequests(
 			}
 			reqs = append(reqs, req)
 
-		case *v1alpha2.TCPRoute:
-			status := v1alpha2.TCPRouteStatus{
+		case *v1.TCPRoute:
+			status := v1.TCPRouteStatus{
 				RouteStatus: routeStatus,
 			}
 			req := UpdateRequest{
 				NsName:       routeKey.NamespacedName,
-				ResourceType: &v1alpha2.TCPRoute{},
+				ResourceType: &v1.TCPRoute{},
 				Setter:       newTCPRouteStatusSetter(status, gatewayCtlrName),
 			}
 			reqs = append(reqs, req)
 
-		case *v1alpha2.UDPRoute:
-			status := v1alpha2.UDPRouteStatus{
+		case *v1.UDPRoute:
+			status := v1.UDPRouteStatus{
 				RouteStatus: routeStatus,
 			}
 			req := UpdateRequest{
 				NsName:       routeKey.NamespacedName,
-				ResourceType: &v1alpha2.UDPRoute{},
+				ResourceType: &v1.UDPRoute{},
 				Setter:       newUDPRouteStatusSetter(status, gatewayCtlrName),
 			}
 			reqs = append(reqs, req)
@@ -244,7 +243,7 @@ func PrepareGatewayClassRequests(
 		var suppFeatures []v1.SupportedFeature
 		// Skip reporting supported features if we are in BestEffort mode
 		if !gc.BestEffort {
-			suppFeatures = supportedFeatures(gc.ExperimentalSupported)
+			suppFeatures = supportedFeatures()
 		}
 
 		req := UpdateRequest{
@@ -264,7 +263,7 @@ func PrepareGatewayClassRequests(
 		// Skip reporting supported features if we are in BestEffort mode
 		// If gc is nil, we can safely populate supported features
 		if gc == nil || !gc.BestEffort {
-			ignoredSuppFeatures = supportedFeatures(false)
+			ignoredSuppFeatures = supportedFeatures()
 		}
 
 		req := UpdateRequest{
@@ -513,7 +512,7 @@ func PrepareNGFPolicyRequests(
 
 			ancestorStatuses = append(ancestorStatuses, v1.PolicyAncestorStatus{
 				AncestorRef:    ancestor.Ancestor,
-				ControllerName: v1alpha2.GatewayController(gatewayCtlrName),
+				ControllerName: v1.GatewayController(gatewayCtlrName),
 				Conditions:     apiConds,
 			})
 		}
@@ -555,7 +554,7 @@ func PrepareBackendTLSPolicyRequests(
 					Group:     helpers.GetPointer[v1.Group](v1.GroupName),
 					Kind:      helpers.GetPointer[v1.Kind](kinds.Gateway),
 				},
-				ControllerName: v1alpha2.GatewayController(gatewayCtlrName),
+				ControllerName: v1.GatewayController(gatewayCtlrName),
 				Conditions:     apiConds,
 			}
 
@@ -598,7 +597,7 @@ func PrepareSnippetsFilterRequests(
 			Controllers: []ngfAPI.ControllerStatus{
 				{
 					Conditions:     apiConds,
-					ControllerName: v1alpha2.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 				},
 			},
 		}
@@ -631,7 +630,7 @@ func PrepareAuthenticationFilterRequests(
 			Controllers: []ngfAPI.ControllerStatus{
 				{
 					Conditions:     apiConds,
-					ControllerName: v1alpha2.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 				},
 			},
 		}

--- a/internal/controller/status/prepare_requests_test.go
+++ b/internal/controller/status/prepare_requests_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPI "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/conditions"
@@ -31,7 +30,6 @@ func createK8sClientFor(resourceType ngftypes.ObjectType) client.Client {
 
 	// for simplicity, we add all used schemes here
 	utilruntime.Must(v1.Install(scheme))
-	utilruntime.Must(v1alpha2.Install(scheme))
 	utilruntime.Must(ngfAPI.AddToScheme(scheme))
 	utilruntime.Must(inference.Install(scheme))
 
@@ -810,7 +808,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 							Message:            conditions.GatewayClassMessageGatewayClassConflict,
 						},
 					},
-					SupportedFeatures: supportedFeatures(false),
+					SupportedFeatures: supportedFeatures(),
 				},
 				{Name: "ignored-2"}: {
 					Conditions: []metav1.Condition{
@@ -823,7 +821,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 							Message:            conditions.GatewayClassMessageGatewayClassConflict,
 						},
 					},
-					SupportedFeatures: supportedFeatures(false),
+					SupportedFeatures: supportedFeatures(),
 				},
 			},
 		},
@@ -857,7 +855,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 							Message:            "The Gateway API CRD versions are supported",
 						},
 					},
-					SupportedFeatures: supportedFeatures(false),
+					SupportedFeatures: supportedFeatures(),
 				},
 			},
 		},
@@ -929,7 +927,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 							Message:            "The Gateway API CRD versions are not recommended. Recommended version is v1.4.0",
 						},
 					},
-					SupportedFeatures: supportedFeatures(false),
+					SupportedFeatures: supportedFeatures(),
 				},
 			},
 		},
@@ -3607,23 +3605,23 @@ func TestBuildInferencePoolStatuses(t *testing.T) {
 
 func TestBuildTCPRouteStatuses(t *testing.T) {
 	t.Parallel()
-	tcpValid := &v1alpha2.TCPRoute{
+	tcpValid := &v1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "tcp-valid",
 			Generation: 3,
 		},
-		Spec: v1alpha2.TCPRouteSpec{
+		Spec: v1.TCPRouteSpec{
 			CommonRouteSpec: commonRouteSpecValid,
 		},
 	}
-	tcpInvalid := &v1alpha2.TCPRoute{
+	tcpInvalid := &v1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "tcp-invalid",
 			Generation: 3,
 		},
-		Spec: v1alpha2.TCPRouteSpec{
+		Spec: v1.TCPRouteSpec{
 			CommonRouteSpec: commonRouteSpecInvalid,
 		},
 	}
@@ -3641,7 +3639,7 @@ func TestBuildTCPRouteStatuses(t *testing.T) {
 		},
 	}
 
-	expectedStatuses := map[types.NamespacedName]v1alpha2.TCPRouteStatus{
+	expectedStatuses := map[types.NamespacedName]v1.TCPRouteStatus{
 		{Namespace: "test", Name: "tcp-valid"}: {
 			RouteStatus: routeStatusValid,
 		},
@@ -3652,7 +3650,7 @@ func TestBuildTCPRouteStatuses(t *testing.T) {
 
 	g := NewWithT(t)
 
-	k8sClient := createK8sClientFor(&v1alpha2.TCPRoute{})
+	k8sClient := createK8sClientFor(&v1.TCPRoute{})
 
 	for _, r := range routes {
 		err := k8sClient.Create(t.Context(), r.Source)
@@ -3673,7 +3671,7 @@ func TestBuildTCPRouteStatuses(t *testing.T) {
 	g.Expect(reqs).To(HaveLen(len(expectedStatuses)))
 
 	for nsname, expected := range expectedStatuses {
-		var tcpRoute v1alpha2.TCPRoute
+		var tcpRoute v1.TCPRoute
 
 		err := k8sClient.Get(t.Context(), nsname, &tcpRoute)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -3683,23 +3681,23 @@ func TestBuildTCPRouteStatuses(t *testing.T) {
 
 func TestBuildUDPRouteStatuses(t *testing.T) {
 	t.Parallel()
-	udpValid := &v1alpha2.UDPRoute{
+	udpValid := &v1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "udp-valid",
 			Generation: 3,
 		},
-		Spec: v1alpha2.UDPRouteSpec{
+		Spec: v1.UDPRouteSpec{
 			CommonRouteSpec: commonRouteSpecValid,
 		},
 	}
-	udpInvalid := &v1alpha2.UDPRoute{
+	udpInvalid := &v1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "udp-invalid",
 			Generation: 3,
 		},
-		Spec: v1alpha2.UDPRouteSpec{
+		Spec: v1.UDPRouteSpec{
 			CommonRouteSpec: commonRouteSpecInvalid,
 		},
 	}
@@ -3717,7 +3715,7 @@ func TestBuildUDPRouteStatuses(t *testing.T) {
 		},
 	}
 
-	expectedStatuses := map[types.NamespacedName]v1alpha2.UDPRouteStatus{
+	expectedStatuses := map[types.NamespacedName]v1.UDPRouteStatus{
 		{Namespace: "test", Name: "udp-valid"}: {
 			RouteStatus: routeStatusValid,
 		},
@@ -3728,7 +3726,7 @@ func TestBuildUDPRouteStatuses(t *testing.T) {
 
 	g := NewWithT(t)
 
-	k8sClient := createK8sClientFor(&v1alpha2.UDPRoute{})
+	k8sClient := createK8sClientFor(&v1.UDPRoute{})
 
 	for _, r := range routes {
 		err := k8sClient.Create(t.Context(), r.Source)
@@ -3749,7 +3747,7 @@ func TestBuildUDPRouteStatuses(t *testing.T) {
 	g.Expect(reqs).To(HaveLen(len(expectedStatuses)))
 
 	for nsname, expected := range expectedStatuses {
-		var udpRoute v1alpha2.UDPRoute
+		var udpRoute v1.UDPRoute
 
 		err := k8sClient.Get(t.Context(), nsname, &udpRoute)
 		g.Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/status/status_setters.go
+++ b/internal/controller/status/status_setters.go
@@ -6,7 +6,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPI "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies"
@@ -161,9 +160,9 @@ func newGRPCRouteStatusSetter(status gatewayv1.GRPCRouteStatus, gatewayCtlrName 
 	}
 }
 
-func newTCPRouteStatusSetter(status v1alpha2.TCPRouteStatus, gatewayCtlrName string) Setter {
+func newTCPRouteStatusSetter(status gatewayv1.TCPRouteStatus, gatewayCtlrName string) Setter {
 	return func(object client.Object) (wasSet bool) {
-		tr := helpers.MustCastObject[*v1alpha2.TCPRoute](object)
+		tr := helpers.MustCastObject[*gatewayv1.TCPRoute](object)
 
 		// keep all the parent statuses that belong to other controllers
 		for _, os := range tr.Status.Parents {
@@ -182,9 +181,9 @@ func newTCPRouteStatusSetter(status v1alpha2.TCPRouteStatus, gatewayCtlrName str
 	}
 }
 
-func newUDPRouteStatusSetter(status v1alpha2.UDPRouteStatus, gatewayCtlrName string) Setter {
+func newUDPRouteStatusSetter(status gatewayv1.UDPRouteStatus, gatewayCtlrName string) Setter {
 	return func(object client.Object) (wasSet bool) {
-		ur := helpers.MustCastObject[*v1alpha2.UDPRoute](object)
+		ur := helpers.MustCastObject[*gatewayv1.UDPRoute](object)
 
 		// keep all the parent statuses that belong to other controllers
 		for _, os := range ur.Status.Parents {

--- a/internal/controller/status/status_setters_test.go
+++ b/internal/controller/status/status_setters_test.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	inference "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	ngfAPI "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/policies/policiesfakes"
@@ -501,7 +500,7 @@ func TestNewTLSRouteStatusSetter(t *testing.T) {
 		{
 			name: "TLSRoute has no status",
 			newStatus: gatewayv1.TLSRouteStatus{
-				RouteStatus: v1alpha2.RouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
 							ParentRef:      gatewayv1.ParentReference{},
@@ -2214,12 +2213,12 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 
 	tests := []struct {
 		name                         string
-		status, newStatus, expStatus v1alpha2.TCPRouteStatus
+		status, newStatus, expStatus gatewayv1.TCPRouteStatus
 		expStatusSet                 bool
 	}{
 		{
 			name: "TCPRoute has no status",
-			newStatus: v1alpha2.TCPRouteStatus{
+			newStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2230,7 +2229,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.TCPRouteStatus{
+			expStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2245,7 +2244,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "TCPRoute has old status",
-			newStatus: v1alpha2.TCPRouteStatus{
+			newStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2256,7 +2255,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.TCPRouteStatus{
+			status: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2267,7 +2266,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.TCPRouteStatus{
+			expStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2282,7 +2281,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "TCPRoute has old status, keep other controller statuses",
-			newStatus: v1alpha2.TCPRouteStatus{
+			newStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2293,7 +2292,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.TCPRouteStatus{
+			status: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2309,7 +2308,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.TCPRouteStatus{
+			expStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2329,7 +2328,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "TCPRoute has same status",
-			newStatus: v1alpha2.TCPRouteStatus{
+			newStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2340,7 +2339,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.TCPRouteStatus{
+			status: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2351,7 +2350,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.TCPRouteStatus{
+			expStatus: gatewayv1.TCPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2372,7 +2371,7 @@ func TestNewTCPRouteStatusSetter(t *testing.T) {
 			g := NewWithT(t)
 
 			setter := newTCPRouteStatusSetter(test.newStatus, controllerName)
-			obj := &v1alpha2.TCPRoute{Status: test.status}
+			obj := &gatewayv1.TCPRoute{Status: test.status}
 
 			statusSet := setter(obj)
 
@@ -2391,12 +2390,12 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 
 	tests := []struct {
 		name                         string
-		status, newStatus, expStatus v1alpha2.UDPRouteStatus
+		status, newStatus, expStatus gatewayv1.UDPRouteStatus
 		expStatusSet                 bool
 	}{
 		{
 			name: "UDPRoute has no status",
-			newStatus: v1alpha2.UDPRouteStatus{
+			newStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2407,7 +2406,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.UDPRouteStatus{
+			expStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2422,7 +2421,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "UDPRoute has old status",
-			newStatus: v1alpha2.UDPRouteStatus{
+			newStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2433,7 +2432,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.UDPRouteStatus{
+			status: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2444,7 +2443,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.UDPRouteStatus{
+			expStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2459,7 +2458,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "UDPRoute has old status, keep other controller statuses",
-			newStatus: v1alpha2.UDPRouteStatus{
+			newStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2470,7 +2469,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.UDPRouteStatus{
+			status: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2486,7 +2485,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.UDPRouteStatus{
+			expStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2506,7 +2505,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 		},
 		{
 			name: "UDPRoute has same status",
-			newStatus: v1alpha2.UDPRouteStatus{
+			newStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2517,7 +2516,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1alpha2.UDPRouteStatus{
+			status: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2528,7 +2527,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			expStatus: v1alpha2.UDPRouteStatus{
+			expStatus: gatewayv1.UDPRouteStatus{
 				RouteStatus: gatewayv1.RouteStatus{
 					Parents: []gatewayv1.RouteParentStatus{
 						{
@@ -2549,7 +2548,7 @@ func TestNewUDPRouteStatusSetter(t *testing.T) {
 			g := NewWithT(t)
 
 			setter := newUDPRouteStatusSetter(test.newStatus, controllerName)
-			obj := &v1alpha2.UDPRoute{Status: test.status}
+			obj := &gatewayv1.UDPRoute{Status: test.status}
 
 			statusSet := setter(obj)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ GW_SERVICE_TYPE = NodePort## Service type to use for the gateway
 NGF_VERSION ?= edge## NGF version to be tested
 PULL_POLICY ?= Never## Pull policy for the images
 NGINX_CONF_DIR = internal/controller/nginx/conf
-STANDARD_CONFORMANCE_PROFILES = GATEWAY-HTTP,GATEWAY-GRPC,GATEWAY-TLS
+STANDARD_CONFORMANCE_PROFILES = GATEWAY-HTTP,GATEWAY-GRPC,GATEWAY-TLS,GATEWAY-TCP,GATEWAY-UDP
 EXPERIMENTAL_CONFORMANCE_PROFILES =
 CONFORMANCE_PROFILES = $(STANDARD_CONFORMANCE_PROFILES) # by default we use the standard conformance profiles. If experimental is enabled we override this and add the experimental profiles.
 SUPPORTED_EXTENDED_FEATURES_OPENSHIFT = HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,GatewayPort8080,GatewayAddressEmpty,HTTPRouteResponseHeaderModification,HTTPRoutePathRedirect,GatewayHTTPListenerIsolation,GatewayInfrastructurePropagation,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors,HTTPRouteRequestPercentageMirror,HTTPRouteBackendProtocolWebSocket,HTTPRouteParentRefPort,HTTPRouteDestinationPortMatching,HTTPRouteHTTPSListenerDetectMisdirectedRequests,GatewayBackendClientCertificate
@@ -71,9 +71,11 @@ run-conformance-tests: deploy-metallb ## Run conformance tests
 	rm output.txt
 	grpc_core_result=`yq '.profiles[] | select(.name == "GATEWAY-GRPC") | .core.result' conformance-profile.yaml`; \
 	tls_core_result=`yq '.profiles[] | select(.name == "GATEWAY-TLS") | .core.result' conformance-profile.yaml`; \
+	tcp_core_result=`yq '.profiles[] | select(.name == "GATEWAY-TCP") | .core.result' conformance-profile.yaml`; \
+	udp_core_result=`yq '.profiles[] | select(.name == "GATEWAY-UDP") | .core.result' conformance-profile.yaml`; \
 	http_core_result=`yq '.profiles[] | select(.name == "GATEWAY-HTTP") | .core.result' conformance-profile.yaml`; \
 	http_extended_result=`yq '.profiles[] | select(.name == "GATEWAY-HTTP") | .extended.result' conformance-profile.yaml`; \
-	if [ "$$grpc_core_result" != "failure" ] && [ "$$tls_core_result" != "failure" ] && [ "$$http_core_result" != "failure" ] && [ "$$http_extended_result" != "failure" ] ; then \
+	if [ "$$grpc_core_result" != "failure" ] && [ "$$tls_core_result" != "failure" ] && [ "$$tcp_core_result" != "failure" ] && [ "$$udp_core_result" != "failure" ] && [ "$$http_core_result" != "failure" ] && [ "$$http_extended_result" != "failure" ] ; then \
 		exit 0; \
 	else \
 		exit 2; \


### PR DESCRIPTION
With the release of Gateway API 1.6, we can update our support for TCPRoute and UDPRoute from v1alpha2 to v1. These are no longer experimental features.

Multiple L4 routes can now be attached to the same listener as well, though only the oldest is used.

Testing: Conformance suite passes with all new TCP and UDP tests

Closes #5378

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Support v1 TCPRoute and UDPRoute
```
