### PR TITLE
Correctly resolve auth secrets for WAF Policies

### DIFF
--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -99,6 +99,9 @@ type Graph struct {
 	// ReferencedAPLogConfs includes APLogConf resources referenced by WAFPolicy resources.
 	ReferencedAPLogConfs map[types.NamespacedName]*unstructured.Unstructured
 	// ReferencedWAFSecrets includes Secrets referenced by WAFPolicy (auth and TLS CA).
+	// Similar to ReferencedSecrets, it includes entries for Secrets that do not exist in the cluster.
+	// We need such entries so that we can query the Graph to determine if a Secret is referenced
+	// by a WAFPolicy, including the case when the Secret is newly created.
 	ReferencedWAFSecrets map[types.NamespacedName]*v1.Secret
 	// SnippetsFilters holds all the SnippetsFilters.
 	SnippetsFilters map[types.NamespacedName]*SnippetsFilter

--- a/internal/controller/state/graph/policies.go
+++ b/internal/controller/state/graph/policies.go
@@ -1269,6 +1269,8 @@ func resolveBundleAuth(
 
 	secret, exists := wafInput.Secrets[secretNsName]
 	if !exists {
+		// Still track the secret so that a rebuild is triggered when the Secret appears.
+		output.ReferencedWAFSecrets[secretNsName] = secret
 		cond := conditions.NewPolicyRefsNotResolved(
 			fmt.Sprintf("auth secret %q not found", secretNsName),
 		)
@@ -1319,6 +1321,8 @@ func resolveTLSCA(
 
 	secret, exists := wafInput.Secrets[secretNsName]
 	if !exists {
+		// Still track the secret so that a rebuild is triggered when the Secret appears.
+		output.ReferencedWAFSecrets[secretNsName] = secret
 		cond := conditions.NewPolicyRefsNotResolved(
 			fmt.Sprintf("TLS CA secret %q not found", secretNsName),
 		)

--- a/internal/controller/state/graph/policies_test.go
+++ b/internal/controller/state/graph/policies_test.go
@@ -3200,7 +3200,9 @@ func TestProcessWAFPolicies(t *testing.T) {
 			},
 			expSecrets: map[types.NamespacedName]*corev1.Secret{},
 			expConditions: func(_ *Policy) []conditions.Condition {
-				return []conditions.Condition{conditions.NewPolicyProgrammedStaleBundleWarning("policy bundle", "fetch failed")}
+				return []conditions.Condition{
+					conditions.NewPolicyProgrammedStaleBundleWarning("policy bundle", "fetch failed"),
+				}
 			},
 			expValid: true,
 		},
@@ -3220,7 +3222,7 @@ func TestProcessWAFPolicies(t *testing.T) {
 				}
 			},
 			expBundles: map[WAFBundleKey]*WAFBundleData{},
-			expSecrets: map[types.NamespacedName]*corev1.Secret{},
+			expSecrets: map[types.NamespacedName]*corev1.Secret{authSecretNsName: nil},
 			expConditions: func(_ *Policy) []conditions.Condition {
 				return []conditions.Condition{
 					conditions.NewPolicyRefsNotResolved(
@@ -3269,7 +3271,7 @@ func TestProcessWAFPolicies(t *testing.T) {
 				}
 			},
 			expBundles: map[WAFBundleKey]*WAFBundleData{},
-			expSecrets: map[types.NamespacedName]*corev1.Secret{},
+			expSecrets: map[types.NamespacedName]*corev1.Secret{tlsSecretNsName: nil},
 			expConditions: func(_ *Policy) []conditions.Condition {
 				return []conditions.Condition{
 					conditions.NewPolicyRefsNotResolved(
@@ -3506,7 +3508,7 @@ func TestProcessWAFPolicies(t *testing.T) {
 			expBundles: map[WAFBundleKey]*WAFBundleData{
 				bundleKey: {Data: fetchedData, Checksum: fetchedChecksum},
 			},
-			expSecrets: map[types.NamespacedName]*corev1.Secret{},
+			expSecrets: map[types.NamespacedName]*corev1.Secret{authSecretNsName: nil},
 			expConditions: func(_ *Policy) []conditions.Condition {
 				return []conditions.Condition{
 					conditions.NewPolicyRefsNotResolved(
@@ -3547,7 +3549,7 @@ func TestProcessWAFPolicies(t *testing.T) {
 			expBundles: map[WAFBundleKey]*WAFBundleData{
 				bundleKey: {Data: fetchedData, Checksum: fetchedChecksum},
 			},
-			expSecrets: map[types.NamespacedName]*corev1.Secret{},
+			expSecrets: map[types.NamespacedName]*corev1.Secret{tlsSecretNsName: nil},
 			expConditions: func(_ *Policy) []conditions.Condition {
 				return []conditions.Condition{
 					conditions.NewPolicyRefsNotResolved(
@@ -3642,7 +3644,7 @@ func TestProcessWAFPolicies(t *testing.T) {
 					Data: fetchedData, Checksum: fetchedChecksum,
 				},
 			},
-			expSecrets: map[types.NamespacedName]*corev1.Secret{},
+			expSecrets: map[types.NamespacedName]*corev1.Secret{authSecretNsName: nil},
 			expConditions: func(_ *Policy) []conditions.Condition {
 				return []conditions.Condition{
 					conditions.NewPolicyRefsNotResolved(
@@ -3951,11 +3953,10 @@ func TestResolveBundleAuth(t *testing.T) {
 	}
 
 	tests := []struct {
-		secret    *corev1.Secret
-		expAuth   *fetch.BundleAuth
-		expCond   *conditions.Condition
-		name      string
-		expSecret bool
+		secret  *corev1.Secret
+		expAuth *fetch.BundleAuth
+		expCond *conditions.Condition
+		name    string
 	}{
 		{
 			name:   "secret not found",
@@ -3969,8 +3970,7 @@ func TestResolveBundleAuth(t *testing.T) {
 			secret: &corev1.Secret{
 				Data: map[string][]byte{secrets.BundleTokenKey: []byte("my-token")},
 			},
-			expAuth:   &fetch.BundleAuth{BearerToken: "my-token"},
-			expSecret: true,
+			expAuth: &fetch.BundleAuth{BearerToken: "my-token"},
 		},
 		{
 			name: "token key present but empty after trimming",
@@ -3980,7 +3980,6 @@ func TestResolveBundleAuth(t *testing.T) {
 			expCond: helpers.GetPointer(conditions.NewPolicyRefsNotResolved(
 				fmt.Sprintf("auth secret %q has empty %q key", secretNsName, secrets.BundleTokenKey),
 			)),
-			expSecret: true,
 		},
 		{
 			name: "username and password present",
@@ -3990,8 +3989,7 @@ func TestResolveBundleAuth(t *testing.T) {
 					secrets.BundlePasswordKey: []byte("pass"),
 				},
 			},
-			expAuth:   &fetch.BundleAuth{Username: "user", Password: "pass"},
-			expSecret: true,
+			expAuth: &fetch.BundleAuth{Username: "user", Password: "pass"},
 		},
 		{
 			name: "username present but password empty",
@@ -4005,7 +4003,6 @@ func TestResolveBundleAuth(t *testing.T) {
 				"auth secret %q must contain either %q or both %q and %q",
 				secretNsName, secrets.BundleTokenKey, secrets.BundleUsernameKey, secrets.BundlePasswordKey,
 			))),
-			expSecret: true,
 		},
 		{
 			name: "both username and password empty",
@@ -4016,7 +4013,6 @@ func TestResolveBundleAuth(t *testing.T) {
 				"auth secret %q must contain either %q or both %q and %q",
 				secretNsName, secrets.BundleTokenKey, secrets.BundleUsernameKey, secrets.BundlePasswordKey,
 			))),
-			expSecret: true,
 		},
 	}
 
@@ -4037,11 +4033,7 @@ func TestResolveBundleAuth(t *testing.T) {
 				g.Expect(got).To(Equal(tc.expAuth))
 			}
 
-			if tc.expSecret {
-				g.Expect(output.ReferencedWAFSecrets).To(HaveKey(secretNsName))
-			} else {
-				g.Expect(output.ReferencedWAFSecrets).To(BeEmpty())
-			}
+			g.Expect(output.ReferencedWAFSecrets).To(HaveKey(secretNsName))
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

Problem: When deploying a `WAFPolicy` either as `type: N1C` or `type: NIM`, the secret referenced in `spec.policySource.auth.secretRef.name` will never be found by the `WAFPolicy` if the secret is deployed **after** the policy is deployed.

Solution: Ensure  auth secrets for WAF are tracked as "referenced" even if they are `nil`/non-existent. This ensure the secret can be found and resolved not matter what order the resources are applied in.

Testing: Manually tested the deployment scenarios. Updated existing unit tests.

Closes https://github.com/nginx/nginx-gateway-fabric/issues/5634

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Correctly resolve auth secrets for WAF Policies
```
