### PR TITLE
Fix stale WAF bundle/error state after poller teardown

### DIFF
--- a/internal/framework/waf/poller/manager.go
+++ b/internal/framework/waf/poller/manager.go
@@ -196,7 +196,7 @@ func (m *pollerManager) startPoller(ctx context.Context, cfg Config) {
 		if desc == "" {
 			desc = "WAF bundle"
 		}
-		m.recordPollResult(policyNsName, bundleKey, desc, newChecksum, err)
+		m.recordPollResult(poller, policyNsName, bundleKey, desc, newChecksum, err)
 		if m.statusCallback != nil {
 			m.statusCallback(poller.getTargetDeployments())
 		}
@@ -248,7 +248,12 @@ func (m *pollerManager) startPoller(ctx context.Context, cfg Config) {
 // If newChecksum is non-empty, the bundle was successfully updated and the update is recorded.
 // If err is non-nil, it stores the error for this bundle key.
 // This method is called by the internal status callback.
+// The result is discarded unless p is still the registered poller for the policy: an in-flight
+// poll can finish after StopPoller/StopPollersNotIn cleared this poller's state (or after
+// startPoller replaced the poller), and recording it would resurrect state that nothing
+// would ever clean up.
 func (m *pollerManager) recordPollResult(
+	p *poller,
 	policyNsName types.NamespacedName,
 	bundleKey graph.WAFBundleKey,
 	bundleDescription string,
@@ -257,6 +262,12 @@ func (m *pollerManager) recordPollResult(
 ) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Ownership check: compare the poller identity, not just key presence, so a result from a
+	// replaced poller cannot be recorded under the new poller's registration.
+	if entry, exists := m.pollers[policyNsName]; !exists || entry.poller != p {
+		return
+	}
 
 	if err == nil {
 		if existing := m.pollErrors[policyNsName]; existing != nil && existing.BundleKey == bundleKey {
@@ -302,8 +313,17 @@ func (m *pollerManager) GetAllBundleUpdates() map[types.NamespacedName]BundleUpd
 // cache — not only when the policy was previously in BundlePending state. A spurious reconcile
 // event in that case is harmless: it triggers an unnecessary graph rebuild but causes no
 // incorrect behavior.
+// The update is discarded if the bundle key is no longer registered: the owning poller has been
+// stopped (or restarted with different sources) and its cache entries cleared, so caching an
+// in-flight result would leave stale bundle data behind that nothing would ever clean up.
 func (m *pollerManager) cacheBundleUpdate(bundleKey graph.WAFBundleKey, data []byte, checksum string) {
 	m.mu.Lock()
+
+	// Ownership check: only cache updates for bundle keys that are still registered.
+	if _, registered := m.bundleKeyToPolicy[bundleKey]; !registered {
+		m.mu.Unlock()
+		return
+	}
 
 	_, alreadyCached := m.bundleCache[bundleKey]
 

--- a/internal/framework/waf/poller/manager_test.go
+++ b/internal/framework/waf/poller/manager_test.go
@@ -428,12 +428,16 @@ func TestManager_pollErrors(t *testing.T) {
 	policyNsName := types.NamespacedName{Namespace: "default", Name: "test-policy"}
 	bundleKey := graph.WAFBundleKey("default_test-policy")
 
+	// Register a poller entry so recordPollResult accepts results for this policy.
+	p := &poller{}
+	mgr.pollers[policyNsName] = &pollerEntry{poller: p, cancel: func() {}}
+
 	// Initially no errors.
 	g.Expect(mgr.GetAllPollErrors()).To(BeNil())
 
 	// Record an error.
 	testErr := errors.New("network timeout")
-	mgr.recordPollResult(policyNsName, bundleKey, "policy bundle", "", testErr)
+	mgr.recordPollResult(p, policyNsName, bundleKey, "policy bundle", "", testErr)
 
 	allErrors := mgr.GetAllPollErrors()
 	g.Expect(allErrors).To(HaveLen(1))
@@ -443,7 +447,7 @@ func TestManager_pollErrors(t *testing.T) {
 	g.Expect(allErrors[policyNsName].Err).To(Equal(testErr))
 
 	// Clear error on success.
-	mgr.recordPollResult(policyNsName, bundleKey, "policy bundle", "", nil)
+	mgr.recordPollResult(p, policyNsName, bundleKey, "policy bundle", "", nil)
 
 	g.Expect(mgr.GetAllPollErrors()).To(BeNil())
 }
@@ -585,6 +589,107 @@ func TestManager_stopPollersNotInClearsBundleCache(t *testing.T) {
 	g.Expect(bundles).ToNot(HaveKey(bundleKeyB))
 }
 
+func TestManager_stopPollerDiscardsInFlightPollResults(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	mgr := newTestManager(ManagerConfig{
+		Logger:      logr.Discard(),
+		Fetcher:     &fetchfakes.FakeFetcher{},
+		Deployments: &agentfakes.FakeDeploymentStorer{},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	policyNsName := types.NamespacedName{Namespace: "default", Name: "test-policy"}
+	bundleKey := graph.WAFBundleKey("test_policy")
+	sources := []BundleSource{
+		{
+			BundleKey: bundleKey,
+			Request:   fetch.Request{URL: "http://example.com/bundle.tgz"},
+			Interval:  1 * time.Hour,
+		},
+	}
+
+	mgr.ReconcilePoller(ctx, Config{
+		PolicyNsName:      policyNsName,
+		Sources:           sources,
+		TargetDeployments: []types.NamespacedName{{Namespace: "nginx-gateway", Name: "nginx"}},
+	})
+
+	// Capture the poller's callbacks; an in-flight poll invokes these, possibly after teardown.
+	p := mgr.pollers[policyNsName].poller
+
+	mgr.StopPoller(policyNsName)
+
+	// Simulate an in-flight poll finishing after the poller was stopped.
+	// The stopped poller's results must be discarded, not resurrect cleared state.
+	p.statusCallback(policyNsName, bundleKey, "", errors.New("network timeout"))
+	g.Expect(mgr.GetAllPollErrors()).ToNot(HaveKey(policyNsName))
+
+	p.statusCallback(policyNsName, bundleKey, "stale-checksum", nil)
+	g.Expect(mgr.GetAllBundleUpdates()).ToNot(HaveKey(policyNsName))
+
+	p.bundleUpdateCallback(bundleKey, []byte("stale-data"), "stale-checksum")
+	g.Expect(mgr.GetLatestBundles()).ToNot(HaveKey(bundleKey))
+}
+
+func TestManager_restartedPollerDiscardsStaleInFlightPollResults(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	mgr := newTestManager(ManagerConfig{
+		Logger:      logr.Discard(),
+		Fetcher:     &fetchfakes.FakeFetcher{},
+		Deployments: &agentfakes.FakeDeploymentStorer{},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	policyNsName := types.NamespacedName{Namespace: "default", Name: "test-policy"}
+	oldBundleKey := graph.WAFBundleKey("test_policy_old")
+	newBundleKey := graph.WAFBundleKey("test_policy_new")
+	targets := []types.NamespacedName{{Namespace: "nginx-gateway", Name: "nginx"}}
+
+	mgr.ReconcilePoller(ctx, Config{
+		PolicyNsName: policyNsName,
+		Sources: []BundleSource{{
+			BundleKey: oldBundleKey,
+			Request:   fetch.Request{URL: "http://example.com/old.tgz"},
+			Interval:  1 * time.Hour,
+		}},
+		TargetDeployments: targets,
+	})
+
+	oldPoller := mgr.pollers[policyNsName].poller
+
+	// Reconcile with changed sources - the poller is replaced by a new instance.
+	mgr.ReconcilePoller(ctx, Config{
+		PolicyNsName: policyNsName,
+		Sources: []BundleSource{{
+			BundleKey: newBundleKey,
+			Request:   fetch.Request{URL: "http://example.com/new.tgz"},
+			Interval:  1 * time.Hour,
+		}},
+		TargetDeployments: targets,
+	})
+
+	g.Expect(mgr.pollers[policyNsName].poller).ToNot(BeIdenticalTo(oldPoller))
+
+	// Simulate the replaced poller's in-flight poll finishing after the restart.
+	// Its results must not be recorded under the new poller's registration.
+	oldPoller.statusCallback(policyNsName, oldBundleKey, "", errors.New("network timeout"))
+	g.Expect(mgr.GetAllPollErrors()).ToNot(HaveKey(policyNsName))
+
+	oldPoller.statusCallback(policyNsName, oldBundleKey, "stale-checksum", nil)
+	g.Expect(mgr.GetAllBundleUpdates()).ToNot(HaveKey(policyNsName))
+
+	oldPoller.bundleUpdateCallback(oldBundleKey, []byte("stale-data"), "stale-checksum")
+	g.Expect(mgr.GetLatestBundles()).ToNot(HaveKey(oldBundleKey))
+}
+
 func TestManager_GetLatestBundles(t *testing.T) {
 	t.Parallel()
 
@@ -615,6 +720,8 @@ func TestManager_GetLatestBundles(t *testing.T) {
 		bundleData := []byte("bundle content")
 		checksum := "abc123"
 
+		mgr.bundleKeyToPolicy[bundleKey] = types.NamespacedName{Namespace: "default", Name: "my-policy"}
+
 		mgr.cacheBundleUpdate(bundleKey, bundleData, checksum)
 
 		bundles := mgr.GetLatestBundles()
@@ -636,6 +743,7 @@ func TestManager_GetLatestBundles(t *testing.T) {
 		})
 
 		bundleKey := graph.WAFBundleKey("default_my-policy")
+		mgr.bundleKeyToPolicy[bundleKey] = types.NamespacedName{Namespace: "default", Name: "my-policy"}
 		mgr.cacheBundleUpdate(bundleKey, []byte("old"), "old-checksum")
 		mgr.cacheBundleUpdate(bundleKey, []byte("new"), "new-checksum")
 
@@ -656,6 +764,7 @@ func TestManager_GetLatestBundles(t *testing.T) {
 		})
 
 		bundleKey := graph.WAFBundleKey("default_my-policy")
+		mgr.bundleKeyToPolicy[bundleKey] = types.NamespacedName{Namespace: "default", Name: "my-policy"}
 		mgr.cacheBundleUpdate(bundleKey, []byte("data"), "checksum")
 
 		copy1 := mgr.GetLatestBundles()
@@ -676,7 +785,9 @@ func TestManager_GetLatestBundles(t *testing.T) {
 			Deployments: &agentfakes.FakeDeploymentStorer{},
 		})
 
-		mgr.cacheBundleUpdate(graph.WAFBundleKey("default_policy"), []byte("data"), "checksum")
+		bundleKey := graph.WAFBundleKey("default_policy")
+		mgr.bundleKeyToPolicy[bundleKey] = types.NamespacedName{Namespace: "default", Name: "policy"}
+		mgr.cacheBundleUpdate(bundleKey, []byte("data"), "checksum")
 		g.Expect(mgr.GetLatestBundles()).To(HaveLen(1))
 
 		mgr.stopAll()


### PR DESCRIPTION
### Proposed changes

Problem: When a WAF poller is stopped (`StopPoller` / `StopPollersNotIn`, e.g. on WAFPolicy deletion or a bundle-source change) or replaced (`startPoller`), the manager deletes the poller's entries from `pollErrors`, `bundleUpdates`, and `bundleCache` under the lock, then cancels the poller without waiting for an in-flight poll to finish. The poll-result callbacks (`recordPollResult` / `cacheBundleUpdate`) re-acquire the lock and write those same maps without checking that the poller is still registered, so an in-flight poll completing during teardown can resurrect state for a poller that no longer exists — and since the poller is gone, nothing ever cleans it up. Stale bundle data or a stale poll error then lingers in the manager indefinitely.

Solution: Ownership-gate the poll-result callbacks, per the expected behavior in the issue. `recordPollResult` now receives the reporting poller and, under the lock, discards the result unless that exact poller instance is still registered for the policy — comparing identity rather than key presence, so a replaced poller's late result also cannot be recorded under the new poller's registration. `cacheBundleUpdate` discards updates for bundle keys no longer registered in `bundleKeyToPolicy`. The poller goroutine is never joined under the event loop; late results are simply dropped.

Testing: Added regression tests for both teardown paths (`TestManager_stopPollerDiscardsInFlightPollResults` and `TestManager_restartedPollerDiscardsStaleInFlightPollResults`) that drive the poller's real wrapped callbacks after `StopPoller` / a source-change restart. Both fail without the fix (stale poll error / bundle update / cached bundle resurface) and pass with it. Ran `go test ./internal/framework/waf/poller/... -race -count=1`, `go vet`, and golangci-lint — all clean.

Fixes #5418

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Fixed a race where stopping or restarting a WAF poller could leave stale bundle data or a stale poll error behind in the manager if a poll was in flight during teardown.
```
