### PR TITLE
Fix misleading NginxConfigPushed on no-op config updates

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -303,7 +303,7 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 			h.setLatestConfiguration(gw, &cfg)
 
 			deployment.FileLock.Lock()
-			h.updateNginxConf(deployment, cfg, effectiveVolumeMounts(gw.EffectiveNginxProxy))
+			configPushed := h.updateNginxConf(deployment, cfg, effectiveVolumeMounts(gw.EffectiveNginxProxy))
 			deployment.FileLock.Unlock()
 
 			configErr := deployment.GetLatestConfigError()
@@ -312,7 +312,7 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 			statusObj = &status.QueueObject{
 				UpdateType:        status.UpdateAll,
 				Error:             errors.Join(configErr, upstreamErr),
-				NginxConfigPushed: true,
+				NginxConfigPushed: configPushed,
 				Deployment: status.Deployment{
 					NamespacedName: gw.DeploymentName,
 					GatewayName:    gw.Source.GetName(),
@@ -570,9 +570,10 @@ func (h *eventHandlerImpl) waitForStatusUpdates(ctx context.Context) {
 			h.cfg.logger.Info("NGINX configuration was successfully updated")
 		}
 		// Only update LatestReloadResult when a config push was actually attempted.
-		// Status-only queue items (e.g., WAF poll callbacks) have NginxConfigPushed=false
-		// and no error; updating LatestReloadResult for those would incorrectly clear a
-		// prior NGINX reload error without any config change having occurred.
+		// Status-only queue items (e.g., WAF poll callbacks) and no-op UpdateConfig
+		// results have NginxConfigPushed=false and no error; updating LatestReloadResult
+		// for those would incorrectly clear a prior NGINX reload error without any
+		// config change having occurred.
 		if gw != nil && (item.NginxConfigPushed || item.Error != nil) {
 			gw.LatestReloadResult = nginxReloadRes
 		}
@@ -1002,18 +1003,21 @@ func (h *eventHandlerImpl) parseAndCaptureEvent(ctx context.Context, logger logr
 }
 
 // updateNginxConf updates nginx conf files and reloads nginx.
+// It returns true when configuration was broadcast to agents.
 func (h *eventHandlerImpl) updateNginxConf(
 	deployment *agent.Deployment,
 	conf dataplane.Configuration,
 	volumeMounts []v1.VolumeMount,
-) {
+) bool {
 	files := h.cfg.generator.Generate(h.cfg.logger.WithName("generator"), conf)
-	h.cfg.nginxUpdater.UpdateConfig(deployment, files, volumeMounts)
+	configPushed := h.cfg.nginxUpdater.UpdateConfig(deployment, files, volumeMounts)
 
 	// If using NGINX Plus, update upstream servers using the API.
 	if h.cfg.plus {
 		h.cfg.nginxUpdater.UpdateUpstreamServers(deployment, conf)
 	}
+
+	return configPushed
 }
 
 // updateControlPlaneAndSetStatus updates the control plane configuration and then sets the status

--- a/internal/controller/handler_test.go
+++ b/internal/controller/handler_test.go
@@ -530,6 +530,37 @@ var _ = Describe("eventHandler", func() {
 		})
 	})
 
