### PR TITLE
refactor: remove support for secret type nginx.org/htpasswd  (#4870)

### DIFF
--- a/internal/controller/state/dataplane/configuration_test.go
+++ b/internal/controller/state/dataplane/configuration_test.go
@@ -10211,28 +10211,11 @@ func TestBuildSSLKeyPairs(t *testing.T) {
 func TestBuildAuthSecrets(t *testing.T) {
 	t.Parallel()
 
-	htpasswdSecretNsName := types.NamespacedName{Namespace: "test", Name: "htpasswd-secret"}
 	tlsSecretNsName := types.NamespacedName{Namespace: "test", Name: "tls-secret"}
 	nilSourceSecretNsName := types.NamespacedName{Namespace: "test", Name: "nil-source"}
 	opaqueBasicAuthSecretNsName := types.NamespacedName{Namespace: "test", Name: "opaque-auth-basic-secret"}
 	opaqueJWTAuthSecretNsName := types.NamespacedName{Namespace: "test", Name: "opaque-auth-jwt-secret"}
 	invalidKeySecretNsName := types.NamespacedName{Namespace: "test", Name: "invalid-key-secret"}
-
-	// TODO: This secret type will be removed in a future release.
-	// Right now, this validates the `fallthrough` scenario.
-	// https://github.com/nginx/nginx-gateway-fabric/issues/4870
-	htpasswdSecret := &secrets.Secret{
-		Source: &apiv1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      htpasswdSecretNsName.Name,
-				Namespace: htpasswdSecretNsName.Namespace,
-			},
-			Type: apiv1.SecretType(secrets.SecretTypeHtpasswd),
-			Data: map[string][]byte{
-				secrets.AuthKey: []byte("user:$apr1$cred"),
-			},
-		},
-	}
 
 	opaqueAuthSecretBasicData := &secrets.Secret{
 		Source: &apiv1.Secret{
@@ -10305,21 +10288,6 @@ func TestBuildAuthSecrets(t *testing.T) {
 		expected map[AuthFileID]AuthFileData
 		name     string
 	}{
-		{
-			name: "htpasswd secret",
-			secrets: map[types.NamespacedName]*secrets.Secret{
-				htpasswdSecretNsName: htpasswdSecret,
-			},
-			filters: map[types.NamespacedName]*graph.AuthenticationFilter{
-				htpasswdSecretNsName: buildBasicAuthFilter(
-					htpasswdSecretNsName,
-					htpasswdSecretNsName.Namespace,
-				),
-			},
-			expected: map[AuthFileID]AuthFileData{
-				"basic_auth_test_htpasswd-secret": []byte("user:$apr1$cred"),
-			},
-		},
 		{
 			name: "opaque secret with auth key for basic auth",
 			secrets: map[types.NamespacedName]*secrets.Secret{

--- a/internal/controller/state/graph/authentication_filter.go
+++ b/internal/controller/state/graph/authentication_filter.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"

--- a/internal/controller/state/graph/authentication_filter.go
+++ b/internal/controller/state/graph/authentication_filter.go
@@ -283,39 +283,6 @@ func resolveAuthenticationFilterSecret(
 		return []conditions.Condition{cond}, false
 	}
 
-	// FIXME(s.odonovan): Remove this secret type 3 releases after 2.5.0.
-	// Issue https://github.com/nginx/nginx-gateway-fabric/issues/4870 will remove this secret type.
-	return resolveHtPasswdSecret(authSecretNsName, resourceResolver)
-}
-
-func resolveHtPasswdSecret(
-	authSecretNsName types.NamespacedName,
-	resourceResolver resolver.Resolver,
-) ([]conditions.Condition, bool) {
-	secretsMap := resourceResolver.GetSecrets()[authSecretNsName]
-	if secretsMap == nil || secretsMap.Source == nil {
-		cond := conditions.NewAuthenticationFilterInvalid(
-			fmt.Sprintf("failed to resolve resource. Secret %s/%s is invalid or missing.",
-				authSecretNsName.Namespace,
-				authSecretNsName.Name),
-		)
-		return []conditions.Condition{cond}, false
-	}
-
-	if secretsMap.Source.Type == corev1.SecretType(secrets.SecretTypeHtpasswd) {
-		msg := fmt.Sprintf(
-			"The AuthenticationFilter is accepted,"+
-				" but the referenced Secret %s/%s of type %q is now deprecated."+
-				" This secret type will be removed in a future release."+
-				" Please use type %q instead.",
-			authSecretNsName.Namespace,
-			authSecretNsName.Name,
-			secretsMap.Source.Type,
-			corev1.SecretTypeOpaque,
-		)
-		cond := conditions.NewAuthenticationFilterAcceptedWithMessage(msg)
-		return []conditions.Condition{cond}, true
-	}
 	return nil, true
 }
 

--- a/internal/controller/state/graph/authentication_filter_test.go
+++ b/internal/controller/state/graph/authentication_filter_test.go
@@ -236,9 +236,7 @@ func TestValidateAuthenticationFilter(t *testing.T) {
 		args    args
 	}{
 		{
-			// FIXME(s.odonovan): Remove this secret type 3 releases after 2.5.0.
-			// Issue https://github.com/nginx/nginx-gateway-fabric/issues/4870 will remove this secret type.
-			name: "valid Basic auth filter with htpasswd secret",
+			name: "invalid: Basic auth filter with unsupported htpasswd secret type",
 			args: args{
 				secretNsName: types.NamespacedName{Namespace: "test", Name: "af"},
 				filter: createAuthenticationFilterWithBasicAuth(
@@ -250,13 +248,12 @@ func TestValidateAuthenticationFilter(t *testing.T) {
 					{
 						ResourceType:   resolver.ResourceTypeSecret,
 						NamespacedName: types.NamespacedName{Namespace: "test", Name: "hp"},
-					}: createAuthSecret(corev1.SecretType(secrets.SecretTypeHtpasswd), "test", "hp", true),
+					}: createAuthSecret(corev1.SecretType("nginx.org/htpasswd"), "test", "hp", true),
 				},
 			},
-			expCond: conditions.NewAuthenticationFilterAcceptedWithMessage(
-				"The AuthenticationFilter is accepted, but the referenced Secret test/hp of type \"nginx.org/htpasswd\"" +
-					" is now deprecated. This secret type will be removed in a future release." +
-					" Please use type \"Opaque\" instead.",
+			expCond: conditions.NewAuthenticationFilterInvalid(
+				"spec.basic.secretRef: Invalid value: \"secret test/hp is invalid\": " +
+					"unsupported secret type \"nginx.org/htpasswd\"",
 			),
 		},
 		{
@@ -389,7 +386,7 @@ func TestValidateAuthenticationFilter(t *testing.T) {
 			),
 		},
 		{
-			name: "invalid: htpasswd secret missing required key",
+			name: "invalid: basic auth secret missing required key",
 			args: args{
 				filter: createAuthenticationFilterWithBasicAuth(
 					types.NamespacedName{Namespace: "test", Name: "af"},

--- a/internal/controller/state/graph/shared/secrets/secrets.go
+++ b/internal/controller/state/graph/shared/secrets/secrets.go
@@ -21,15 +21,6 @@ type Secret struct {
 	CertBundle *CertificateBundle
 }
 
-type SecretType string
-
-const (
-	// SecretTypeHtpasswd represents a Secret containing an htpasswd file for Basic Auth.
-	// FIXME(s.odonovan): Remove this secret type 3 releases after 2.5.0.
-	// Issue https://github.com/nginx/nginx-gateway-fabric/issues/4870 will remove this secret type.
-	SecretTypeHtpasswd SecretType = "nginx.org/htpasswd" // #nosec G101
-)
-
 const (
 	// AuthKey is the Secret key for Basic Auth credentials.
 	AuthKey = "auth"

--- a/internal/controller/state/resolver/secrets.go
+++ b/internal/controller/state/resolver/secrets.go
@@ -59,10 +59,6 @@ func (s *secretEntry) validate(obj client.Object) {
 		}
 
 		certBundle = secrets.NewCertificateBundle(client.ObjectKeyFromObject(secret), "Secret", cert)
-	// FIXME(s.odonovan): Remove this secret type 3 releases after 2.5.0.
-	// Issue https://github.com/nginx/nginx-gateway-fabric/issues/4870 will remove this secret type.
-	case secret.Type == v1.SecretType(secrets.SecretTypeHtpasswd):
-		fallthrough
 	case secret.Type == v1.SecretTypeOpaque && s.expectedKey != "":
 		validationErr = validateOpaqueSecretKey(secret, s.expectedKey)
 	default:

--- a/tests/suite/manifests/authentication-filter/basic-invalid-auth.yaml
+++ b/tests/suite/manifests/authentication-filter/basic-invalid-auth.yaml
@@ -120,7 +120,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth1
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user1 password1"
   auth: dXNlcjE6JGFwcjEkWEFKeU5yekgkY0Rjdy9YMVBCZTFmTjltQVBweXpxMA==
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth2
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user2 password2"
   auth: dXNlcjI6JGFwcjEkd0lKUUpjZEUkSXUuYjVhMlBGODdtQi5zT0x4aUg5MQ==
@@ -162,7 +162,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth-wrong-key
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user2 password2"
   creds: dXNlcjI6JGFwcjEkd0lKUUpjZEUkSXUuYjVhMlBGODdtQi5zT0x4aUg5MQ==

--- a/tests/suite/manifests/authentication-filter/basic-valid-auth.yaml
+++ b/tests/suite/manifests/authentication-filter/basic-valid-auth.yaml
@@ -75,7 +75,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth1
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user1 password1"
   auth: dXNlcjE6JGFwcjEkWEFKeU5yekgkY0Rjdy9YMVBCZTFmTjltQVBweXpxMA==
@@ -95,7 +95,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth2
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user2 password2"
   auth: dXNlcjI6JGFwcjEkd0lKUUpjZEUkSXUuYjVhMlBGODdtQi5zT0x4aUg5MQ==
@@ -115,7 +115,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth-grpc
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user2 password2"
   auth: dXNlcjI6JGFwcjEkd0lKUUpjZEUkSXUuYjVhMlBGODdtQi5zT0x4aUg5MQ==

--- a/tests/suite/manifests/authentication-filter/basic-valid-auth3.yaml
+++ b/tests/suite/manifests/authentication-filter/basic-valid-auth3.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: basic-auth3
-type: nginx.org/htpasswd
+type: Opaque
 data:
   # Base64 of "htpasswd -bn user3 password3"
   auth: dXNlcjM6JGFwcjEka0FBc2d0V1AkekdRNG9CaGEyR0hRdGtEZUFEQ0pnMQ==


### PR DESCRIPTION
### Proposed changes

Problem: Legacy support for secrets of `type: nginx.org/htpasswd` was deprecated in release 2.5.0 and scheduled for removal after 3 releases (#4870).

Solution: Removed `SecretTypeHtpasswd` constant and legacy `resolveHtPasswdSecret` fallback logic. Updated all related test cases to assert that `type: nginx.org/htpasswd` is rejected as an unsupported secret type, and migrated test manifests to `type: Opaque`.

Testing:
- Updated unit tests in `internal/controller/state/graph/authentication_filter_test.go`.
- Updated unit tests in `internal/controller/state/dataplane/configuration_test.go`.

Closes #4870

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Removed deprecated support for secrets of type `nginx.org/htpasswd` in AuthenticationFilter. Please use `Opaque` secrets with the `auth` key instead.