### PR TITLE
Harden agent auth and config-apply robustness

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -277,7 +277,7 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 				Error: errors.New("NGINX configuration update withheld: WAF bundle for Gateway is still pending"),
 			}
 		default:
-			deployment := h.cfg.nginxDeployments.GetOrStore(ctx, gw.DeploymentName, gw.Source.GetName())
+			deployment := h.cfg.nginxDeployments.LoadOrStore(ctx, gw.DeploymentName, gw.Source.GetName())
 			if deployment == nil {
 				panic("expected deployment, got nil")
 			}

--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -92,6 +92,7 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 ) {
 	msg := deployment.SetFiles(files, volumeMounts)
 	if msg == nil {
+		deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
 		n.logger.V(1).Info("No changes to nginx configuration files, not sending to agent")
 		return
 	}
@@ -164,7 +165,7 @@ func (n *NginxUpdaterImpl) UpdateUpstreamServers(
 		requestApplied, err := n.sendRequest(broadcaster, msg, deployment)
 		if err != nil {
 			errs = append(errs, fmt.Errorf(
-				"couldn't update upstream via the API: %w", deployment.GetConfigurationStatus()))
+				"couldn't update upstream via the API: %w", err))
 		}
 		applied = applied || requestApplied
 	}

--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -109,11 +110,19 @@ func TestUpdateConfig_NoChange(t *testing.T) {
 	// Set the initial files on the deployment
 	deployment.SetFiles([]File{file}, []v1.VolumeMount{})
 
+	testErr := errors.New("test error")
+	deployment.SetPodErrorStatus("pod1", testErr)
+
 	// Call UpdateConfig with the same files
 	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
 
 	// Verify that no new configuration was sent
 	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(0))
