### PR TITLE
fix: improve SnippetsFilters telemetry directive parsing (#2702)

### DIFF
--- a/internal/controller/telemetry/collector.go
+++ b/internal/controller/telemetry/collector.go
@@ -680,18 +680,158 @@ func collectSnippetsPoliciesDirectives(g *graph.Graph) ([]string, []int64) {
 	return parseDirectiveContextMapIntoLists(directiveContextMap)
 }
 
+// parseSnippetValueIntoDirectives parses the directive names from an NGINX snippet value.
+// It properly handles comments (#), quoted strings ('...' and "..." with escaped quotes),
+// semicolons inside values/comments, and block directives (such as map $x $y { ... })
+// by capturing top-level directive names and skipping block bodies and comments.
 func parseSnippetValueIntoDirectives(snippetValue string) []string {
-	separatedDirectives := strings.Split(snippetValue, ";")
-	directives := make([]string, 0, len(separatedDirectives))
+	var directives []string
+	n := len(snippetValue)
+	i := 0
 
-	for _, directive := range separatedDirectives {
-		// the strings.TrimSpace is needed in the case of multi-line NGINX Snippet values
-		directive = strings.Split(strings.TrimSpace(directive), " ")[0]
+	for i < n {
+		// Skip whitespace
+		for i < n && (snippetValue[i] == ' ' || snippetValue[i] == '\t' || snippetValue[i] == '\r' || snippetValue[i] == '\n') {
+			i++
+		}
+		if i >= n {
+			break
+		}
 
-		// splitting on the delimiting character can result in a directive being empty or a space/newline character,
-		// so we check here to ensure it's not
-		if directive != "" {
-			directives = append(directives, directive)
+		// Skip comments starting with '#'
+		if snippetValue[i] == '#' {
+			for i < n && snippetValue[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		// Skip stray semicolons or closing braces
+		if snippetValue[i] == ';' || snippetValue[i] == '}' {
+			i++
+			continue
+		}
+
+		// Read directive name
+		start := i
+		for i < n && snippetValue[i] != ' ' && snippetValue[i] != '\t' && snippetValue[i] != '\r' && snippetValue[i] != '\n' &&
+			snippetValue[i] != ';' && snippetValue[i] != '{' && snippetValue[i] != '#' {
+			i++
+		}
+
+		directiveName := snippetValue[start:i]
+
+		// Discard invalid directive names (e.g. variables starting with $, quotes, braces)
+		if directiveName == "" || strings.HasPrefix(directiveName, "$") || strings.HasPrefix(directiveName, "'") || strings.HasPrefix(directiveName, "\"") {
+			continue
+		}
+
+		directives = append(directives, directiveName)
+
+		// Scan until the end of this directive statement (either ';' or '{...}')
+		for i < n {
+			// Skip whitespace
+			if snippetValue[i] == ' ' || snippetValue[i] == '\t' || snippetValue[i] == '\r' || snippetValue[i] == '\n' {
+				i++
+				continue
+			}
+
+			// Comment
+			if snippetValue[i] == '#' {
+				for i < n && snippetValue[i] != '\n' {
+					i++
+				}
+				continue
+			}
+
+			// Single quote string
+			if snippetValue[i] == '\'' {
+				i++
+				for i < n && snippetValue[i] != '\'' {
+					if snippetValue[i] == '\\' && i+1 < n {
+						i += 2
+					} else {
+						i++
+					}
+				}
+				if i < n {
+					i++ // consume closing quote
+				}
+				continue
+			}
+
+			// Double quote string
+			if snippetValue[i] == '"' {
+				i++
+				for i < n && snippetValue[i] != '"' {
+					if snippetValue[i] == '\\' && i+1 < n {
+						i += 2
+					} else {
+						i++
+					}
+				}
+				if i < n {
+					i++ // consume closing quote
+				}
+				continue
+			}
+
+			// Semicolon ends a simple directive
+			if snippetValue[i] == ';' {
+				i++
+				break
+			}
+
+			// Opening brace begins a block directive; skip entire block
+			if snippetValue[i] == '{' {
+				i++
+				braceDepth := 1
+				for i < n && braceDepth > 0 {
+					if snippetValue[i] == '#' {
+						for i < n && snippetValue[i] != '\n' {
+							i++
+						}
+						continue
+					}
+					if snippetValue[i] == '\'' {
+						i++
+						for i < n && snippetValue[i] != '\'' {
+							if snippetValue[i] == '\\' && i+1 < n {
+								i += 2
+							} else {
+								i++
+							}
+						}
+						if i < n {
+							i++
+						}
+						continue
+					}
+					if snippetValue[i] == '"' {
+						i++
+						for i < n && snippetValue[i] != '"' {
+							if snippetValue[i] == '\\' && i+1 < n {
+								i += 2
+							} else {
+								i++
+							}
+						}
+						if i < n {
+							i++
+						}
+						continue
+					}
+					if snippetValue[i] == '{' {
+						braceDepth++
+					} else if snippetValue[i] == '}' {
+						braceDepth--
+					}
+					i++
+				}
+				break
+			}
+
+			i++
 		}
 	}
 

--- a/internal/controller/telemetry/collector_internal_test.go
+++ b/internal/controller/telemetry/collector_internal_test.go
@@ -1,0 +1,32 @@
+package telemetry
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseSnippetValueIntoDirectives", func() {
+	DescribeTable("extracting directive names from snippet values",
+		func(input string, expected []string) {
+			Expect(parseSnippetValueIntoDirectives(input)).To(Equal(expected))
+		},
+		Entry("empty snippet", "", nil),
+		Entry("whitespace and comment only", "   \n\t  # comment only with ; and {\n   ", nil),
+		Entry("simple single directive", "worker_priority 0;", []string{"worker_priority"}),
+		Entry("multiple directives on one line", "aio on; keepalive_timeout 65s;", []string{"aio", "keepalive_timeout"}),
+		Entry("directive without arguments", "aio; worker_processes auto;", []string{"aio", "worker_processes"}),
+		Entry("multi-line directives with comments", "worker_priority 1;\n# comment with ; semicolon\nworker_rlimit_nofile 50;\n", []string{"worker_priority", "worker_rlimit_nofile"}),
+		Entry("inline comment with semicolon", "worker_processes auto; # inline; comment\nworker_cpu_affinity auto;", []string{"worker_processes", "worker_cpu_affinity"}),
+		Entry("comment before semicolon", "worker_processes auto # comment \n ;", []string{"worker_processes"}),
+		Entry("semicolon in double-quoted string", `proxy_set_header hello "myvalue;abc";`, []string{"proxy_set_header"}),
+		Entry("semicolon in single-quoted string", `proxy_set_header hello 'myvalue;abc';`, []string{"proxy_set_header"}),
+		Entry("escaped quote in double-quoted string", `proxy_set_header foo "bar\"baz;qux"; proxy_set_header test 1;`, []string{"proxy_set_header", "proxy_set_header"}),
+		Entry("escaped quote in single-quoted string", `proxy_set_header foo 'bar\'baz;qux'; proxy_set_header test 1;`, []string{"proxy_set_header", "proxy_set_header"}),
+		Entry("issue 2702 map block directive", "aio on; map $http_x $x {default 0; 'abc' 1;}", []string{"aio", "map"}),
+		Entry("block directive with types", "types { text/html html; image/png png; }", []string{"types"}),
+		Entry("block with quoted braces", `map $x $y { "~^foo{" 1; "bar}" 2; default 0; } aio on;`, []string{"map", "aio"}),
+		Entry("block with comment containing braces", "map $x $y {\n# { comment }\ndefault 0;\n} aio on;", []string{"map", "aio"}),
+		Entry("multiple block directives", "map $a $b { default 0; } map $c $d { default 1; }", []string{"map", "map"}),
+		Entry("nested block braces", "block_directive arg { inner { default 0; } } other_dir 1;", []string{"block_directive", "other_dir"}),
+	)
+})

--- a/internal/controller/telemetry/collector_test.go
+++ b/internal/controller/telemetry/collector_test.go
@@ -1418,6 +1418,37 @@ var _ = Describe("Collector", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(data).To(Equal(expData))
 			})
+
+			It("collects correct data when snippets include block directives, quotes, and comments", func(ctx SpecContext) {
+				fakeGraphGetter.GetLatestGraphReturns(&graph.Graph{
+					SnippetsFilters: map[types.NamespacedName]*graph.SnippetsFilter{
+						{Namespace: "test", Name: "sf-1"}: {
+							Snippets: map[ngfAPI.NginxContext]string{
+								ngfAPI.NginxContextMain:               "worker_priority 0; # comment with ; and {",
+								ngfAPI.NginxContextHTTP:               "aio on; map $http_x $x {default 0; 'abc' 1;}",
+								ngfAPI.NginxContextHTTPServer:         `proxy_set_header hello "myvalue;abc"; auth_delay 10s;`,
+								ngfAPI.NginxContextHTTPServerLocation: "# leading comment;\nkeepalive_time 10s;",
+							},
+						},
+					},
+				})
+
+				expData.SnippetsFilterCount = 1
+				expData.SnippetsFiltersDirectives = []string{
+					"aio-http",
+					"map-http",
+					"keepalive_time-location",
+					"worker_priority-main",
+					"auth_delay-server",
+					"proxy_set_header-server",
+				}
+				expData.SnippetsFiltersDirectivesCount = []int64{1, 1, 1, 1, 1, 1}
+
+				data, err := dataCollector.Collect(ctx)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(data).To(Equal(expData))
+			})
 		})
 	})
 })


### PR DESCRIPTION
### Proposed changes

Problem:
parseSnippetValueIntoDirectives parsed NGINX snippet values using strings.Split(snippetValue, ";"). This caused incorrect telemetry directive collection when snippets contained:
1. Block directives (such as map or types) where block contents and closing braces were mistakenly parsed as directives.
2. Quoted strings containing semicolons (e.g. proxy_set_header hello "val;abc";).
3. Comments containing semicolons (both full-line and inline).

Solution:
Implemented a tokenizer in parseSnippetValueIntoDirectives that ignores comments, parses top-level directive names, tracks quoted strings and escapes, and skips block directive bodies ({ ... }) with brace depth tracking. Added comprehensive unit test coverage for all edge cases.

Testing:
- Added Ginkgo DescribeTable in collector_internal_test.go with 18 edge cases.
- Added end-to-end test in collector_test.go verifying telemetry collector metrics with block directives, comments, and quoted semicolons.
- Ran all unit and package tests across cmd/... and internal/... with -race and -shuffle=on.

Closes #2702

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Fixed an issue where SnippetsFilter telemetry collection incorrectly parsed block directives (e.g. map), quoted semicolons, and comments as directives.