### PR TITLE
Fix config changing for same SnippetsPolicy objects

### DIFF
--- a/internal/controller/nginx/config/includes.go
+++ b/internal/controller/nginx/config/includes.go
@@ -132,15 +132,13 @@ func createIncludeFromAuthZMap(filterNsName string, authZMap dataplane.AuthZMap)
 // Duplicate includes are possible when a single policy targets multiple resources, or a snippets filter
 // is referenced on multiple routing rules.
 func deduplicateIncludes(includes []shared.Include) []shared.Include {
-	uniqueIncludes := make(map[string]shared.Include)
+	seen := make(map[string]struct{}, len(includes))
+	results := make([]shared.Include, 0, len(includes))
 	for _, i := range includes {
-		if _, ok := uniqueIncludes[i.Name]; !ok {
-			uniqueIncludes[i.Name] = i
+		if _, ok := seen[i.Name]; ok {
+			continue
 		}
-	}
-
-	results := make([]shared.Include, 0, len(uniqueIncludes))
-	for _, i := range uniqueIncludes {
+		seen[i.Name] = struct{}{}
 		results = append(results, i)
 	}
 

--- a/internal/controller/nginx/config/includes_test.go
+++ b/internal/controller/nginx/config/includes_test.go
@@ -230,7 +230,7 @@ func TestCreateIncludesFromLocationSnippetsFilter(t *testing.T) {
 			g := NewWithT(t)
 
 			includes := createIncludesFromLocationSnippetsFilters(test.filters)
-			g.Expect(includes).To(ConsistOf(test.expIncludes))
+			g.Expect(includes).To(Equal(test.expIncludes))
 		})
 	}
 }

--- a/internal/controller/nginx/config/policies/snippetspolicy/generator.go
+++ b/internal/controller/nginx/config/policies/snippetspolicy/generator.go
@@ -1,7 +1,9 @@
 package snippetspolicy
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 
 	"github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config/http"
@@ -67,13 +69,26 @@ func (g *Generator) generate(
 	context v1alpha1.NginxContext,
 ) policies.GenerateResultFiles {
 	var files policies.GenerateResultFiles
+	snippetsPolicies := make([]*v1alpha1.SnippetsPolicy, 0, len(pols))
 
 	for _, policy := range pols {
 		sp, ok := policy.(*v1alpha1.SnippetsPolicy)
 		if !ok {
 			continue
 		}
+		snippetsPolicies = append(snippetsPolicies, sp)
+	}
 
+	// Policy slices are built from graph maps, so their order can change between
+	// reconciliations. Sort them to keep equivalent NGINX configuration stable.
+	slices.SortFunc(snippetsPolicies, func(a, b *v1alpha1.SnippetsPolicy) int {
+		return cmp.Or(
+			cmp.Compare(a.GetNamespace(), b.GetNamespace()),
+			cmp.Compare(a.GetName(), b.GetName()),
+		)
+	})
+
+	for _, sp := range snippetsPolicies {
 		for _, snippet := range sp.Spec.Snippets {
 			if snippet.Context != context {
 				continue

--- a/internal/controller/nginx/config/policies/snippetspolicy/generator_test.go
+++ b/internal/controller/nginx/config/policies/snippetspolicy/generator_test.go
@@ -146,6 +146,33 @@ func TestGenerator(t *testing.T) {
 		gWithT.Expect(files[1].Name).To(ContainSubstring("p2"))
 	})
 
+	t.Run("GenerateForMain orders policies by namespace and name", func(t *testing.T) {
+		gWithT := NewWithT(t)
+		newPolicy := func(namespace, name string) *v1alpha1.SnippetsPolicy {
+			return &v1alpha1.SnippetsPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SnippetsPolicySpec{
+					Snippets: []v1alpha1.Snippet{
+						{Context: v1alpha1.NginxContextMain, Value: name + ";"},
+					},
+				},
+			}
+		}
+
+		files := g.GenerateForMain([]policies.Policy{
+			newPolicy("zebra", "first"),
+			newPolicy("alpha", "second"),
+			newPolicy("alpha", "first"),
+		})
+
+		gWithT.Expect(files).To(HaveLen(3))
+		gWithT.Expect([]string{files[0].Name, files[1].Name, files[2].Name}).To(Equal([]string{
+			"SnippetsPolicy_main_alpha-first.conf",
+			"SnippetsPolicy_main_alpha-second.conf",
+			"SnippetsPolicy_main_zebra-first.conf",
+		}))
+	})
+
 	t.Run("GenerateForMain with multiple targets", func(t *testing.T) {
 		gWithT := NewWithT(t)
 		policy := &v1alpha1.SnippetsPolicy{


### PR DESCRIPTION
### Proposed changes

Problem: SnippetsPolicy ordering can change between equivalent reconciliations because policies originate from map iteration. Include deduplication also loses its input order. This can change generated NGINX configuration and trigger an
unnecessary reload.

Solution: Sort SnippetsPolicy resources by namespace and name before generating their configuration files. Preserve first-seen order when deduplicating includes.

Testing:
- Added a regression test requiring include deduplication to preserve order.
- Added a regression test requiring deterministic SnippetsPolicy ordering.

Closes #5624

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
NONE
```
