### PR TITLE
Collect ExternalLoadBalancerCount in telemetry

### DIFF
--- a/internal/controller/telemetry/collector.go
+++ b/internal/controller/telemetry/collector.go
@@ -155,6 +155,8 @@ type NGFResourceCounts struct {
 	PLMWAFPolicyCount int64
 	// ListenerSetCount is the number of relevant ListenerSets.
 	ListenerSetCount int64
+	// ExternalLoadBalancerCount is the number of relevant ExternalLoadBalancers.
+	ExternalLoadBalancerCount int64
 }
 
 func (rc *NGFResourceCounts) CountPolicies(g *graph.Graph) {
@@ -377,6 +379,7 @@ func collectGraphResourceCount(
 
 	ngfResourceCounts.GatewayAttachedNpCount = gatewayAttachedNPCount
 	ngfResourceCounts.ListenerSetCount = int64(len(g.ListenerSets))
+	ngfResourceCounts.ExternalLoadBalancerCount = int64(len(g.ExternalLoadBalancers))
 
 	ngfResourceCounts.InferencePoolCount = int64(len(g.ReferencedInferencePools))
 

--- a/internal/controller/telemetry/collector_test.go
+++ b/internal/controller/telemetry/collector_test.go
@@ -628,6 +628,10 @@ var _ = Describe("Collector", Ordered, func() {
 						{Namespace: "test", Name: "listenerSet-2"}: {},
 						{Namespace: "test", Name: "listenerSet-3"}: {},
 					},
+					ExternalLoadBalancers: map[types.NamespacedName]*graph.ExternalLoadBalancer{
+						{Namespace: "test", Name: "elb-1"}: {},
+						{Namespace: "test", Name: "elb-2"}: {},
+					},
 				}
 
 				configs := []*dataplane.Configuration{
@@ -713,6 +717,7 @@ var _ = Describe("Collector", Ordered, func() {
 					HTTPWAFPolicyCount:                       1,
 					NIMWAFPolicyCount:                        1,
 					ListenerSetCount:                         3,
+					ExternalLoadBalancerCount:                2,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -1034,6 +1039,9 @@ var _ = Describe("Collector", Ordered, func() {
 				ListenerSets: map[types.NamespacedName]*graph.ListenerSet{
 					{Namespace: "test", Name: "listenerSet-1"}: {},
 				},
+				ExternalLoadBalancers: map[types.NamespacedName]*graph.ExternalLoadBalancer{
+					{Namespace: "test", Name: "elb-1"}: {},
+				},
 			}
 
 			config1 = []*dataplane.Configuration{
@@ -1133,6 +1141,7 @@ var _ = Describe("Collector", Ordered, func() {
 					N1CWAFPolicyCount:                        1,
 					PLMWAFPolicyCount:                        1,
 					ListenerSetCount:                         1,
+					ExternalLoadBalancerCount:                1,
 				}
 				expData.NginxPodCount = 1
 

--- a/internal/controller/telemetry/data.avdl
+++ b/internal/controller/telemetry/data.avdl
@@ -160,6 +160,9 @@ attached at the Route level. */
 		/** ListenerSetCount is the number of relevant ListenerSets. */
 		long? ListenerSetCount = null;
 		
+		/** ExternalLoadBalancerCount is the number of relevant ExternalLoadBalancers. */
+		long? ExternalLoadBalancerCount = null;
+		
 		/** NginxPodCount is the total number of Nginx data plane Pods. */
 		long? NginxPodCount = null;
 		

--- a/internal/controller/telemetry/data_test.go
+++ b/internal/controller/telemetry/data_test.go
@@ -58,6 +58,7 @@ func TestDataAttributes(t *testing.T) {
 			N1CWAFPolicyCount:                        30,
 			PLMWAFPolicyCount:                        31,
 			ListenerSetCount:                         32,
+			ExternalLoadBalancerCount:                33,
 		},
 		SnippetsFiltersDirectives:       []string{"main-three-count", "http-two-count", "server-one-count"},
 		SnippetsFiltersDirectivesCount:  []int64{3, 2, 1},
@@ -124,6 +125,7 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("N1CWAFPolicyCount", 30),
 		attribute.Int64("PLMWAFPolicyCount", 31),
 		attribute.Int64("ListenerSetCount", 32),
+		attribute.Int64("ExternalLoadBalancerCount", 33),
 
 		// Top level attributes
 		attribute.Int64("NginxPodCount", 3),
@@ -200,6 +202,7 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("N1CWAFPolicyCount", 0),
 		attribute.Int64("PLMWAFPolicyCount", 0),
 		attribute.Int64("ListenerSetCount", 0),
+		attribute.Int64("ExternalLoadBalancerCount", 0),
 
 		// Top level attributes
 		attribute.Int64("NginxPodCount", 0),

--- a/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
@@ -45,6 +45,7 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("N1CWAFPolicyCount", d.N1CWAFPolicyCount))
 	attrs = append(attrs, attribute.Int64("PLMWAFPolicyCount", d.PLMWAFPolicyCount))
 	attrs = append(attrs, attribute.Int64("ListenerSetCount", d.ListenerSetCount))
+	attrs = append(attrs, attribute.Int64("ExternalLoadBalancerCount", d.ExternalLoadBalancerCount))
 
 	return attrs
 }

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"N1CWAFPolicyCount: Int(0)",
 				"PLMWAFPolicyCount: Int(0)",
 				"ListenerSetCount: Int(0)",
+				"ExternalLoadBalancerCount: Int(0)",
 				"NginxPodCount: Int(0)",
 				"ControlPlanePodCount: Int(1)",
 				"NginxOneConnectionEnabled: Bool(false)",


### PR DESCRIPTION
Problem: We want to collect the number of ExternalLoadBalancer watched by NGF.

Solution: Collect the count of ExternalLoadBalancers. 

Testing: Unit tests and manually verified collection via debug logs.

Partially Closes #5676

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
