### PR TITLE
Fixes an issues where mounted secrets were read only leading to agent…

### DIFF
--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -936,17 +936,25 @@ func createInitializeCommand() *cobra.Command {
 	// flag names
 	const srcFlag = "source"
 	const destFlag = "destination"
+	const permissionsFlag = "permissions"
 
 	// flag values
 	var srcFiles []string
 	var destDirs []string
+	var permissions []string
 	var plus bool
 
 	cmd := &cobra.Command{
 		Use:   "initialize",
 		Short: "Write initial configuration files",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := validateCopyArgs(srcFiles, destDirs); err != nil {
+			if len(permissions) == 0 {
+				permissions = make([]string, len(srcFiles))
+				for i := range permissions {
+					permissions[i] = file.RegularFileMode
+				}
+			}
+			if err := validateCopyArgs(srcFiles, destDirs, permissions); err != nil {
 				return err
 			}
 
@@ -976,6 +984,7 @@ func createInitializeCommand() *cobra.Command {
 				files = append(files, fileToCopy{
 					destDirName: destDirs[i],
 					srcFileName: src,
+					permissions: permissions[i],
 				})
 			}
 
@@ -1003,6 +1012,17 @@ func createInitializeCommand() *cobra.Command {
 		destFlag,
 		[]string{},
 		"The destination directories for the source files at the same array index to be copied to",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&permissions,
+		permissionsFlag,
+		[]string{},
+		fmt.Sprintf(
+			"The file permissions (octal, e.g. %s for regular files or %s for secrets) to apply to the "+
+				"source file at the same array index. Defaults to %s for all files.",
+			file.RegularFileMode, file.SecretFileMode, file.RegularFileMode,
+		),
 	)
 
 	cmd.Flags().BoolVar(

--- a/cmd/gateway/initialize.go
+++ b/cmd/gateway/initialize.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/go-logr/logr"
 
@@ -19,6 +20,7 @@ const (
 type fileToCopy struct {
 	destDirName string
 	srcFileName string
+	permissions string
 }
 
 type initializeConfig struct {
@@ -33,7 +35,7 @@ type initializeConfig struct {
 
 func initialize(cfg initializeConfig) error {
 	for _, f := range cfg.copy {
-		if err := copyFile(cfg.fileManager, f.srcFileName, f.destDirName); err != nil {
+		if err := copyFile(cfg.fileManager, f.srcFileName, f.destDirName, f.permissions); err != nil {
 			return err
 		}
 	}
@@ -68,7 +70,7 @@ func initialize(cfg initializeConfig) error {
 	return nil
 }
 
-func copyFile(osFileManager file.OSFileManager, src, dest string) error {
+func copyFile(osFileManager file.OSFileManager, src, dest, permissions string) error {
 	srcFile, err := osFileManager.Open(src)
 	if err != nil {
 		return fmt.Errorf("error opening source file: %w", err)
@@ -85,7 +87,11 @@ func copyFile(osFileManager file.OSFileManager, src, dest string) error {
 		return fmt.Errorf("error copying file contents: %w", err)
 	}
 
-	if err := osFileManager.Chmod(destFile, os.FileMode(file.RegularFileModeInt)); err != nil {
+	mode, err := strconv.ParseUint(permissions, 8, 32)
+	if err != nil {
+		return fmt.Errorf("invalid file permissions %q: %w", permissions, err)
+	}
+	if err := osFileManager.Chmod(destFile, os.FileMode(mode)); err != nil {
 		return fmt.Errorf("error setting file permissions: %w", err)
 	}
 

--- a/cmd/gateway/initialize_test.go
+++ b/cmd/gateway/initialize_test.go
@@ -32,10 +32,12 @@ func TestInitialize_OSS(t *testing.T) {
 			{
 				destDirName: "destDir",
 				srcFileName: "src1",
+				permissions: file.RegularFileMode,
 			},
 			{
 				destDirName: "destDir2",
 				srcFileName: "src2",
+				permissions: file.RegularFileMode,
 			},
 		},
 		plus: false,
@@ -66,10 +68,12 @@ func TestInitialize_OSS_Error(t *testing.T) {
 			{
 				destDirName: "destDir",
 				srcFileName: "src1",
+				permissions: file.RegularFileMode,
 			},
 			{
 				destDirName: "destDir2",
 				srcFileName: "src2",
+				permissions: file.RegularFileMode,
 			},
 		},
 		plus: false,
@@ -129,10 +133,12 @@ func TestInitialize_Plus(t *testing.T) {
 					{
 						destDirName: "destDir",
 						srcFileName: "src1",
+						permissions: file.RegularFileMode,
 					},
 					{
 						destDirName: "destDir2",
 						srcFileName: "src2",
+						permissions: file.RegularFileMode,
 					},
 				},
 				podUID:     "install-id",
@@ -168,7 +174,7 @@ func TestCopyFile(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer os.RemoveAll(dest)
 
-	g.Expect(copyFile(file.NewStdLibOSFileManager(), src.Name(), dest)).To(Succeed())
+	g.Expect(copyFile(file.NewStdLibOSFileManager(), src.Name(), dest, file.RegularFileMode)).To(Succeed())
 	_, err = os.Stat(filepath.Join(dest, filepath.Base(src.Name())))
 	g.Expect(err).ToNot(HaveOccurred())
 }
@@ -229,9 +235,27 @@ func TestCopyFileErrors(t *testing.T) {
 			t.Parallel()
 
 			g := NewWithT(t)
-			err := copyFile(test.fileMgr, "source", "destDir")
+			err := copyFile(test.fileMgr, "source", "destDir", file.RegularFileMode)
 
 			g.Expect(err).To(MatchError(test.expErr))
 		})
 	}
+}
+
+func TestCopyFileInvalidPermissions(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	src, err := os.CreateTemp(os.TempDir(), "testfile")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer os.Remove(src.Name())
+
+	dest, err := os.MkdirTemp(os.TempDir(), "testdir")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer os.RemoveAll(dest)
+
+	err = copyFile(file.NewStdLibOSFileManager(), src.Name(), dest, "not-octal")
+
+	expErr := `invalid file permissions "not-octal": strconv.ParseUint: parsing "not-octal": invalid syntax`
+	g.Expect(err).To(MatchError(expErr))
 }

--- a/cmd/gateway/validation.go
+++ b/cmd/gateway/validation.go
@@ -267,9 +267,12 @@ func ensureNoPortCollisions(ports ...int) error {
 }
 
 // validateCopyArgs ensures that arguments to the initialize command are set.
-func validateCopyArgs(srcFiles []string, destDirs []string) error {
+func validateCopyArgs(srcFiles []string, destDirs []string, permissions []string) error {
 	if len(srcFiles) != len(destDirs) {
 		return errors.New("source and destination must have the same number of elements")
+	}
+	if len(srcFiles) != len(permissions) {
+		return errors.New("source and permissions must have the same number of elements")
 	}
 	if len(srcFiles) == 0 {
 		return errors.New("source must not be empty")

--- a/cmd/gateway/validation_test.go
+++ b/cmd/gateway/validation_test.go
@@ -661,34 +661,46 @@ func TestValidateInitializeArgs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		destDirs []string
-		srcFiles []string
-		expErr   bool
+		name        string
+		destDirs    []string
+		srcFiles    []string
+		permissions []string
+		expErr      bool
 	}{
 		{
-			name:     "valid values",
-			destDirs: []string{"/dest/"},
-			srcFiles: []string{"/src/file"},
-			expErr:   false,
+			name:        "valid values",
+			destDirs:    []string{"/dest/"},
+			srcFiles:    []string{"/src/file"},
+			permissions: []string{"0644"},
+			expErr:      false,
 		},
 		{
-			name:     "invalid dest",
-			destDirs: []string{},
-			srcFiles: []string{"/src/file"},
-			expErr:   true,
+			name:        "invalid dest",
+			destDirs:    []string{},
+			srcFiles:    []string{"/src/file"},
+			permissions: []string{"0644"},
+			expErr:      true,
 		},
 		{
-			name:     "invalid src",
-			destDirs: []string{"/dest/"},
-			srcFiles: []string{},
-			expErr:   true,
+			name:        "invalid src",
+			destDirs:    []string{"/dest/"},
+			srcFiles:    []string{},
+			permissions: []string{"0644"},
+			expErr:      true,
 		},
 		{
-			name:     "different lengths",
-			destDirs: []string{"/dest/"},
-			srcFiles: []string{"src1", "src2"},
-			expErr:   true,
+			name:        "different lengths",
+			destDirs:    []string{"/dest/"},
+			srcFiles:    []string{"src1", "src2"},
+			permissions: []string{"0644", "0644"},
+			expErr:      true,
+		},
+		{
+			name:        "permissions length mismatch",
+			destDirs:    []string{"/dest/"},
+			srcFiles:    []string{"/src/file"},
+			permissions: []string{"0644", "0640"},
+			expErr:      true,
 		},
 	}
 
@@ -697,7 +709,7 @@ func TestValidateInitializeArgs(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			err := validateCopyArgs(tc.srcFiles, tc.destDirs)
+			err := validateCopyArgs(tc.srcFiles, tc.destDirs, tc.permissions)
 			if !tc.expErr {
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {

--- a/internal/controller/nginx/config/generator.go
+++ b/internal/controller/nginx/config/generator.go
@@ -71,6 +71,15 @@ const (
 	// mgmtIncludesFile is the path to the file containing the NGINX Plus mgmt config.
 	mgmtIncludesFile = mainIncludesFolder + "/mgmt.conf"
 
+	// MgmtCAFile is the CA cert path for the usage-reporting endpoint's TLS connection.
+	MgmtCAFile = secretsFolder + "/mgmt-ca.crt"
+
+	// MgmtClientSSLCertFile is the client cert path for mTLS with the usage-reporting endpoint.
+	MgmtClientSSLCertFile = secretsFolder + "/mgmt-tls.crt"
+
+	// MgmtClientSSLKeyFile is the client key path for mTLS with the usage-reporting endpoint.
+	MgmtClientSSLKeyFile = secretsFolder + "/mgmt-tls.key"
+
 	// nginxPlusConfigFile is the path to the file containing the NGINX Plus API config.
 	nginxPlusConfigFile = httpFolder + "/plus-api.conf"
 )

--- a/internal/controller/nginx/config/main_config.go
+++ b/internal/controller/nginx/config/main_config.go
@@ -110,7 +110,7 @@ func (g GeneratorImpl) generateMgmtFiles(conf dataplane.Configuration) []agent.F
 	if content, ok := conf.AuxiliarySecrets[graph.PlusReportCACertificate]; ok {
 		caFile := agent.File{
 			Meta: &pb.FileMeta{
-				Name:        secretsFolder + "/mgmt-ca.crt",
+				Name:        MgmtCAFile,
 				Hash:        filesHelper.GenerateHash(content),
 				Permissions: file.SecretFileMode,
 				Size:        int64(len(content)),
@@ -124,7 +124,7 @@ func (g GeneratorImpl) generateMgmtFiles(conf dataplane.Configuration) []agent.F
 	if content, ok := conf.AuxiliarySecrets[graph.PlusReportClientSSLCertificate]; ok {
 		certFile := agent.File{
 			Meta: &pb.FileMeta{
-				Name:        secretsFolder + "/mgmt-tls.crt",
+				Name:        MgmtClientSSLCertFile,
 				Hash:        filesHelper.GenerateHash(content),
 				Permissions: file.SecretFileMode,
 				Size:        int64(len(content)),
@@ -138,7 +138,7 @@ func (g GeneratorImpl) generateMgmtFiles(conf dataplane.Configuration) []agent.F
 	if content, ok := conf.AuxiliarySecrets[graph.PlusReportClientSSLKey]; ok {
 		keyFile := agent.File{
 			Meta: &pb.FileMeta{
-				Name:        secretsFolder + "/mgmt-tls.key",
+				Name:        MgmtClientSSLKeyFile,
 				Hash:        filesHelper.GenerateHash(content),
 				Permissions: file.SecretFileMode,
 				Size:        int64(len(content)),

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,12 +31,14 @@ import (
 	ngfAPIv1alpha1 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha1"
 	ngfAPIv1alpha2 "github.com/nginx/nginx-gateway-fabric/v2/apis/v1alpha2"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/config"
+	nginxconfig "github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/config"
 	nginxTypes "github.com/nginx/nginx-gateway-fabric/v2/internal/controller/nginx/types"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/dataplane"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph/shared/configmaps"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/controller/state/graph/shared/secrets"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/controller"
+	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/file"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/helpers"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/kinds"
 	"github.com/nginx/nginx-gateway-fabric/v2/internal/framework/waf"
@@ -68,6 +71,11 @@ const (
 	agentVolumeMountPath     = "/etc/nginx-agent/secrets"
 	agentNICVolumeName       = "agent-dataplane-key"
 	agentNICDataplaneKeyFile = "dataplane.key"
+
+	// usageCertsSourceMountPath is where the raw CA/client SSL Secrets for NGINX Plus usage reporting are
+	// mounted (read-only) in the init container, so their contents can be copied into the writable
+	// nginx-secrets volume under mgmt-prefixed filenames before the agent starts managing them.
+	usageCertsSourceMountPath = "/etc/nginx/certs-bootstrap-source"
 )
 
 // portProtoEntry represents a unique port and protocol combination.
@@ -662,10 +670,15 @@ func (p *NginxProvisioner) buildBootstrapConfigMap(
 
 	if p.cfg.Plus {
 		mgmtFields := map[string]any{
-			"UsageEndpoint":        p.cfg.PlusUsageConfig.Endpoint,
-			"SkipVerify":           p.cfg.PlusUsageConfig.SkipVerify,
-			"UsageCASecret":        caSecret,
-			"UsageClientSSLSecret": clientSSLSecret,
+			"UsageEndpoint": p.cfg.PlusUsageConfig.Endpoint,
+			"SkipVerify":    p.cfg.PlusUsageConfig.SkipVerify,
+		}
+		if caSecret {
+			mgmtFields["UsageCAFile"] = nginxconfig.MgmtCAFile
+		}
+		if clientSSLSecret {
+			mgmtFields["UsageClientSSLCertFile"] = nginxconfig.MgmtClientSSLCertFile
+			mgmtFields["UsageClientSSLKeyFile"] = nginxconfig.MgmtClientSSLKeyFile
 		}
 		cm.Data[configmaps.MgmtConfKey] = string(helpers.MustExecuteTemplate(mgmtTemplate, mgmtFields))
 	}
@@ -1389,10 +1402,13 @@ func (p *NginxProvisioner) buildInitContainers(nProxyCfg *graph.EffectiveNginxPr
 				"initialize",
 				"--source", "/agent/nginx-agent.conf",
 				"--destination", "/etc/nginx-agent",
+				"--permissions", file.RegularFileMode,
 				"--source", "/includes/main.conf",
 				"--destination", "/etc/nginx/main-includes",
+				"--permissions", file.RegularFileMode,
 				"--source", "/includes/events.conf",
 				"--destination", "/etc/nginx/events-includes",
+				"--permissions", file.RegularFileMode,
 			},
 			Env: []corev1.EnvVar{
 				{
@@ -1549,6 +1565,7 @@ func (p *NginxProvisioner) configureNginxPlus(
 		initCmd,
 		"--source", "/includes/mgmt.conf",
 		"--destination", "/etc/nginx/main-includes",
+		"--permissions", file.RegularFileMode,
 		"--nginx-plus",
 	)
 	spec.Spec.InitContainers[0].Command = initCmd
@@ -1581,28 +1598,50 @@ func (p *NginxProvisioner) configureNginxPlus(
 		})
 	}
 
-	// Add usage certs if configured
+	// Add usage certs if configured. The Secrets are mounted read-only into the init container only; the
+	// init container copies their contents into the writable nginx-secrets volume (under the same
+	// filenames the dynamic config generator uses) so nginx-agent has write access for its own file
+	// management once it takes over from this bootstrap config.
 	if names.ca != "" || names.clientSSL != "" {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "nginx-plus-usage-certs",
-			MountPath: "/etc/nginx/certs-bootstrap/",
-		})
-
 		sources := []corev1.VolumeProjection{}
+		initCmd := spec.Spec.InitContainers[0].Command
+		destDir := path.Dir(nginxconfig.MgmtCAFile)
 		if names.ca != "" {
+			caFileName := path.Base(nginxconfig.MgmtCAFile)
 			sources = append(sources, corev1.VolumeProjection{
 				Secret: &corev1.SecretProjection{
 					LocalObjectReference: corev1.LocalObjectReference{Name: names.ca},
+					Items:                []corev1.KeyToPath{{Key: secrets.CAKey, Path: caFileName}},
 				},
 			})
+			initCmd = append(initCmd,
+				"--source", path.Join(usageCertsSourceMountPath, caFileName),
+				"--destination", destDir,
+				"--permissions", file.SecretFileMode,
+			)
 		}
 		if names.clientSSL != "" {
+			certFileName := path.Base(nginxconfig.MgmtClientSSLCertFile)
+			keyFileName := path.Base(nginxconfig.MgmtClientSSLKeyFile)
 			sources = append(sources, corev1.VolumeProjection{
 				Secret: &corev1.SecretProjection{
 					LocalObjectReference: corev1.LocalObjectReference{Name: names.clientSSL},
+					Items: []corev1.KeyToPath{
+						{Key: secrets.TLSCertKey, Path: certFileName},
+						{Key: secrets.TLSKeyKey, Path: keyFileName},
+					},
 				},
 			})
+			initCmd = append(initCmd,
+				"--source", path.Join(usageCertsSourceMountPath, certFileName),
+				"--destination", destDir,
+				"--permissions", file.SecretFileMode,
+				"--source", path.Join(usageCertsSourceMountPath, keyFileName),
+				"--destination", destDir,
+				"--permissions", file.SecretFileMode,
+			)
 		}
+		spec.Spec.InitContainers[0].Command = initCmd
 
 		spec.Spec.Volumes = append(spec.Spec.Volumes, corev1.Volume{
 			Name: "nginx-plus-usage-certs",
@@ -1612,6 +1651,11 @@ func (p *NginxProvisioner) configureNginxPlus(
 				},
 			},
 		})
+
+		spec.Spec.InitContainers[0].VolumeMounts = append(spec.Spec.InitContainers[0].VolumeMounts,
+			corev1.VolumeMount{Name: "nginx-plus-usage-certs", MountPath: usageCertsSourceMountPath, ReadOnly: true},
+			corev1.VolumeMount{Name: "nginx-secrets", MountPath: destDir},
+		)
 	}
 
 	spec.Spec.Containers[0].VolumeMounts = volumeMounts

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"path"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -1087,10 +1088,18 @@ func TestBuildNginxResourceObjects_Plus(t *testing.T) {
 		MountPath: "/etc/nginx/" + secrets.LicenseJWTKey,
 		SubPath:   secrets.LicenseJWTKey,
 	}))
-	g.Expect(container.VolumeMounts).To(ContainElement(corev1.VolumeMount{
+	g.Expect(initContainer.VolumeMounts).To(ContainElement(corev1.VolumeMount{
 		Name:      "nginx-plus-usage-certs",
-		MountPath: "/etc/nginx/certs-bootstrap/",
+		MountPath: usageCertsSourceMountPath,
+		ReadOnly:  true,
 	}))
+	g.Expect(initContainer.VolumeMounts).To(ContainElement(corev1.VolumeMount{
+		Name:      "nginx-secrets",
+		MountPath: "/etc/nginx/secrets",
+	}))
+	g.Expect(initContainer.Command).To(ContainElement(path.Join(usageCertsSourceMountPath, "mgmt-ca.crt")))
+	g.Expect(initContainer.Command).To(ContainElement(path.Join(usageCertsSourceMountPath, "mgmt-tls.crt")))
+	g.Expect(initContainer.Command).To(ContainElement(path.Join(usageCertsSourceMountPath, "mgmt-tls.key")))
 	g.Expect(container.Image).To(Equal(fmt.Sprintf("%s:1.0.0", defaultNginxPlusImagePath)))
 }
 

--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -28,12 +28,12 @@ const mgmtTemplateText = `mgmt {
     {{- if .SkipVerify }}
     ssl_verify off;
     {{- end }}
-    {{- if .UsageCASecret }}
-    ssl_trusted_certificate /etc/nginx/certs-bootstrap/ca.crt;
+    {{- if .UsageCAFile }}
+    ssl_trusted_certificate {{ .UsageCAFile }};
     {{- end }}
-    {{- if .UsageClientSSLSecret }}
-    ssl_certificate        /etc/nginx/certs-bootstrap/tls.crt;
-    ssl_certificate_key    /etc/nginx/certs-bootstrap/tls.key;
+    {{- if .UsageClientSSLCertFile }}
+    ssl_certificate        {{ .UsageClientSSLCertFile }};
+    ssl_certificate_key    {{ .UsageClientSSLKeyFile }};
     {{- end }}
     enforce_initial_report off;
     deployment_context /etc/nginx/main-includes/deployment_ctx.json;

--- a/internal/framework/file/file.go
+++ b/internal/framework/file/file.go
@@ -16,7 +16,7 @@ const (
 	RegularFileModeInt = 0o644
 	// RegularFileMode defines the default file mode for regular files.
 	RegularFileMode = "0644"
-	// secretFileMode defines the default file mode for files with secrets as an integer.
+	// secretFileModeInt defines the default file mode for files with secrets as an integer.
 	secretFileModeInt = 0o640
 	// SecretFileMode defines the default file mode for files with secrets.
 	SecretFileMode = "0640"


### PR DESCRIPTION
Cherry-pick for [5877](https://github.com/nginx/nginx-gateway-fabric/pull/5877)

### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Customer was unable to specify usage reporting certs since they are mounted as volume mounts with type secret. Secrets mounted are readOnly which was further leading to nginx-agent failing when trying to rotate it.

Solution: Redirected the NGINX Plus usage reporting CA/client certs from a read-only Secret-mounted volume into a writable emptyDir which is copied by init container, matching the path the dynamic config generator already uses fixing the crash while preserving cert rotation.

Testing: Manual testing

- verified that specifying certs for usage reporting did not lead to errors and traffic could be passed successfully.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5887

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes an issue where NGINX pods would crash-loop with a read-only file system error when `caSecretName` or `clientSSLSecretName` was set for NGINX Plus usage reporting during pod startup.
```
