### PR TITLE
fix: render NGINX service patches in helm chart (#5857)

### DIFF
--- a/charts/nginx-gateway-fabric/templates/_helpers.tpl
+++ b/charts/nginx-gateway-fabric/templates/_helpers.tpl
@@ -103,7 +103,7 @@ Filters out empty fields from a struct.
 {{- $result := dict }}
 {{- range $key, $value := . }}
   {{- if and (not (empty $value)) (not (and (kindIs "slice" $value) (eq (len $value) 0))) }}
-    {{- $result = merge $result (dict $key $value) }}
+    {{- $_ := set $result $key $value }}
   {{- end }}
 {{- end }}
 {{- if $result -}}


### PR DESCRIPTION
Problem: When specifying the patches list in the NGINX Service section of the helm chart, patches were not being rendered properly because filterEmptyFields relied on merge (Sprig/mergo), which is intended for deep-merging maps and could encounter issues or drop slice elements.

Solution: Updated the filterEmptyFields template helper in _helpers.tpl to use set $result $key $value instead of merge. Because set directly assigns key-value pairs into the dictionary, slices (like patches, nodePorts, etc.) and complex fields are preserved cleanly without needing custom omit workarounds or template-level manual rendering.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix NGINX Service patches rendering in Helm chart.
```