+	g.Expect(deployment.GetLatestConfigError()).To(Equal(testErr))
+
+	deployment.SetPodErrorStatus("pod1", nil)
+	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
 }
 
 func TestUpdateUpstreamServers(t *testing.T) {
@@ -261,9 +270,9 @@ func TestUpdateUpstreamServers(t *testing.T) {
 
 			if test.expErr {
 				expErr := errors.Join(
-					fmt.Errorf("couldn't update upstream via the API: %w", testErr),
-					fmt.Errorf("couldn't update upstream via the API: %w", testErr),
-					fmt.Errorf("couldn't update upstream via the API: %w", testErr),
+					fmt.Errorf("couldn't update upstream via the API: %w", context.DeadlineExceeded),
+					fmt.Errorf("couldn't update upstream via the API: %w", context.DeadlineExceeded),
+					fmt.Errorf("couldn't update upstream via the API: %w", context.DeadlineExceeded),
 				)
 
 				g.Expect(deployment.GetLatestUpstreamError()).To(Equal(expErr))

--- a/internal/controller/nginx/agent/agentfakes/fake_deployment_storer.go
+++ b/internal/controller/nginx/agent/agentfakes/fake_deployment_storer.go
@@ -21,17 +21,17 @@ type FakeDeploymentStorer struct {
 	getReturnsOnCall map[int]struct {
 		result1 *agent.Deployment
 	}
-	GetOrStoreStub        func(context.Context, types.NamespacedName, string) *agent.Deployment
-	getOrStoreMutex       sync.RWMutex
-	getOrStoreArgsForCall []struct {
+	LoadOrStoreStub        func(context.Context, types.NamespacedName, string) *agent.Deployment
+	loadOrStoreMutex       sync.RWMutex
+	loadOrStoreArgsForCall []struct {
 		arg1 context.Context
 		arg2 types.NamespacedName
 		arg3 string
 	}
-	getOrStoreReturns struct {
+	loadOrStoreReturns struct {
 		result1 *agent.Deployment
 	}
-	getOrStoreReturnsOnCall map[int]struct {
+	loadOrStoreReturnsOnCall map[int]struct {
 		result1 *agent.Deployment
 	}
 	RemoveStub        func(types.NamespacedName)
@@ -104,18 +104,18 @@ func (fake *FakeDeploymentStorer) GetReturnsOnCall(i int, result1 *agent.Deploym
 	}{result1}
 }
 
-func (fake *FakeDeploymentStorer) GetOrStore(arg1 context.Context, arg2 types.NamespacedName, arg3 string) *agent.Deployment {
-	fake.getOrStoreMutex.Lock()
-	ret, specificReturn := fake.getOrStoreReturnsOnCall[len(fake.getOrStoreArgsForCall)]
-	fake.getOrStoreArgsForCall = append(fake.getOrStoreArgsForCall, struct {
+func (fake *FakeDeploymentStorer) LoadOrStore(arg1 context.Context, arg2 types.NamespacedName, arg3 string) *agent.Deployment {
+	fake.loadOrStoreMutex.Lock()
+	ret, specificReturn := fake.loadOrStoreReturnsOnCall[len(fake.loadOrStoreArgsForCall)]
+	fake.loadOrStoreArgsForCall = append(fake.loadOrStoreArgsForCall, struct {
 		arg1 context.Context
 		arg2 types.NamespacedName
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.GetOrStoreStub
-	fakeReturns := fake.getOrStoreReturns
-	fake.recordInvocation("GetOrStore", []interface{}{arg1, arg2, arg3})
-	fake.getOrStoreMutex.Unlock()
+	stub := fake.LoadOrStoreStub
+	fakeReturns := fake.loadOrStoreReturns
+	fake.recordInvocation("LoadOrStore", []interface{}{arg1, arg2, arg3})
+	fake.loadOrStoreMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -125,44 +125,44 @@ func (fake *FakeDeploymentStorer) GetOrStore(arg1 context.Context, arg2 types.Na
 	return fakeReturns.result1
 }
 
-func (fake *FakeDeploymentStorer) GetOrStoreCallCount() int {
-	fake.getOrStoreMutex.RLock()
-	defer fake.getOrStoreMutex.RUnlock()
-	return len(fake.getOrStoreArgsForCall)
+func (fake *FakeDeploymentStorer) LoadOrStoreCallCount() int {
+	fake.loadOrStoreMutex.RLock()
+	defer fake.loadOrStoreMutex.RUnlock()
+	return len(fake.loadOrStoreArgsForCall)
 }
 
-func (fake *FakeDeploymentStorer) GetOrStoreCalls(stub func(context.Context, types.NamespacedName, string) *agent.Deployment) {
-	fake.getOrStoreMutex.Lock()
-	defer fake.getOrStoreMutex.Unlock()
-	fake.GetOrStoreStub = stub
+func (fake *FakeDeploymentStorer) LoadOrStoreCalls(stub func(context.Context, types.NamespacedName, string) *agent.Deployment) {
+	fake.loadOrStoreMutex.Lock()
+	defer fake.loadOrStoreMutex.Unlock()
+	fake.LoadOrStoreStub = stub
 }
 
-func (fake *FakeDeploymentStorer) GetOrStoreArgsForCall(i int) (context.Context, types.NamespacedName, string) {
-	fake.getOrStoreMutex.RLock()
-	defer fake.getOrStoreMutex.RUnlock()
-	argsForCall := fake.getOrStoreArgsForCall[i]
+func (fake *FakeDeploymentStorer) LoadOrStoreArgsForCall(i int) (context.Context, types.NamespacedName, string) {
+	fake.loadOrStoreMutex.RLock()
+	defer fake.loadOrStoreMutex.RUnlock()
+	argsForCall := fake.loadOrStoreArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeDeploymentStorer) GetOrStoreReturns(result1 *agent.Deployment) {
-	fake.getOrStoreMutex.Lock()
-	defer fake.getOrStoreMutex.Unlock()
-	fake.GetOrStoreStub = nil
-	fake.getOrStoreReturns = struct {
+func (fake *FakeDeploymentStorer) LoadOrStoreReturns(result1 *agent.Deployment) {
+	fake.loadOrStoreMutex.Lock()
+	defer fake.loadOrStoreMutex.Unlock()
+	fake.LoadOrStoreStub = nil
+	fake.loadOrStoreReturns = struct {
 		result1 *agent.Deployment
 	}{result1}
 }
 
-func (fake *FakeDeploymentStorer) GetOrStoreReturnsOnCall(i int, result1 *agent.Deployment) {
-	fake.getOrStoreMutex.Lock()
-	defer fake.getOrStoreMutex.Unlock()
-	fake.GetOrStoreStub = nil
-	if fake.getOrStoreReturnsOnCall == nil {
-		fake.getOrStoreReturnsOnCall = make(map[int]struct {
+func (fake *FakeDeploymentStorer) LoadOrStoreReturnsOnCall(i int, result1 *agent.Deployment) {
+	fake.loadOrStoreMutex.Lock()
+	defer fake.loadOrStoreMutex.Unlock()
+	fake.LoadOrStoreStub = nil
+	if fake.loadOrStoreReturnsOnCall == nil {
+		fake.loadOrStoreReturnsOnCall = make(map[int]struct {
 			result1 *agent.Deployment
 		})
 	}
-	fake.getOrStoreReturnsOnCall[i] = struct {
+	fake.loadOrStoreReturnsOnCall[i] = struct {
 		result1 *agent.Deployment
 	}{result1}
 }

--- a/internal/controller/nginx/agent/broadcast/broadcast.go
+++ b/internal/controller/nginx/agent/broadcast/broadcast.go
@@ -3,6 +3,7 @@ package broadcast
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	pb "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -50,7 +51,9 @@ type DeploymentBroadcaster struct {
 	subCh     chan storedChannels
 	unsubCh   chan string
 	listeners map[string]storedChannels
-	doneCh    chan struct{}
+	// doneCh carries the number of listeners that acknowledged the in-flight message once
+	// publishing completes
+	doneCh chan int32
 	// broadcasterCtx is the main context for the broadcaster, which is canceled on shutdown.
 	// It is the parent context for all listener contexts.
 	broadcasterCtx    context.Context
@@ -69,7 +72,7 @@ func NewDeploymentBroadcaster(ctx context.Context) *DeploymentBroadcaster {
 		publishCh:         make(chan NginxAgentMessage),
 		subCh:             make(chan storedChannels),
 		unsubCh:           make(chan string),
-		doneCh:            make(chan struct{}),
+		doneCh:            make(chan int32),
 		broadcasterCtx:    broadcasterCtx,
 		broadcasterCancel: broadcasterCancel,
 	}
@@ -116,7 +119,7 @@ func (b *DeploymentBroadcaster) Subscribe() SubscriberChannels {
 }
 
 // Send the message to all listeners. Wait for all listeners to respond.
-// Returns true if there were listeners that received and responded to the message.
+// Returns true if at least one listener received and acknowledged the message.
 func (b *DeploymentBroadcaster) Send(message NginxAgentMessage) bool {
 	// Try to send message, but can be interrupted by shutdown
 	select {
@@ -127,15 +130,11 @@ func (b *DeploymentBroadcaster) Send(message NginxAgentMessage) bool {
 
 	// Wait for completion, but can be interrupted by shutdown
 	select {
-	case <-b.doneCh:
+	case acked := <-b.doneCh:
+		return acked > 0
 	case <-b.broadcasterCtx.Done():
 		return false
 	}
-
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	return len(b.listeners) > 0
 }
 
 // CancelSubscription removes a Subscriber from the channel list.
@@ -193,7 +192,8 @@ func (b *DeploymentBroadcaster) publisher() {
 			}
 			b.mu.RUnlock()
 
-			// Send to all listeners
+			// Send to all listeners, tracking how many actually acknowledge the message
+			var acked atomic.Int32
 			var wg sync.WaitGroup
 			for _, channels := range currentListeners {
 				wg.Go(func() {
@@ -212,7 +212,8 @@ func (b *DeploymentBroadcaster) publisher() {
 					case <-b.broadcasterCtx.Done():
 						return
 					case <-channels.responseCh:
-						// Response received, continue
+						// Response received, count as acknowledged
+						acked.Add(1)
 						return
 					}
 				})
@@ -224,8 +225,8 @@ func (b *DeploymentBroadcaster) publisher() {
 			// the done signal, so we return to avoid blocking.
 			case <-b.broadcasterCtx.Done():
 				return
-			case b.doneCh <- struct{}{}:
-				// Signal that publishing is done and all responses received
+			case b.doneCh <- acked.Load():
+				// Signal that publishing is done and report how many listeners acknowledged
 			}
 		}
 	}

--- a/internal/controller/nginx/agent/command.go
+++ b/internal/controller/nginx/agent/command.go
@@ -186,7 +186,7 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 	deployment.FileLock.RUnlock()
 	defer broadcaster.CancelSubscription(channels.ID)
 
-	var pendingBroadcastRequest *broadcast.NginxAgentMessage
+	pendingBroadcastRequest := false
 
 	for {
 		// When a message is received over the ListenCh, it is assumed and required that the
@@ -198,12 +198,14 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 		// which releases the lock.
 		select {
 		case <-ctx.Done():
-			select {
-			case channels.ResponseCh <- struct{}{}:
-			default:
+			if pendingBroadcastRequest {
+				trySignalBroadcastResponse(channels.ResponseCh)
 			}
 			return grpcStatus.Error(codes.Canceled, context.Cause(ctx).Error())
 		case <-cs.resetConnChan:
+			if pendingBroadcastRequest {
+				trySignalBroadcastResponse(channels.ResponseCh)
+			}
 			return grpcStatus.Error(codes.Unavailable, "TLS files updated")
 		case msg := <-channels.ListenCh:
 			var req *pb.ManagementPlaneRequest
@@ -232,22 +234,19 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 			if err := msgr.Send(ctx, req); err != nil {
 				cs.logger.Error(err, "error sending request to agent")
 				deployment.SetPodErrorStatus(grpcInfo.UUID, err)
-				channels.ResponseCh <- struct{}{}
+				trySignalBroadcastResponse(channels.ResponseCh)
 
 				return grpcStatus.Error(codes.Internal, err.Error())
 			}
 
 			// Track this broadcast request to distinguish it from initial config operations.
 			// Only broadcast operations should signal ResponseCh for coordination.
-			pendingBroadcastRequest = &msg
+			pendingBroadcastRequest = true
 		case err = <-msgr.Errors():
 			cs.logger.Error(err, "connection error", conn.ParentType, conn.ParentName, "uuid", grpcInfo.UUID)
 			deployment.SetPodErrorStatus(grpcInfo.UUID, err)
-			select {
-			case channels.ResponseCh <- struct{}{}:
-			default:
-			}
-			if pendingBroadcastRequest != nil {
+			if pendingBroadcastRequest {
+				trySignalBroadcastResponse(channels.ResponseCh)
 				cs.logger.V(1).Info("Connection error during pending request, operation failed", "uuid", grpcInfo.UUID)
 			}
 
@@ -270,9 +269,9 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 
 			// Signal broadcast completion only for tracked broadcast operations.
 			// Initial config responses are ignored to prevent spurious success messages.
-			if pendingBroadcastRequest != nil {
-				pendingBroadcastRequest = nil
-				channels.ResponseCh <- struct{}{}
+			if pendingBroadcastRequest {
+				signalBroadcastResponse(ctx, channels.ResponseCh)
+				pendingBroadcastRequest = false
 			} else {
 				cs.logger.V(1).Info(
 					"Received response for non-broadcast request (likely initial config)",
@@ -281,6 +280,20 @@ func (cs *commandService) Subscribe(in pb.CommandService_SubscribeServer) error 
 				)
 			}
 		}
+	}
+}
+
+func trySignalBroadcastResponse(responseCh chan<- struct{}) {
+	select {
+	case responseCh <- struct{}{}:
+	default:
+	}
+}
+
+func signalBroadcastResponse(ctx context.Context, responseCh chan<- struct{}) {
+	select {
+	case responseCh <- struct{}{}:
+	case <-ctx.Done():
 	}
 }
 
@@ -327,7 +340,7 @@ func (cs *commandService) setInitialConfig(
 	conn *agentgrpc.Connection,
 	msgr messenger.Messenger,
 ) error {
-	if err := cs.validatePodImageVersion(conn.ParentName, conn.ParentType, deployment.imageVersion); err != nil {
+	if err := cs.validatePodImageVersion(ctx, conn.ParentName, conn.ParentType, deployment.imageVersion); err != nil {
 		cs.logAndSendErrorStatus(grpcInfo, deployment, conn, err)
 		return grpcStatus.Errorf(codes.FailedPrecondition, "nginx image version validation failed: %s", err.Error())
 	}
@@ -515,6 +528,7 @@ func buildPlusAPIRequest(action *pb.NGINXPlusAction, instanceID string) *pb.Mana
 // validatePodImageVersion checks if the pod's nginx container image version matches the expected version
 // from its deployment. Returns an error if versions don't match.
 func (cs *commandService) validatePodImageVersion(
+	ctx context.Context,
 	parent types.NamespacedName,
 	parentType string,
 	expectedImage string,
@@ -531,7 +545,7 @@ func (cs *commandService) validatePodImageVersion(
 		return "", false
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	switch parentType {
@@ -607,6 +621,7 @@ func getNginxInstanceID(instances []*pb.Instance) string {
 func getAgentDeploymentNameAndType(instances []*pb.Instance) (types.NamespacedName, string) {
 	var nsName types.NamespacedName
 	var depType string
+	found := false
 
 	for _, instance := range instances {
 		instanceType := instance.GetInstanceMeta().GetInstanceType()
@@ -616,15 +631,30 @@ func getAgentDeploymentNameAndType(instances []*pb.Instance) (types.NamespacedNa
 			for _, label := range labels {
 				fields := label.GetFields()
 
-				if val, ok := fields[nginxTypes.AgentOwnerNameLabel]; ok {
-					fullName := val.GetStringValue()
-					parts := strings.SplitN(fullName, "_", 2)
-					if len(parts) == 2 {
-						nsName = types.NamespacedName{Namespace: parts[0], Name: parts[1]}
-					}
+				nameVal, hasName := fields[nginxTypes.AgentOwnerNameLabel]
+				typeVal, hasType := fields[nginxTypes.AgentOwnerTypeLabel]
+				if !hasName || !hasType {
+					continue
 				}
-				if val, ok := fields[nginxTypes.AgentOwnerTypeLabel]; ok {
-					depType = val.GetStringValue()
+
+				fullName := nameVal.GetStringValue()
+				parts := strings.SplitN(fullName, "_", 2)
+				if len(parts) != 2 {
+					continue
+				}
+
+				candidateName := types.NamespacedName{Namespace: parts[0], Name: parts[1]}
+				candidateType := typeVal.GetStringValue()
+
+				if !found {
+					nsName = candidateName
+					depType = candidateType
+					found = true
+					continue
+				}
+
+				if nsName != candidateName || depType != candidateType {
+					return types.NamespacedName{}, ""
 				}
 			}
 		}

--- a/internal/controller/nginx/agent/command.go
+++ b/internal/controller/nginx/agent/command.go
@@ -619,48 +619,102 @@ func getNginxInstanceID(instances []*pb.Instance) string {
 }
 
 func getAgentDeploymentNameAndType(instances []*pb.Instance) (types.NamespacedName, string) {
-	var nsName types.NamespacedName
-	var depType string
-	found := false
+	selected, found := agentOwner{}, false
 
 	for _, instance := range instances {
-		instanceType := instance.GetInstanceMeta().GetInstanceType()
-		if instanceType == pb.InstanceMeta_INSTANCE_TYPE_AGENT {
-			labels := instance.GetInstanceConfig().GetAgentConfig().GetLabels()
+		candidate, candidateFound, err := getAgentOwnerFromInstance(instance)
+		if err != nil {
+			return types.NamespacedName{}, ""
+		}
+		if !candidateFound {
+			continue
+		}
 
-			for _, label := range labels {
-				fields := label.GetFields()
+		if !found {
+			selected = candidate
+			found = true
+			continue
+		}
 
-				nameVal, hasName := fields[nginxTypes.AgentOwnerNameLabel]
-				typeVal, hasType := fields[nginxTypes.AgentOwnerTypeLabel]
-				if !hasName || !hasType {
-					continue
-				}
-
-				fullName := nameVal.GetStringValue()
-				parts := strings.SplitN(fullName, "_", 2)
-				if len(parts) != 2 {
-					continue
-				}
-
-				candidateName := types.NamespacedName{Namespace: parts[0], Name: parts[1]}
-				candidateType := typeVal.GetStringValue()
-
-				if !found {
-					nsName = candidateName
-					depType = candidateType
-					found = true
-					continue
-				}
-
-				if nsName != candidateName || depType != candidateType {
-					return types.NamespacedName{}, ""
-				}
-			}
+		if selected != candidate {
+			return types.NamespacedName{}, ""
 		}
 	}
 
-	return nsName, depType
+	if !found {
+		return types.NamespacedName{}, ""
+	}
+
+	return selected.name, selected.ownerType
+}
+
+type agentOwner struct {
+	name      types.NamespacedName
+	ownerType string
+}
+
+func getAgentOwnerFromInstance(instance *pb.Instance) (agentOwner, bool, error) {
+	if instance.GetInstanceMeta().GetInstanceType() != pb.InstanceMeta_INSTANCE_TYPE_AGENT {
+		return agentOwner{}, false, nil
+	}
+
+	ownerName, ownerType, hasName, hasType, err := collectOwnerLabels(instance)
+	if err != nil {
+		return agentOwner{}, false, err
+	}
+
+	if hasName != hasType {
+		return agentOwner{}, false, errors.New("incomplete owner labels")
+	}
+
+	if !hasName {
+		return agentOwner{}, false, nil
+	}
+
+	ownerNSName, ok := parseOwnerName(ownerName)
+	if !ok || ownerType == "" {
+		return agentOwner{}, false, errors.New("invalid owner labels")
+	}
+
+	return agentOwner{name: ownerNSName, ownerType: ownerType}, true, nil
+}
+
+func collectOwnerLabels(instance *pb.Instance) (string, string, bool, bool, error) {
+	labels := instance.GetInstanceConfig().GetAgentConfig().GetLabels()
+
+	ownerName, ownerType := "", ""
+	hasName, hasType := false, false
+
+	for _, label := range labels {
+		fields := label.GetFields()
+
+		if nameVal, ok := fields[nginxTypes.AgentOwnerNameLabel]; ok {
+			if hasName {
+				return "", "", false, false, errors.New("duplicate owner-name label")
+			}
+			ownerName = nameVal.GetStringValue()
+			hasName = true
+		}
+
+		if typeVal, ok := fields[nginxTypes.AgentOwnerTypeLabel]; ok {
+			if hasType {
+				return "", "", false, false, errors.New("duplicate owner-type label")
+			}
+			ownerType = typeVal.GetStringValue()
+			hasType = true
+		}
+	}
+
+	return ownerName, ownerType, hasName, hasType, nil
+}
+
+func parseOwnerName(ownerName string) (types.NamespacedName, bool) {
+	parts := strings.SplitN(ownerName, "_", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return types.NamespacedName{}, false
+	}
+
+	return types.NamespacedName{Namespace: parts[0], Name: parts[1]}, true
 }
 
 // UpdateDataPlaneHealth includes full health information about the data plane as reported by the agent.

--- a/internal/controller/nginx/agent/command_test.go
+++ b/internal/controller/nginx/agent/command_test.go
@@ -209,7 +209,7 @@ func TestCreateConnection(t *testing.T) {
 			errString: "error getting pod owner",
 		},
 		{
-			name: "error getting pod owner when labels are split across structs",
+			name: "success when labels are split across structs in the same instance",
 			ctx:  createGrpcContext(t),
 			request: &pb.CreateConnectionRequest{
 				Resource: &pb.Resource{
@@ -240,6 +240,131 @@ func TestCreateConnection(t *testing.T) {
 													},
 												},
 											},
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerTypeLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: nginxTypes.DeploymentType},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			response: &pb.CreateConnectionResponse{
+				Response: &pb.CommandResponse{
+					Status: pb.CommandResponse_COMMAND_STATUS_OK,
+				},
+			},
+		},
+		{
+			name: "error getting pod owner when labels have conflicting owner name",
+			ctx:  createGrpcContext(t),
+			request: &pb.CreateConnectionRequest{
+				Resource: &pb.Resource{
+					Info: &pb.Resource_ContainerInfo{
+						ContainerInfo: &pb.ContainerInfo{
+							Hostname: "nginx-pod",
+						},
+					},
+					Instances: []*pb.Instance{
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceId:   "nginx-id",
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_NGINX,
+							},
+						},
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_AGENT,
+							},
+							InstanceConfig: &pb.InstanceConfig{
+								Config: &pb.InstanceConfig_AgentConfig{
+									AgentConfig: &pb.AgentConfig{
+										Labels: []*structpb.Struct{
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerNameLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: "test_nginx-deployment"},
+													},
+													nginxTypes.AgentOwnerTypeLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: nginxTypes.DeploymentType},
+													},
+												},
+											},
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerNameLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: "test_other-deployment"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			response: &pb.CreateConnectionResponse{
+				Response: &pb.CommandResponse{
+					Status:  pb.CommandResponse_COMMAND_STATUS_ERROR,
+					Message: "error getting pod owner",
+					Error:   "agent labels missing",
+				},
+			},
+			errString: "error getting pod owner",
+		},
+		{
+			name: "error getting pod owner when owner labels are split across instances",
+			ctx:  createGrpcContext(t),
+			request: &pb.CreateConnectionRequest{
+				Resource: &pb.Resource{
+					Info: &pb.Resource_ContainerInfo{
+						ContainerInfo: &pb.ContainerInfo{
+							Hostname: "nginx-pod",
+						},
+					},
+					Instances: []*pb.Instance{
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceId:   "nginx-id",
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_NGINX,
+							},
+						},
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_AGENT,
+							},
+							InstanceConfig: &pb.InstanceConfig{
+								Config: &pb.InstanceConfig_AgentConfig{
+									AgentConfig: &pb.AgentConfig{
+										Labels: []*structpb.Struct{
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerNameLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: "test_nginx-deployment"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_AGENT,
+							},
+							InstanceConfig: &pb.InstanceConfig{
+								Config: &pb.InstanceConfig_AgentConfig{
+									AgentConfig: &pb.AgentConfig{
+										Labels: []*structpb.Struct{
 											{
 												Fields: map[string]*structpb.Value{
 													nginxTypes.AgentOwnerTypeLabel: {

--- a/internal/controller/nginx/agent/command_test.go
+++ b/internal/controller/nginx/agent/command_test.go
@@ -208,6 +208,62 @@ func TestCreateConnection(t *testing.T) {
 			},
 			errString: "error getting pod owner",
 		},
+		{
+			name: "error getting pod owner when labels are split across structs",
+			ctx:  createGrpcContext(t),
+			request: &pb.CreateConnectionRequest{
+				Resource: &pb.Resource{
+					Info: &pb.Resource_ContainerInfo{
+						ContainerInfo: &pb.ContainerInfo{
+							Hostname: "nginx-pod",
+						},
+					},
+					Instances: []*pb.Instance{
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceId:   "nginx-id",
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_NGINX,
+							},
+						},
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_AGENT,
+							},
+							InstanceConfig: &pb.InstanceConfig{
+								Config: &pb.InstanceConfig_AgentConfig{
+									AgentConfig: &pb.AgentConfig{
+										Labels: []*structpb.Struct{
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerNameLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: "test_nginx-deployment"},
+													},
+												},
+											},
+											{
+												Fields: map[string]*structpb.Value{
+													nginxTypes.AgentOwnerTypeLabel: {
+														Kind: &structpb.Value_StringValue{StringValue: nginxTypes.DeploymentType},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			response: &pb.CreateConnectionResponse{
+				Response: &pb.CommandResponse{
+					Status:  pb.CommandResponse_COMMAND_STATUS_ERROR,
+					Message: "error getting pod owner",
+					Error:   "agent labels missing",
+				},
+			},
+			errString: "error getting pod owner",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -361,12 +361,15 @@ func (d *DeploymentStore) GetOrStore(
 	nsName types.NamespacedName,
 	gatewayName string,
 ) *Deployment {
-	if deployment := d.Get(nsName); deployment != nil {
-		return deployment
-	}
-
 	deployment := newDeployment(broadcast.NewDeploymentBroadcaster(ctx), gatewayName)
-	d.deployments.Store(nsName, deployment)
+	actual, loaded := d.deployments.LoadOrStore(nsName, deployment)
+	if loaded {
+		storedDeployment, ok := actual.(*Deployment)
+		if !ok {
+			panic(fmt.Sprintf("expected Deployment, got type %T", actual))
+		}
+		return storedDeployment
+	}
 
 	return deployment
 }

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -90,6 +90,15 @@ func (d *Deployment) GetBroadcaster() broadcast.Broadcaster {
 	return d.broadcaster
 }
 
+func (d *Deployment) ensureBroadcaster(ctx context.Context) {
+	d.FileLock.Lock()
+	defer d.FileLock.Unlock()
+
+	if d.broadcaster == nil {
+		d.broadcaster = broadcast.NewDeploymentBroadcaster(ctx)
+	}
+}
+
 // SetImageVersion sets the deployment's image version.
 func (d *Deployment) SetImageVersion(imageVersion string) {
 	d.FileLock.Lock()
@@ -322,7 +331,7 @@ func (d *Deployment) rebuildFileOverviews() *broadcast.NginxAgentMessage {
 // DeploymentStorer is an interface to store Deployments.
 type DeploymentStorer interface {
 	Get(types.NamespacedName) *Deployment
-	GetOrStore(context.Context, types.NamespacedName, string) *Deployment
+	LoadOrStore(context.Context, types.NamespacedName, string) *Deployment
 	Remove(types.NamespacedName)
 }
 
@@ -354,24 +363,22 @@ func (d *DeploymentStore) Get(nsName types.NamespacedName) *Deployment {
 	return deployment
 }
 
-// GetOrStore returns the existing value for the key if present.
+// LoadOrStore returns the existing value for the key if present.
 // Otherwise, it stores and returns the given value.
-func (d *DeploymentStore) GetOrStore(
+func (d *DeploymentStore) LoadOrStore(
 	ctx context.Context,
 	nsName types.NamespacedName,
 	gatewayName string,
 ) *Deployment {
-	deployment := newDeployment(broadcast.NewDeploymentBroadcaster(ctx), gatewayName)
-	actual, loaded := d.deployments.LoadOrStore(nsName, deployment)
-	if loaded {
-		storedDeployment, ok := actual.(*Deployment)
-		if !ok {
-			panic(fmt.Sprintf("expected Deployment, got type %T", actual))
-		}
-		return storedDeployment
-	}
+	deployment := newDeployment(nil, gatewayName)
+	actual, _ := d.deployments.LoadOrStore(nsName, deployment)
 
-	return deployment
+	storedDeployment, ok := actual.(*Deployment)
+	if !ok {
+		panic(fmt.Sprintf("expected Deployment, got type %T", actual))
+	}
+	storedDeployment.ensureBroadcaster(ctx)
+	return storedDeployment
 }
 
 // StoreWithBroadcaster creates a new Deployment with the supplied broadcaster and stores it.

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -259,7 +259,7 @@ func TestDeploymentStore_GetOrStore_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results <- depStore.GetOrStore(t.Context(), nsName, "gateway")
+			results <- depStore.LoadOrStore(t.Context(), nsName, "gateway")
 		}()
 	}
 
@@ -460,13 +460,13 @@ func TestDeploymentStore(t *testing.T) {
 
 	nsName := types.NamespacedName{Namespace: "default", Name: "test-deployment"}
 
-	deployment := store.GetOrStore(t.Context(), nsName, "gateway")
+	deployment := store.LoadOrStore(t.Context(), nsName, "gateway")
 	g.Expect(deployment).ToNot(BeNil())
 
 	fetchedDeployment := store.Get(nsName)
 	g.Expect(fetchedDeployment).To(Equal(deployment))
 
-	deployment = store.GetOrStore(t.Context(), nsName, "gateway")
+	deployment = store.LoadOrStore(t.Context(), nsName, "gateway")
 	g.Expect(fetchedDeployment).To(Equal(deployment))
 
 	store.Remove(nsName)

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	pb "github.com/nginx/agent/v3/api/grpc/mpi/v1"
@@ -241,6 +242,42 @@ func TestSetLatestUpstreamError(t *testing.T) {
 	err := errors.New("test error")
 	deployment.SetLatestUpstreamError(err)
 	g.Expect(deployment.GetLatestUpstreamError()).To(MatchError(err))
+}
+
+func TestDeploymentStore_GetOrStore_Concurrent(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	depStore := NewDeploymentStore(&agentgrpcfakes.FakeConnectionsTracker{})
+	nsName := types.NamespacedName{Name: "nginx", Namespace: "default"}
+
+	const goroutines = 25
+	results := make(chan *Deployment, goroutines)
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- depStore.GetOrStore(t.Context(), nsName, "gateway")
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var first *Deployment
+	for dep := range results {
+		if first == nil {
+			first = dep
+			continue
+		}
+
+		g.Expect(dep).To(BeIdenticalTo(first))
+	}
+
+	stored := depStore.Get(nsName)
+	g.Expect(stored).To(BeIdenticalTo(first))
 }
 
 func TestUpdateWAFBundle(t *testing.T) {

--- a/internal/controller/nginx/agent/deployment_test.go
+++ b/internal/controller/nginx/agent/deployment_test.go
@@ -244,7 +244,7 @@ func TestSetLatestUpstreamError(t *testing.T) {
 	g.Expect(deployment.GetLatestUpstreamError()).To(MatchError(err))
 }
 
-func TestDeploymentStore_GetOrStore_Concurrent(t *testing.T) {
+func TestDeploymentStore_LoadOrStore_Concurrent(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 

--- a/internal/controller/nginx/agent/file.go
+++ b/internal/controller/nginx/agent/file.go
@@ -99,11 +99,19 @@ func (fs *fileService) GetFileStream(
 	}
 
 	size := req.GetFileMeta().GetSize()
+	if size < 0 {
+		return status.Error(codes.InvalidArgument, "file size cannot be negative")
+	}
+
+	if size != int64(len(contents)) {
+		return status.Error(codes.InvalidArgument, "file size does not match content length")
+	}
+
 	var sizeUint32 uint32
 	if size > math.MaxUint32 {
-		return status.Error(codes.Internal, "file size is too large and cannot be converted to uint32")
+		return status.Error(codes.InvalidArgument, "file size is too large and cannot be converted to uint32")
 	}
-	sizeUint32 = uint32(size) //nolint:gosec // validation check performed on previous line
+	sizeUint32 = uint32(size)
 	hash := req.GetFileMeta().GetHash()
 
 	fs.logger.V(1).Info(

--- a/internal/controller/nginx/agent/file_test.go
+++ b/internal/controller/nginx/agent/file_test.go
@@ -96,7 +96,7 @@ func TestGetFile_ReturnsEmptyContents(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	dep := depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	fileMeta := &pb.FileMeta{
 		Name: "empty.conf",

--- a/internal/controller/nginx/agent/file_test.go
+++ b/internal/controller/nginx/agent/file_test.go
@@ -386,6 +386,76 @@ func TestGetFileStream_InvalidRequest(t *testing.T) {
 	g.Expect(server.sentChunks).To(BeEmpty())
 }
 
+func TestGetFileStream_InvalidFileSize(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		errMsg      string
+		requestSize int64
+	}{
+		{
+			name:        "negative file size",
+			requestSize: -1,
+			errMsg:      "file size cannot be negative",
+		},
+		{
+			name:        "file size mismatch",
+			requestSize: int64(len([]byte("test content")) + 1),
+			errMsg:      "file size does not match content length",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			deploymentName := types.NamespacedName{Name: "nginx-deployment", Namespace: "default"}
+			connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
+			conn := agentgrpc.Connection{
+				InstanceID: "12345",
+				ParentName: deploymentName,
+			}
+			connTracker.GetConnectionReturns(conn)
+
+			depStore := NewDeploymentStore(connTracker)
+			dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+
+			contents := []byte("test content")
+			dep.files = []File{
+				{
+					Meta: &pb.FileMeta{
+						Name: "test.conf",
+						Hash: "some-hash",
+						Size: int64(len(contents)),
+					},
+					Contents: contents,
+				},
+			}
+
+			fs := newFileService(logr.Discard(), depStore, connTracker)
+
+			ctx := grpcContext.NewGrpcContext(t.Context(), grpcContext.GrpcInfo{UUID: "1234567"})
+
+			req := &pb.GetFileRequest{
+				FileMeta: &pb.FileMeta{
+					Name: "test.conf",
+					Hash: "some-hash",
+					Size: tc.requestSize,
+				},
+				MessageMeta: &pb.MessageMeta{},
+			}
+
+			server := newMockServerStreamingServer(ctx)
+
+			err := fs.GetFileStream(req, server)
+			g.Expect(err).To(Equal(status.Error(codes.InvalidArgument, tc.errMsg)))
+			g.Expect(server.sentChunks).To(BeEmpty())
+		})
+	}
+}
+
 func TestGetOverview(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)

--- a/internal/controller/nginx/agent/file_test.go
+++ b/internal/controller/nginx/agent/file_test.go
@@ -49,7 +49,7 @@ func TestGetFile(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	dep := depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	fileMeta := &pb.FileMeta{
 		Name: "test.conf",
@@ -156,7 +156,7 @@ func TestGetFile_InvalidRequest(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	_ = depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	_ = depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	fs := newFileService(logr.Discard(), depStore, connTracker)
 
@@ -243,7 +243,7 @@ func TestGetFile_FileNotFound(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	fs := newFileService(logr.Discard(), depStore, connTracker)
 
@@ -278,7 +278,7 @@ func TestGetFileStream(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	dep := depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	// Create a file larger than defaultChunkSize to ensure multiple chunks are sent
 	fileContent := make([]byte, defaultChunkSize+100)
@@ -355,7 +355,7 @@ func TestGetFileStream_InvalidRequest(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	_ = depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	_ = depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	fs := newFileService(logr.Discard(), depStore, connTracker)
 
@@ -420,7 +420,7 @@ func TestGetFileStream_InvalidFileSize(t *testing.T) {
 			connTracker.GetConnectionReturns(conn)
 
 			depStore := NewDeploymentStore(connTracker)
-			dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+			dep := depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 			contents := []byte("test content")
 			dep.files = []File{
@@ -481,7 +481,7 @@ func TestUpdateOverview(t *testing.T) {
 	connTracker.GetConnectionReturns(conn)
 
 	depStore := NewDeploymentStore(connTracker)
-	dep := depStore.GetOrStore(t.Context(), deploymentName, "gateway")
+	dep := depStore.LoadOrStore(t.Context(), deploymentName, "gateway")
 
 	// Create a file larger than defaultChunkSize to ensure multiple chunks are sent
 	fileContent := make([]byte, defaultChunkSize+100)

--- a/internal/controller/nginx/agent/grpc/filewatcher/filewatcher.go
+++ b/internal/controller/nginx/agent/grpc/filewatcher/filewatcher.go
@@ -13,9 +13,16 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const monitoringInterval = 5 * time.Second
+
+// addWatcherRetryBaseDelay is the initial delay between retries when adding a file watcher fails.
+const addWatcherRetryBaseDelay = 100 * time.Millisecond
+
+// addWatcherMaxAttempts is the maximum number of attempts to add a file watcher before giving up.
+const addWatcherMaxAttempts = 5
 
 var emptyEvent = fsnotify.Event{
 	Name: "",
@@ -92,27 +99,28 @@ func (w *FileWatcher) addWatcher(path string) {
 }
 
 func (w *FileWatcher) addWatcherWithRetry(ctx context.Context, path string) {
-	backoff := 100 * time.Millisecond
-	for attempt := 1; ; attempt++ {
+	backoff := wait.Backoff{
+		Duration: addWatcherRetryBaseDelay,
+		Factor:   2.0,
+		Steps:    addWatcherMaxAttempts,
+	}
+
+	attempt := 0
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
+		attempt++
 		if err := w.watcher.Add(path); err != nil {
-			if attempt >= 5 {
-				w.logger.Error(err, "failed to watch path after retries", "path", path, "attempts", attempt)
-				return
-			}
-
+			lastErr = err
 			w.logger.Error(err, "failed to watch path, retrying", "path", path, "attempt", attempt)
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
-
-			backoff *= 2
-			continue
+			return false, nil
 		}
 
-		return
+		return true, nil
+	})
+	// Only log a final failure if retries were exhausted; if ctx was canceled (e.g. shutdown),
+	// exit silently as the caller no longer cares about the outcome.
+	if err != nil && ctx.Err() == nil {
+		w.logger.Error(lastErr, "failed to watch path after retries", "path", path, "attempts", attempt)
 	}
 }
 
@@ -142,14 +150,21 @@ func (w *FileWatcher) checkForUpdates() {
 
 func (w *FileWatcher) snapshotFileHashes() {
 	for _, file := range w.filesToWatch {
-		w.fileHashes[file] = hashFileContents(file)
+		hash, err := hashFileContents(file)
+		if err != nil {
+			w.logger.Error(err, "failed to read file for hashing", "path", file)
+		}
+		w.fileHashes[file] = hash
 	}
 }
 
 func (w *FileWatcher) didFileHashesChange() bool {
 	changed := false
 	for _, file := range w.filesToWatch {
-		currentHash := hashFileContents(file)
+		currentHash, err := hashFileContents(file)
+		if err != nil {
+			w.logger.Error(err, "failed to read file for hashing", "path", file)
+		}
 		if prevHash, ok := w.fileHashes[file]; !ok || prevHash != currentHash {
 			w.fileHashes[file] = currentHash
 			changed = true
@@ -178,14 +193,14 @@ func buildPathsToWatch(files []string) []string {
 	return paths
 }
 
-func hashFileContents(path string) string {
+func hashFileContents(path string) (string, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Sprintf("read-error:%v", err)
+		return "", err
 	}
 
 	hash := sha256.Sum256(contents)
-	return hex.EncodeToString(hash[:])
+	return hex.EncodeToString(hash[:]), nil
 }
 
 func isEventSkippable(event fsnotify.Event) bool {

--- a/internal/controller/nginx/agent/grpc/filewatcher/filewatcher.go
+++ b/internal/controller/nginx/agent/grpc/filewatcher/filewatcher.go
@@ -2,7 +2,12 @@ package filewatcher
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -22,8 +27,10 @@ type FileWatcher struct {
 	filesChanged *atomic.Bool
 	watcher      *fsnotify.Watcher
 	notifyCh     chan<- struct{}
+	fileHashes   map[string]string
 	logger       logr.Logger
 	filesToWatch []string
+	pathsToWatch []string
 	interval     time.Duration
 }
 
@@ -41,6 +48,8 @@ func NewFileWatcher(logger logr.Logger, files []string, notifyCh chan<- struct{}
 		watcher:      watcher,
 		logger:       logger,
 		filesToWatch: files,
+		pathsToWatch: buildPathsToWatch(files),
+		fileHashes:   make(map[string]string, len(files)),
 		notifyCh:     notifyCh,
 		interval:     monitoringInterval,
 	}, nil
@@ -51,9 +60,13 @@ func (w *FileWatcher) Watch(ctx context.Context) {
 	w.logger.V(1).Info("Starting file watcher")
 
 	ticker := time.NewTicker(w.interval)
-	for _, file := range w.filesToWatch {
-		w.addWatcher(file)
+	defer ticker.Stop()
+
+	for _, watchPath := range w.pathsToWatch {
+		w.addWatcherWithRetry(ctx, watchPath)
 	}
+
+	w.snapshotFileHashes()
 
 	for {
 		select {
@@ -74,7 +87,32 @@ func (w *FileWatcher) Watch(ctx context.Context) {
 
 func (w *FileWatcher) addWatcher(path string) {
 	if err := w.watcher.Add(path); err != nil {
-		w.logger.Error(err, "failed to watch file", "file", path)
+		w.logger.Error(err, "failed to watch path", "path", path)
+	}
+}
+
+func (w *FileWatcher) addWatcherWithRetry(ctx context.Context, path string) {
+	backoff := 100 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		if err := w.watcher.Add(path); err != nil {
+			if attempt >= 5 {
+				w.logger.Error(err, "failed to watch path after retries", "path", path, "attempts", attempt)
+				return
+			}
+
+			w.logger.Error(err, "failed to watch path, retrying", "path", path, "attempt", attempt)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+
+			backoff *= 2
+			continue
+		}
+
+		return
 	}
 }
 
@@ -84,18 +122,70 @@ func (w *FileWatcher) handleEvent(event fsnotify.Event) {
 	}
 
 	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
-		w.addWatcher(event.Name)
+		w.addWatcher(filepath.Dir(event.Name))
 	}
 
 	w.filesChanged.Store(true)
 }
 
 func (w *FileWatcher) checkForUpdates() {
+	if w.didFileHashesChange() {
+		w.filesChanged.Store(true)
+	}
+
 	if w.filesChanged.Load() {
 		w.logger.Info("TLS files changed, sending notification to reset nginx agent connections")
 		w.notifyCh <- struct{}{}
 		w.filesChanged.Store(false)
 	}
+}
+
+func (w *FileWatcher) snapshotFileHashes() {
+	for _, file := range w.filesToWatch {
+		w.fileHashes[file] = hashFileContents(file)
+	}
+}
+
+func (w *FileWatcher) didFileHashesChange() bool {
+	changed := false
+	for _, file := range w.filesToWatch {
+		currentHash := hashFileContents(file)
+		if prevHash, ok := w.fileHashes[file]; !ok || prevHash != currentHash {
+			w.fileHashes[file] = currentHash
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func buildPathsToWatch(files []string) []string {
+	set := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		dir := filepath.Dir(file)
+		if dir == "." {
+			dir = file
+		}
+		set[dir] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(set))
+	for path := range set {
+		paths = append(paths, path)
+	}
+
+	sort.Strings(paths)
+	return paths
+}
+
+func hashFileContents(path string) string {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("read-error:%v", err)
+	}
+
+	hash := sha256.Sum256(contents)
+	return hex.EncodeToString(hash[:])
 }
 
 func isEventSkippable(event fsnotify.Event) bool {

--- a/internal/controller/nginx/agent/grpc/filewatcher/filewatcher_test.go
+++ b/internal/controller/nginx/agent/grpc/filewatcher/filewatcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -67,4 +68,41 @@ func TestFileWatcher_handleEvent(t *testing.T) {
 	w.handleEvent(fsnotify.Event{Name: "test-rename", Op: fsnotify.Rename})
 	g.Expect(w.filesChanged.Load()).To(BeTrue())
 	w.filesChanged.Store(false)
+}
+
+func TestBuildPathsToWatch(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	base := t.TempDir()
+	files := []string{
+		filepath.Join(base, "tls.crt"),
+		filepath.Join(base, "tls.key"),
+		filepath.Join(base, "ca.crt"),
+	}
+
+	paths := buildPathsToWatch(files)
+	g.Expect(paths).To(HaveLen(1))
+	g.Expect(paths[0]).To(Equal(base))
+}
+
+func TestFileWatcher_CheckForUpdates_DetectsChangeWithoutFsNotifyEvent(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	notifyCh := make(chan struct{}, 1)
+	file := path.Join(t.TempDir(), "test-file")
+	err := os.WriteFile(file, []byte("old"), 0o600)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	w, err := NewFileWatcher(logr.Discard(), []string{file}, notifyCh)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	w.snapshotFileHashes()
+
+	err = os.WriteFile(file, []byte("new"), 0o600)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	w.checkForUpdates()
+	g.Expect(notifyCh).To(Receive())
 }

--- a/internal/controller/nginx/agent/grpc/grpc.go
+++ b/internal/controller/nginx/agent/grpc/grpc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -125,8 +126,8 @@ func (g *Server) createServer(tlsCredentials credentials.TransportCredentials) *
 				PermitWithoutStream: true,
 			},
 		),
-		grpc.ChainStreamInterceptor(g.interceptor.Stream(g.logger)),
-		grpc.ChainUnaryInterceptor(g.interceptor.Unary(g.logger)),
+		grpc.ChainStreamInterceptor(recoveryStreamInterceptor(g.logger), g.interceptor.Stream(g.logger)),
+		grpc.ChainUnaryInterceptor(recoveryUnaryInterceptor(g.logger), g.interceptor.Unary(g.logger)),
 		grpc.Creds(tlsCredentials),
 		// Set max message size to 4MB to match the agent side.
 		grpc.MaxSendMsgSize(1024*1024*4), // 4MB
@@ -134,6 +135,52 @@ func (g *Server) createServer(tlsCredentials credentials.TransportCredentials) *
 	)
 
 	return server
+}
+
+func recoveryStreamInterceptor(logger logr.Logger) grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) (err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logger.Error(
+					fmt.Errorf("%v", recovered),
+					"panic recovered in stream RPC",
+					"method", info.FullMethod,
+					"stack", string(debug.Stack()),
+				)
+				err = status.Error(codes.Internal, "internal server error")
+			}
+		}()
+
+		return handler(srv, ss)
+	}
+}
+
+func recoveryUnaryInterceptor(logger logr.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logger.Error(
+					fmt.Errorf("%v", recovered),
+					"panic recovered in unary RPC",
+					"method", info.FullMethod,
+					"stack", string(debug.Stack()),
+				)
+				err = status.Error(codes.Internal, "internal server error")
+			}
+		}()
+
+		return handler(ctx, req)
+	}
 }
 
 func getTLSConfig() (credentials.TransportCredentials, error) {

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -2,6 +2,7 @@ package interceptor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -2,7 +2,6 @@ package interceptor
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -13,7 +12,9 @@ import (
 	"google.golang.org/grpc/status"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,6 +25,9 @@ import (
 const (
 	headerUUID = "uuid"
 	headerAuth = "authorization"
+
+	podNameClaimKey = "authentication.kubernetes.io/pod-name"
+	podUIDClaimKey  = "authentication.kubernetes.io/pod-uid"
 )
 
 // PodCheckRetry controls how long validateToken will wait for the agent's Pod
@@ -151,20 +155,19 @@ func (c ContextSetter) validateToken(
 	defer createCancel()
 
 	if err := c.k8sClient.Create(createCtx, tokenReview); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error creating TokenReview: %v", err))
+		logger.Error(err, "failed to create TokenReview")
+		return nil, status.Error(codes.Internal, "authentication failed")
 	}
 
 	if !tokenReview.Status.Authenticated {
-		return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("invalid authorization: %s", tokenReview.Status.Error))
+		logger.V(1).Info("token review was not authenticated", "reason", tokenReview.Status.Error)
+		return nil, status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 
 	usernameItems := strings.Split(tokenReview.Status.User.Username, ":")
 	if len(usernameItems) != 4 || usernameItems[0] != "system" || usernameItems[1] != "serviceaccount" {
-		msg := fmt.Sprintf(
-			"token username must be of the format 'system:serviceaccount:NAMESPACE:NAME': %s",
-			tokenReview.Status.User.Username,
-		)
-		return nil, status.Error(codes.Unauthenticated, msg)
+		logger.V(1).Info("token username did not match expected service account format")
+		return nil, status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 
 	saNamespace := usernameItems[2]
@@ -177,11 +180,132 @@ func (c ContextSetter) validateToken(
 		}).AsSelector(),
 	}
 
-	if err := c.waitForRunningPod(ctx, logger, opts, saNamespace, saName); err != nil {
+	validatedByBoundClaims, err := c.waitForBoundPodFromTokenClaims(
+		ctx,
+		logger,
+		saNamespace,
+		saName,
+		tokenReview.Status.User.Extra,
+	)
+	if err != nil {
 		return nil, err
 	}
 
+	if !validatedByBoundClaims {
+		if err := c.waitForRunningPod(ctx, logger, opts, saNamespace, saName); err != nil {
+			return nil, err
+		}
+	}
+
 	return grpcContext.NewGrpcContext(ctx, *grpcInfo), nil
+}
+
+func (c ContextSetter) waitForBoundPodFromTokenClaims(
+	ctx context.Context,
+	logger logr.Logger,
+	saNamespace string,
+	saName string,
+	extra map[string]authv1.ExtraValue,
+) (bool, error) {
+	boundPodName, boundPodUID, ok := getBoundPodClaims(extra)
+	if !ok {
+		logger.V(1).Info("token has no bound pod identity claims; using service-account pod fallback validation")
+		return false, nil
+	}
+
+	retry := c.podCheck
+	if retry.PollInterval <= 0 || retry.Timeout <= 0 {
+		retry = defaultPodCheckRetry
+	}
+
+	return c.waitForBoundPodIdentity(ctx, logger, saNamespace, saName, boundPodName, boundPodUID, retry)
+}
+
+func getBoundPodClaims(extra map[string]authv1.ExtraValue) (name string, uid string, ok bool) {
+	nameValues, hasName := extra[podNameClaimKey]
+	uidValues, hasUID := extra[podUIDClaimKey]
+	if !hasName || !hasUID || len(nameValues) == 0 || len(uidValues) == 0 {
+		return "", "", false
+	}
+
+	return nameValues[0], uidValues[0], true
+}
+
+func (c ContextSetter) waitForBoundPodIdentity(
+	ctx context.Context,
+	logger logr.Logger,
+	saNamespace string,
+	saName string,
+	boundPodName string,
+	boundPodUID string,
+	retry PodCheckRetry,
+) (bool, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, retry.Timeout)
+	defer cancel()
+
+	var validationErr error
+	pollErr := wait.PollUntilContextCancel(waitCtx, retry.PollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			pod := &corev1.Pod{}
+			err := c.k8sClient.Get(ctx, types.NamespacedName{Namespace: saNamespace, Name: boundPodName}, pod)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+
+				logger.Error(err, "failed to fetch pod from token bound claims", "namespace", saNamespace, "pod", boundPodName)
+				validationErr = status.Error(codes.Internal, "authentication failed")
+				return false, validationErr
+			}
+
+			if reason, ok := validateBoundPodIdentity(pod, saName, boundPodUID); !ok {
+				logger.V(1).Info(
+					"bound pod identity validation failed",
+					"namespace", saNamespace,
+					"pod", boundPodName,
+					"reason", reason,
+				)
+				validationErr = status.Error(codes.Unauthenticated, "invalid authorization")
+				return false, validationErr
+			}
+
+			if pod.Status.Phase != corev1.PodRunning {
+				return false, nil
+			}
+
+			return true, nil
+		},
+	)
+	if pollErr == nil {
+		return true, nil
+	}
+
+	if validationErr != nil {
+		return false, validationErr
+	}
+
+	if wait.Interrupted(pollErr) {
+		return false, status.Error(codes.Unavailable, "agent pod is not ready")
+	}
+
+	logger.Error(pollErr, "error waiting for pod identity from token bound claims")
+	return false, status.Error(codes.Internal, "authentication failed")
+}
+
+func validateBoundPodIdentity(pod *corev1.Pod, serviceAccountName, boundPodUID string) (reason string, ok bool) {
+	if string(pod.UID) != boundPodUID {
+		return "pod UID mismatch", false
+	}
+
+	if pod.Spec.ServiceAccountName != serviceAccountName {
+		return "service account mismatch", false
+	}
+
+	if pod.Labels[controller.AppNameLabel] != serviceAccountName {
+		return "app label mismatch", false
+	}
+
+	return "", true
 }
 
 // waitForRunningPod polls for a Running Pod that matches the agent's
@@ -215,7 +339,8 @@ func (c ContextSetter) waitForRunningPod(
 			attempt++
 			var podList corev1.PodList
 			if err := c.k8sClient.List(ctx, &podList, opts); err != nil {
-				listErr = status.Error(codes.Internal, fmt.Sprintf("error listing pods: %s", err.Error()))
+				logger.Error(err, "failed to list pods for service-account validation")
+				listErr = status.Error(codes.Internal, "authentication failed")
 				return false, listErr
 			}
 
@@ -242,11 +367,14 @@ func (c ContextSetter) waitForRunningPod(
 	// returning a hard error, surface the startup-not-ready signal as
 	// Unavailable so callers can retry; otherwise propagate the List error.
 	if wait.Interrupted(pollErr) {
-		return status.Error(codes.Unavailable, fmt.Sprintf(
-			"no running pods found for service account %s/%s after %d attempts (%s); "+
-				"the agent's Pod may still be starting",
-			saNamespace, saName, attempt, time.Since(start),
-		))
+		logger.V(1).Info(
+			"no running pods found for service account before timeout",
+			"namespace", saNamespace,
+			"serviceAccount", saName,
+			"attempts", attempt,
+			"elapsed", time.Since(start).String(),
+		)
+		return status.Error(codes.Unavailable, "agent pod is not ready")
 	}
 	if listErr != nil {
 		return listErr

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -166,7 +166,8 @@ func (c ContextSetter) validateToken(
 
 	usernameItems := strings.Split(tokenReview.Status.User.Username, ":")
 	if len(usernameItems) != 4 || usernameItems[0] != "system" || usernameItems[1] != "serviceaccount" {
-		logger.V(1).Info("token username did not match expected service account format")
+		format := "system:serviceaccount:NAMESPACE:NAME"
+		logger.V(1).Info(fmt.Sprintf("token username did not match expected service account format %q", format))
 		return nil, status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
@@ -41,10 +41,13 @@ func (m *mockServerStream) Context() context.Context {
 
 type mockClient struct {
 	client.Client
-	createErr, listErr              error
-	username, appName, podNamespace string
-	authenticated                   bool
-	// noRunningPods, when true, returns a pod that is not in Running phase.
+	createErr     error
+	listErr       error
+	extra         map[string]authv1.ExtraValue
+	username      string
+	appName       string
+	podNamespace  string
+	authenticated bool
 	noRunningPods bool
 }
 
@@ -54,7 +57,7 @@ func (m *mockClient) Create(_ context.Context, obj client.Object, _ ...client.Cr
 		return errors.New("couldn't convert object to TokenReview")
 	}
 	tr.Status.Authenticated = m.authenticated
-	tr.Status.User = authv1.UserInfo{Username: m.username}
+	tr.Status.User = authv1.UserInfo{Username: m.username, Extra: m.extra}
 
 	return m.createErr
 }
@@ -151,7 +154,7 @@ func TestInterceptor(t *testing.T) {
 			authenticated: true,
 			createErr:     errors.New("not created"),
 			expErrCode:    codes.Internal,
-			expErrMsg:     "error creating TokenReview",
+			expErrMsg:     "authentication failed",
 		},
 		{
 			name:          "tokenreview created and not authenticated",
@@ -169,7 +172,7 @@ func TestInterceptor(t *testing.T) {
 			authenticated: true,
 			listErr:       errors.New("can't list"),
 			expErrCode:    codes.Internal,
-			expErrMsg:     "error listing pods",
+			expErrMsg:     "authentication failed",
 		},
 		{
 			name:          "invalid username length",
@@ -179,7 +182,7 @@ func TestInterceptor(t *testing.T) {
 			podNamespace:  "default",
 			authenticated: true,
 			expErrCode:    codes.Unauthenticated,
-			expErrMsg:     "must be of the format",
+			expErrMsg:     "invalid authorization",
 		},
 		{
 			name:          "missing system from username",
@@ -189,7 +192,7 @@ func TestInterceptor(t *testing.T) {
 			podNamespace:  "default",
 			authenticated: true,
 			expErrCode:    codes.Unauthenticated,
-			expErrMsg:     "must be of the format",
+			expErrMsg:     "invalid authorization",
 		},
 		{
 			name:          "missing serviceaccount from username",
@@ -199,7 +202,7 @@ func TestInterceptor(t *testing.T) {
 			podNamespace:  "default",
 			authenticated: true,
 			expErrCode:    codes.Unauthenticated,
-			expErrMsg:     "must be of the format",
+			expErrMsg:     "invalid authorization",
 		},
 		{
 			name:          "no running pods times out as Unavailable",
@@ -210,7 +213,7 @@ func TestInterceptor(t *testing.T) {
 			authenticated: true,
 			noRunningPods: true,
 			expErrCode:    codes.Unavailable,
-			expErrMsg:     "no running pods found for service account default/gateway-nginx",
+			expErrMsg:     "agent pod is not ready",
 		},
 	}
 
@@ -250,6 +253,9 @@ func TestInterceptor(t *testing.T) {
 			if test.expErrCode != codes.OK {
 				g.Expect(status.Code(err)).To(Equal(test.expErrCode))
 				g.Expect(err.Error()).To(ContainSubstring(test.expErrMsg))
+				g.Expect(err.Error()).ToNot(ContainSubstring("system:serviceaccount"))
+				g.Expect(err.Error()).ToNot(ContainSubstring("can't list"))
+				g.Expect(err.Error()).ToNot(ContainSubstring("not created"))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
@@ -258,6 +264,9 @@ func TestInterceptor(t *testing.T) {
 			if test.expErrCode != codes.OK {
 				g.Expect(status.Code(err)).To(Equal(test.expErrCode))
 				g.Expect(err.Error()).To(ContainSubstring(test.expErrMsg))
+				g.Expect(err.Error()).ToNot(ContainSubstring("system:serviceaccount"))
+				g.Expect(err.Error()).ToNot(ContainSubstring("can't list"))
+				g.Expect(err.Error()).ToNot(ContainSubstring("not created"))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
@@ -386,7 +395,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 			resultCtx, err := csPatched.validateToken(t.Context(), tc.grpcInfo, logr.Discard())
 			if tc.shouldErr {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring("no running pods"))
+				g.Expect(err.Error()).To(ContainSubstring("agent pod is not ready"))
 				g.Expect(status.Code(err)).To(Equal(codes.Unavailable))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
@@ -394,6 +403,65 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+type tokenClaimClient struct {
+	client.Client
+	listCalls atomic.Int32
+}
+
+func (t *tokenClaimClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	tr, ok := obj.(*authv1.TokenReview)
+	if !ok {
+		return errors.New("couldn't convert object to TokenReview")
+	}
+
+	tr.Status.Authenticated = true
+	tr.Status.User = authv1.UserInfo{
+		Username: "system:serviceaccount:default:gateway-nginx",
+		Extra: map[string]authv1.ExtraValue{
+			podNameClaimKey: {"nginx-pod"},
+			podUIDClaimKey:  {"pod-uid"},
+		},
+	}
+
+	return nil
+}
+
+func (t *tokenClaimClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	t.listCalls.Add(1)
+	return t.Client.List(ctx, obj, opts...)
+}
+
+func TestValidateToken_UsesBoundPodClaimsWhenPresent(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				controller.AppNameLabel: "gateway-nginx",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "gateway-nginx",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(pod).Build()
+	claimClient := &tokenClaimClient{Client: fakeClient}
+
+	cs := NewContextSetter(claimClient, "ngf-audience")
+	cs.podCheck = PodCheckRetry{PollInterval: time.Millisecond, Timeout: time.Second}
+
+	resultCtx, err := cs.validateToken(t.Context(), &grpcContext.GrpcInfo{Token: "dummy-token"}, logr.Discard())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resultCtx).ToNot(BeNil())
+	g.Expect(claimClient.listCalls.Load()).To(Equal(int32(0)))
 }
 
 // retryListClient simulates the cache race where a Pod listing returns no


### PR DESCRIPTION
Problem:

Agent update paths had edge-case reliability and security gaps: unsafe file-stream size handling
missing panic containment
fragile TLS watch/update behavior
stale/noisy status and upstream error reporting
race-prone deployment store access
weaker token-bound pod identity validation and unclear internal failure reasons

Solution:

Added strict file-stream validation and regression tests. Added gRPC panic recovery interceptors.
Improved TLS watcher resilience (retry/backstop/lifecycle cleanup). Fixed status/error handling and clarified broadcast ack behavior. Switched deployment store to atomic LoadOrStore.
Strengthened token-bound pod identity checks with sanitized external errors and explicit internal failure reasons.

Closes #5422
Closes #5421

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
