### PR TITLE
Honor securityContext.capabilities.drop in WAF container. Always run as non-root user.

### DIFF
--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -1747,7 +1747,7 @@ func (p *NginxProvisioner) buildWAFEnforcerContainer(
 			RunAsNonRoot:             helpers.GetPointer(true),
 			ReadOnlyRootFilesystem:   helpers.GetPointer(true),
 			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"all"},
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
 		Env: []corev1.EnvVar{
@@ -1792,11 +1792,11 @@ func (p *NginxProvisioner) buildWAFConfigManagerContainer(
 		ImagePullPolicy: defaultImagePullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: helpers.GetPointer(false),
-			RunAsNonRoot:             helpers.GetPointer(false),
+			RunAsNonRoot:             helpers.GetPointer(true),
 			RunAsUser:                helpers.GetPointer[int64](101),
 			ReadOnlyRootFilesystem:   helpers.GetPointer(true),
 			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"all"},
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -3075,9 +3075,9 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 	// Check config manager security context
 	g.Expect(configMgrContainer.SecurityContext).ToNot(BeNil())
 	g.Expect(configMgrContainer.SecurityContext.AllowPrivilegeEscalation).To(Equal(helpers.GetPointer(false)))
-	g.Expect(configMgrContainer.SecurityContext.RunAsNonRoot).To(Equal(helpers.GetPointer(false)))
+	g.Expect(configMgrContainer.SecurityContext.RunAsNonRoot).To(Equal(helpers.GetPointer(true)))
 	g.Expect(configMgrContainer.SecurityContext.RunAsUser).To(Equal(helpers.GetPointer[int64](101)))
-	g.Expect(configMgrContainer.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("all")))
+	g.Expect(configMgrContainer.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
 
 	// Check config manager resources
 	g.Expect(configMgrContainer.Resources.Limits).To(HaveKey(corev1.ResourceCPU))


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: `waf-config-mgr` and `waf-enforcer` both set pod `spec.securityContext.capabilities.drop` to "all" (lowercase) causing the this securityContext to not be enforced correctly. Also, the `waf-config-mgr` was configured with `RunAsNonRootUser: false`, allowing the container to run as root. 

Solution: Update `spec.securityContext.capabilities.drop` to "ALL" (uppercase) which is the correct convention. Set `RunAsNonRootUser: true` for  `waf-config-mgr`.

Testing: Ran WAF integration test.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes https://github.com/nginx/nginx-gateway-fabric/issues/5419

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Honor securityContext.capabilities.drop in WAF container and always run as non-root user.
```
