### PR TITLE
Fix Kubernetes watch reconnects caused by client-wide REST timeout

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -85,8 +85,6 @@ import (
 )
 
 const (
-	// clusterTimeout is a timeout for connections to the Kubernetes API.
-	clusterTimeout = 10 * time.Second
 	// the following are the names of data fields within NGINX Plus related Secrets.
 	grpcServerPort = 8443
 )
@@ -551,7 +549,9 @@ func createManager(cfg config.Config, healthChecker *graphBuiltHealthChecker) (m
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster config: %w", err)
 	}
-	clusterCfg.Timeout = clusterTimeout
+	// Leave clusterCfg.Timeout at its zero-value default. A client-wide timeout here also
+	// applies to long-running watch requests, causing informer watches to be canceled and
+	// reopened at that interval instead of the longer server-side timeout client-go requests.
 
 	mgr, err := manager.New(clusterCfg, options)
 	if err != nil {

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -549,9 +549,6 @@ func createManager(cfg config.Config, healthChecker *graphBuiltHealthChecker) (m
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster config: %w", err)
 	}
-	// Leave clusterCfg.Timeout at its zero-value default. A client-wide timeout here also
-	// applies to long-running watch requests, causing informer watches to be canceled and
-	// reopened at that interval instead of the longer server-side timeout client-go requests.
 
 	mgr, err := manager.New(clusterCfg, options)
 	if err != nil {


### PR DESCRIPTION
### Proposed changes

Problem: NGF sets `rest.Config.Timeout` to 10 seconds before creating the controller-runtime manager. That client-wide timeout applies to every request made by the client, including long-running informer watch requests, so each watch was being canceled and reopened every 10 seconds instead of honoring the longer server-side timeout that client-go requests.

Solution: Removed the `clusterCfg.Timeout = clusterTimeout` assignment (and the now-unused `clusterTimeout` constant), leaving `rest.Config.Timeout` at its zero-value default. Short-lived operations elsewhere in the codebase already use their own bounded `context.WithTimeout` calls, so they're unaffected.

Testing: Ran the full `internal/controller` test suite (`go test ./internal/controller/...`) and `golangci-lint run internal/controller/...` — both pass. I did not add a new automated test: this is a one-line config change with no existing test harness around the manager's REST client construction, so a unit test would mostly be asserting against the zero-value default rather than exercising real watch behavior. Happy to add one if maintainers have a preferred approach for testing this.

Closes #5793

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Fix Kubernetes informer watches reconnecting every 10 seconds due to a client-wide REST config timeout.
```