+	It("should not treat a no-op UpdateConfig as an NGINX config push", func() {
+		fakeProcessor.ProcessReturns(baseGraph)
+		fakeGenerator.GenerateReturns([]agent.File{
+			{
+				Meta: &pb.FileMeta{
+					Name: "test.conf",
+				},
+			},
+		})
+		fakeNginxUpdater.UpdateConfigReturns(false)
+
+		gw := baseGraph.Gateways[types.NamespacedName{Namespace: "test", Name: "gateway"}]
+		priorErr := errors.New("prior reload error")
+		gw.LatestReloadResult.Error = priorErr
+
+		handler.HandleEventBatch(context.Background(), logr.Discard(), []any{
+			&events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}},
+		})
+
+		Eventually(func() int {
+			return fakeProvisioner.RegisterGatewayCallCount()
+		}).Should(Equal(1))
+		Eventually(func() int {
+			return fakeStatusUpdater.UpdateGroupCallCount()
+		}).Should(BeNumerically(">=", 1))
+
+		Expect(fakeNginxUpdater.UpdateConfigCallCount()).To(Equal(1))
+		// waitForStatusUpdates must not clear a prior reload error when nothing was pushed.
+		Expect(gw.LatestReloadResult.Error).To(Equal(priorErr))
+	})
+
 	It("should update status when receiving a queue event", func() {
 		obj := &status.QueueObject{
 			UpdateType: status.UpdateAll,

--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -105,7 +105,7 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 	}
 
 	deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
-	return true
+	return applied
 }
 
 // UpdateUpstreamServers sends an APIRequest to the agent to update upstream servers using the NGINX Plus API.

--- a/internal/controller/nginx/agent/agent.go
+++ b/internal/controller/nginx/agent/agent.go
@@ -30,7 +30,9 @@ const retryUpstreamTimeout = 5 * time.Second
 
 // NginxUpdater is an interface for updating NGINX using the NGINX agent.
 type NginxUpdater interface {
-	UpdateConfig(deployment *Deployment, files []File, volumeMounts []v1.VolumeMount)
+	// UpdateConfig sends the nginx configuration to agents if files changed.
+	// It returns true when a ConfigApplyRequest was broadcast; false when files were unchanged.
+	UpdateConfig(deployment *Deployment, files []File, volumeMounts []v1.VolumeMount) bool
 	UpdateUpstreamServers(deployment *Deployment, conf dataplane.Configuration)
 }
 
@@ -89,12 +91,12 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 	deployment *Deployment,
 	files []File,
 	volumeMounts []v1.VolumeMount,
-) {
+) bool {
 	msg := deployment.SetFiles(files, volumeMounts)
 	if msg == nil {
 		deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
 		n.logger.V(1).Info("No changes to nginx configuration files, not sending to agent")
-		return
+		return false
 	}
 
 	applied := deployment.GetBroadcaster().Send(*msg)
@@ -103,6 +105,7 @@ func (n *NginxUpdaterImpl) UpdateConfig(
 	}
 
 	deployment.SetLatestConfigError(deployment.GetConfigurationStatus())
+	return true
 }
 
 // UpdateUpstreamServers sends an APIRequest to the agent to update upstream servers using the NGINX Plus API.

--- a/internal/controller/nginx/agent/agent_test.go
+++ b/internal/controller/nginx/agent/agent_test.go
@@ -65,8 +65,9 @@ func TestUpdateConfig(t *testing.T) {
 				deployment.SetPodErrorStatus("pod1", testErr)
 			}
 
-			updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+			pushed := updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
 
+			g.Expect(pushed).To(BeTrue())
 			g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(1))
 			fileContents, _, found := deployment.GetFile(file.Meta.Name, file.Meta.Hash)
 			g.Expect(found).To(BeTrue())
@@ -77,7 +78,7 @@ func TestUpdateConfig(t *testing.T) {
 				// ensure that the error is cleared after the next config is applied
 				deployment.SetPodErrorStatus("pod1", nil)
 				file.Meta.Hash = "5678"
-				updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+				g.Expect(updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})).To(BeTrue())
 				g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
 			} else {
 				g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
@@ -114,14 +115,15 @@ func TestUpdateConfig_NoChange(t *testing.T) {
 	deployment.SetPodErrorStatus("pod1", testErr)
 
 	// Call UpdateConfig with the same files
-	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	pushed := updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
 
 	// Verify that no new configuration was sent
+	g.Expect(pushed).To(BeFalse())
 	g.Expect(fakeBroadcaster.SendCallCount()).To(Equal(0))
 	g.Expect(deployment.GetLatestConfigError()).To(Equal(testErr))
 
 	deployment.SetPodErrorStatus("pod1", nil)
-	updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})
+	g.Expect(updater.UpdateConfig(deployment, []File{file}, []v1.VolumeMount{})).To(BeFalse())
 	g.Expect(deployment.GetLatestConfigError()).ToNot(HaveOccurred())
 }
 

--- a/internal/controller/nginx/agent/agentfakes/fake_nginx_updater.go
+++ b/internal/controller/nginx/agent/agentfakes/fake_nginx_updater.go
@@ -10,12 +10,18 @@ import (
 )
 
 type FakeNginxUpdater struct {
-	UpdateConfigStub        func(*agent.Deployment, []agent.File, []v1.VolumeMount)
+	UpdateConfigStub        func(*agent.Deployment, []agent.File, []v1.VolumeMount) bool
 	updateConfigMutex       sync.RWMutex
 	updateConfigArgsForCall []struct {
 		arg1 *agent.Deployment
 		arg2 []agent.File
 		arg3 []v1.VolumeMount
+	}
+	updateConfigReturns struct {
+		result1 bool
+	}
+	updateConfigReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	UpdateUpstreamServersStub        func(*agent.Deployment, dataplane.Configuration)
 	updateUpstreamServersMutex       sync.RWMutex
@@ -27,7 +33,7 @@ type FakeNginxUpdater struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNginxUpdater) UpdateConfig(arg1 *agent.Deployment, arg2 []agent.File, arg3 []v1.VolumeMount) {
+func (fake *FakeNginxUpdater) UpdateConfig(arg1 *agent.Deployment, arg2 []agent.File, arg3 []v1.VolumeMount) bool {
 	var arg2Copy []agent.File
 	if arg2 != nil {
 		arg2Copy = make([]agent.File, len(arg2))
@@ -39,17 +45,23 @@ func (fake *FakeNginxUpdater) UpdateConfig(arg1 *agent.Deployment, arg2 []agent.
 		copy(arg3Copy, arg3)
 	}
 	fake.updateConfigMutex.Lock()
+	ret, specificReturn := fake.updateConfigReturnsOnCall[len(fake.updateConfigArgsForCall)]
 	fake.updateConfigArgsForCall = append(fake.updateConfigArgsForCall, struct {
 		arg1 *agent.Deployment
 		arg2 []agent.File
 		arg3 []v1.VolumeMount
 	}{arg1, arg2Copy, arg3Copy})
 	stub := fake.UpdateConfigStub
+	fakeReturns := fake.updateConfigReturns
 	fake.recordInvocation("UpdateConfig", []interface{}{arg1, arg2Copy, arg3Copy})
 	fake.updateConfigMutex.Unlock()
 	if stub != nil {
-		fake.UpdateConfigStub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *FakeNginxUpdater) UpdateConfigCallCount() int {
@@ -58,7 +70,7 @@ func (fake *FakeNginxUpdater) UpdateConfigCallCount() int {
 	return len(fake.updateConfigArgsForCall)
 }
 
-func (fake *FakeNginxUpdater) UpdateConfigCalls(stub func(*agent.Deployment, []agent.File, []v1.VolumeMount)) {
+func (fake *FakeNginxUpdater) UpdateConfigCalls(stub func(*agent.Deployment, []agent.File, []v1.VolumeMount) bool) {
 	fake.updateConfigMutex.Lock()
 	defer fake.updateConfigMutex.Unlock()
 	fake.UpdateConfigStub = stub
@@ -69,6 +81,29 @@ func (fake *FakeNginxUpdater) UpdateConfigArgsForCall(i int) (*agent.Deployment,
 	defer fake.updateConfigMutex.RUnlock()
 	argsForCall := fake.updateConfigArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeNginxUpdater) UpdateConfigReturns(result1 bool) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	fake.updateConfigReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeNginxUpdater) UpdateConfigReturnsOnCall(i int, result1 bool) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	if fake.updateConfigReturnsOnCall == nil {
+		fake.updateConfigReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.updateConfigReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeNginxUpdater) UpdateUpstreamServers(arg1 *agent.Deployment, arg2 dataplane.Configuration) {

--- a/internal/controller/status/queue.go
+++ b/internal/controller/status/queue.go
@@ -37,7 +37,8 @@ type QueueObject struct {
 	Deployment         Deployment
 	UpdateType         UpdateType
 	// NginxConfigPushed indicates that an NGINX configuration push was attempted for this update.
-	// When false the update is a status-only change (e.g. a WAF poll result) and the
+	// When false the update is a status-only change (e.g. a WAF poll result) or a no-op
+	// UpdateConfig where files were unchanged, and the
 	// "NGINX configuration was successfully updated" log should be suppressed.
 	NginxConfigPushed bool
 }


### PR DESCRIPTION
### Proposed changes

Problem: With `NginxProxy.spec.useClusterIP: true`, EndpointSlice churn still runs the full reconcile → `updateNginxConf` → `UpdateConfig` path. When rendered files are unchanged, no ConfigApplyRequest is sent to the agent, but the control plane still set `NginxConfigPushed: true` and logged info `"NGINX configuration was successfully updated"`, which made operators/dashboards think a reload happened.

Solution: `NginxUpdater.UpdateConfig` now returns whether a config was actually broadcast/applied (`false` on unchanged files or when `Send` reports not applied). The handler sets `status.QueueObject.NginxConfigPushed` from that value, so the success log and `LatestReloadResult` updates only happen when a push was actually applied.

Testing:
- Unit tests: `go test ./internal/controller/nginx/agent/ ./internal/controller/`
- Verified no-op path returns `false` / does not call `Send`, and push path returns the `Send` applied result
- Handler test: no-op `UpdateConfig` does not clear a prior `LatestReloadResult` error

Expected control-plane log behavior:
- **Before:** EndpointSlice churn with unchanged files still logged at info: `NGINX configuration was successfully updated`
- **After (no-op):** that info success log is suppressed; existing V(1) log remains: `No changes to nginx configuration files, not sending to agent`
- **After (real change):** still logs `Sent nginx configuration to agent` and `NGINX configuration was successfully updated`

Closes #5874

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Fix misleading "NGINX configuration was successfully updated" logs when configuration files are unchanged (for example EndpointSlice churn with useClusterIP enabled).
```